### PR TITLE
feat: add new terminal button in filter bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -275,6 +275,12 @@
               </button>
               <div class="terminals-filter" id="terminals-filter" style="display: none;">
                 <span class="filter-project" id="filter-project-name"></span>
+                <button class="filter-new-terminal-btn" id="btn-new-terminal" title="New terminal (Ctrl+T)">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <line x1="12" y1="5" x2="12" y2="19"/>
+                    <line x1="5" y1="12" x2="19" y2="12"/>
+                  </svg>
+                </button>
 
                 <div class="filter-git-actions" id="filter-git-actions" style="display: none;">
                   <div class="filter-git-group">

--- a/renderer.js
+++ b/renderer.js
@@ -1423,6 +1423,18 @@ if (btnToggleExplorer) {
   btnToggleExplorer.onclick = () => FileExplorer.toggle();
 }
 
+// Wire "+" new terminal button
+const btnNewTerminal = document.getElementById('btn-new-terminal');
+if (btnNewTerminal) {
+  btnNewTerminal.onclick = () => {
+    const selectedFilter = projectsState.get().selectedProjectFilter;
+    const projects = projectsState.get().projects;
+    if (selectedFilter !== null && projects[selectedFilter]) {
+      createTerminalForProject(projects[selectedFilter]);
+    }
+  };
+}
+
 // Subscribe to project selection changes for FileExplorer
 projectsState.subscribe(() => {
   const state = projectsState.get();

--- a/styles/terminal.css
+++ b/styles/terminal.css
@@ -104,6 +104,32 @@
   color: white;
 }
 
+.filter-new-terminal-btn {
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s;
+  flex-shrink: 0;
+}
+
+.filter-new-terminal-btn:hover {
+  background: var(--accent-dim);
+  color: var(--accent);
+}
+
+.filter-new-terminal-btn svg {
+  width: 14px;
+  height: 14px;
+}
+
 /* Git Actions in Filter */
 .filter-git-actions {
   display: flex;


### PR DESCRIPTION
## Summary
- Adds a "+" button in the terminals filter bar, positioned after the project name badge
- One-click terminal creation using the same `createTerminalForProject()` function as Ctrl+T
- Compact 22x22px button with accent-colored hover state matching the filter bar style
- Button inherits visibility from the terminals-filter parent (hidden when no project selected)

## Files Changed (3)
| File | Change |
|------|--------|
| `index.html` | Add `<button class="filter-new-terminal-btn">` with SVG "+" icon after `filter-project-name` span |
| `styles/terminal.css` | Add `.filter-new-terminal-btn` styles (base, `:hover`, `svg`) — 3 rule blocks |
| `renderer.js` | Wire `btn-new-terminal` click handler calling `createTerminalForProject()` with selected project |

## Test plan
- [ ] Select a project — "+" button appears in filter bar after project name
- [ ] Click "+" button — new terminal tab opens (same as Ctrl+T)
- [ ] Hover "+" button — background changes to accent-dim, icon to accent color
- [ ] No project selected — button is hidden (inherits parent display:none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)