### PR TITLE
feat(windows): remember window position, size, and maximized state

### DIFF
--- a/src/main/windows/MainWindow.js
+++ b/src/main/windows/MainWindow.js
@@ -5,9 +5,112 @@
 
 const { BrowserWindow } = require('electron');
 const path = require('path');
+const fs = require('fs');
+const { settingsFile } = require('../utils/paths');
 
 let mainWindow = null;
 let isQuitting = false;
+let normalBounds = null;
+let saveTimer = null;
+
+/**
+ * Load saved window state from settings.json
+ * @returns {Object|null} Saved window state or null
+ */
+function loadWindowState() {
+  try {
+    const data = fs.readFileSync(settingsFile, 'utf8');
+    const settings = JSON.parse(data);
+    return settings.windowState || null;
+  } catch (e) {
+    return null;
+  }
+}
+
+/**
+ * Validate window state against currently connected displays
+ * Uses workArea (excludes taskbar) for bounds check
+ * @param {Object|null} state
+ * @returns {Object|null} Valid state or null (triggers default centering)
+ */
+function validateWindowState(state) {
+  if (!state) return null;
+  if (typeof state.x !== 'number' || typeof state.y !== 'number') return null;
+  if (!state.width || !state.height || state.width <= 0 || state.height <= 0) return null;
+
+  const { screen } = require('electron');
+  const displays = screen.getAllDisplays();
+  const onScreen = displays.some(({ workArea }) => {
+    return (
+      state.x >= workArea.x &&
+      state.x < workArea.x + workArea.width &&
+      state.y >= workArea.y &&
+      state.y < workArea.y + workArea.height
+    );
+  });
+
+  return onScreen ? state : null;
+}
+
+/**
+ * Save window state to settings.json using atomic write
+ * @param {BrowserWindow} win
+ */
+function saveWindowState(win) {
+  if (!win || win.isDestroyed()) return;
+
+  let bounds;
+  if (win.isMaximized()) {
+    if (!normalBounds) return; // No pre-maximized bounds captured yet, skip
+    bounds = normalBounds;
+  } else {
+    bounds = win.getBounds();
+  }
+
+  const state = {
+    x: bounds.x,
+    y: bounds.y,
+    width: bounds.width,
+    height: bounds.height,
+    isMaximized: win.isMaximized()
+  };
+
+  try {
+    let current = {};
+    try {
+      current = JSON.parse(fs.readFileSync(settingsFile, 'utf8'));
+    } catch (e) {
+      // File doesn't exist or is corrupt — start fresh
+    }
+    current.windowState = state;
+    const tmpFile = settingsFile + '.tmp';
+    fs.writeFileSync(tmpFile, JSON.stringify(current, null, 2), 'utf8');
+    fs.renameSync(tmpFile, settingsFile);
+  } catch (e) {
+    console.error('[MainWindow] Failed to save window state:', e);
+  }
+}
+
+/**
+ * Debounced save — used on resize/move events (500ms matches settings debounce convention)
+ * @param {BrowserWindow} win
+ */
+function debouncedSaveWindowState(win) {
+  if (saveTimer) clearTimeout(saveTimer);
+  saveTimer = setTimeout(() => saveWindowState(win), 500);
+}
+
+/**
+ * Immediate save — used on close event for crash-resilient final checkpoint
+ * @param {BrowserWindow} win
+ */
+function saveWindowStateImmediate(win) {
+  if (saveTimer) {
+    clearTimeout(saveTimer);
+    saveTimer = null;
+  }
+  saveWindowState(win);
+}
 
 /**
  * Create the main window
@@ -17,9 +120,13 @@ let isQuitting = false;
  */
 function createMainWindow({ isDev = false } = {}) {
   const isMac = process.platform === 'darwin';
-  mainWindow = new BrowserWindow({
-    width: 1400,
-    height: 900,
+
+  // Load and validate saved window state
+  const savedState = validateWindowState(loadWindowState());
+
+  const winOpts = {
+    width: savedState ? savedState.width : 1400,
+    height: savedState ? savedState.height : 900,
     minWidth: 1000,
     minHeight: 600,
     frame: isMac ? undefined : false,
@@ -29,15 +136,33 @@ function createMainWindow({ isDev = false } = {}) {
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,
-      sandbox: false, // Allow preload to use require() for Node.js modules
-      webviewTag: true, // Enable <webview> for live preview
+      sandbox: false,
+      webviewTag: true,
       preload: path.join(__dirname, '..', 'preload.js')
     }
-  });
+  };
+
+  // Only add x/y if we have a valid saved state — omitting them lets Electron center the window
+  if (savedState) {
+    winOpts.x = savedState.x;
+    winOpts.y = savedState.y;
+  }
+
+  mainWindow = new BrowserWindow(winOpts);
+
+  // Initialize normalBounds for pre-maximized tracking
+  normalBounds = (savedState && !savedState.isMaximized)
+    ? { x: savedState.x, y: savedState.y, width: savedState.width, height: savedState.height }
+    : mainWindow.getBounds();
 
   // Load the main HTML file
   const htmlPath = path.join(__dirname, '..', '..', '..', 'index.html');
   mainWindow.loadFile(htmlPath);
+
+  // Restore maximized state after loadFile
+  if (savedState && savedState.isMaximized) {
+    mainWindow.maximize();
+  }
 
   // Intercept Ctrl+Arrow to prevent Windows Snap and forward to renderer for tab switching
   mainWindow.webContents.on('before-input-event', (event, input) => {
@@ -69,8 +194,33 @@ function createMainWindow({ isDev = false } = {}) {
     mainWindow.webContents.openDevTools();
   }
 
+  // Track normal (non-maximized) bounds for correct state restoration
+  mainWindow.on('resize', () => {
+    if (!mainWindow.isMaximized()) {
+      normalBounds = mainWindow.getBounds();
+      debouncedSaveWindowState(mainWindow);
+    }
+  });
+
+  mainWindow.on('move', () => {
+    if (!mainWindow.isMaximized()) {
+      normalBounds = mainWindow.getBounds();
+      debouncedSaveWindowState(mainWindow);
+    }
+  });
+
+  mainWindow.on('maximize', () => {
+    debouncedSaveWindowState(mainWindow);
+  });
+
+  mainWindow.on('unmaximize', () => {
+    normalBounds = mainWindow.getBounds();
+    debouncedSaveWindowState(mainWindow);
+  });
+
   // Minimize to tray instead of closing
   mainWindow.on('close', (event) => {
+    saveWindowStateImmediate(mainWindow);
     if (!isQuitting) {
       event.preventDefault();
       mainWindow.hide();


### PR DESCRIPTION
## Summary
- Adds window state persistence (position, size, maximized) across app restarts
- Multi-monitor safety: validates saved position against all connected displays via `workArea` bounds check
- Falls back to centered 1400x900 when saved monitor is disconnected or on first launch
- Crash-resilient: debounced continuous save on resize/move/maximize/unmaximize events (500ms), plus immediate save on close
- Atomic write (tmp file + rename) to `~/.claude-terminal/settings.json`

## Files Changed (1)
| File | Change |
|------|--------|
| `src/main/windows/MainWindow.js` | Added `loadWindowState`, `validateWindowState`, `saveWindowState`, `debouncedSaveWindowState`, `saveWindowStateImmediate`; modified `createMainWindow` to restore saved state; added resize/move/maximize/unmaximize event listeners |

## Test plan
- [ ] Launch app, move/resize window, quit via tray, relaunch — window appears at same position and size
- [ ] Maximize window, quit, relaunch — window reopens maximized; unmaximize restores pre-maximize bounds
- [ ] Save state on monitor 2, disconnect monitor 2, relaunch — window centers on primary at 1400x900
- [ ] Move/resize window, force-kill process (Task Manager), relaunch — window restores to last debounced position

🤖 Generated with [Claude Code](https://claude.com/claude-code)