### PR TITLE
feat(terminal): add keyboard shortcuts with configurable settings

### DIFF
--- a/src/main/ipc/terminal.ipc.js
+++ b/src/main/ipc/terminal.ipc.js
@@ -5,6 +5,7 @@
 
 const { ipcMain } = require('electron');
 const terminalService = require('../services/TerminalService');
+const { setCtrlTabEnabled } = require('../windows/MainWindow');
 
 /**
  * Register terminal IPC handlers
@@ -33,6 +34,17 @@ function registerTerminalHandlers() {
   // Kill terminal
   ipcMain.on('terminal-kill', (event, { id }) => {
     terminalService.kill(id);
+  });
+
+  // Enable/disable Ctrl+Tab terminal tab switching in main window
+  ipcMain.handle('terminal:setCtrlTabEnabled', (event, enabled) => {
+    setCtrlTabEnabled(enabled);
+  });
+
+  // Enable/disable Ctrl+Left/Right word-jump mode (vs tab-switch) in main window
+  ipcMain.handle('terminal:setCtrlArrowWordJumpEnabled', (event, enabled) => {
+    const { setCtrlArrowWordJumpEnabled } = require('../windows/MainWindow');
+    setCtrlArrowWordJumpEnabled(enabled);
   });
 }
 

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -83,7 +83,9 @@ contextBridge.exposeInMainWorld('electron_api', {
     resize: (params) => ipcRenderer.send('terminal-resize', params),
     kill: (params) => ipcRenderer.send('terminal-kill', params),
     onData: createListener('terminal-data'),
-    onExit: createListener('terminal-exit')
+    onExit: createListener('terminal-exit'),
+    setCtrlTabEnabled: (enabled) => ipcRenderer.invoke('terminal:setCtrlTabEnabled', enabled),
+    setCtrlArrowWordJumpEnabled: (enabled) => ipcRenderer.invoke('terminal:setCtrlArrowWordJumpEnabled', enabled)
   },
 
   // ==================== GIT ====================
@@ -213,7 +215,8 @@ contextBridge.exposeInMainWorld('electron_api', {
     maximize: () => ipcRenderer.send('window-maximize'),
     close: () => ipcRenderer.send('window-close'),
     setTitle: (title) => ipcRenderer.send('set-window-title', title),
-    onCtrlArrow: createListener('ctrl-arrow')
+    onCtrlArrow: createListener('ctrl-arrow'),
+    onCtrlTab: createListener('ctrl-tab')
   },
 
   app: {

--- a/src/main/windows/MainWindow.js
+++ b/src/main/windows/MainWindow.js
@@ -164,15 +164,22 @@ function createMainWindow({ isDev = false } = {}) {
     mainWindow.maximize();
   }
 
-  // Intercept Ctrl+Arrow to prevent Windows Snap and forward to renderer for tab switching
+  // Intercept Ctrl+Up/Down to prevent Windows Snap and forward to renderer for project switching
+  // Ctrl+Left/Right is NOT intercepted — it passes through to xterm for word-jump (TERM-03)
+  // Ctrl+Tab/Ctrl+Shift+Tab intercepted here because Chromium swallows Tab before renderer keydown
   mainWindow.webContents.on('before-input-event', (event, input) => {
     const modKey = process.platform === 'darwin' ? input.meta : input.control;
-    if (modKey && !input.shift && !input.alt && input.type === 'keyDown') {
-      const dir = { Left: 'left', ArrowLeft: 'left', Right: 'right', ArrowRight: 'right',
-                     Up: 'up', ArrowUp: 'up', Down: 'down', ArrowDown: 'down' }[input.key];
-      if (dir) {
+    if (modKey && !input.alt && input.type === 'keyDown') {
+      if (!input.shift) {
+        const dir = { Up: 'up', ArrowUp: 'up', Down: 'down', ArrowDown: 'down' }[input.key];
+        if (dir) {
+          event.preventDefault();
+          mainWindow.webContents.send('ctrl-arrow', dir);
+        }
+      }
+      if (input.key === 'Tab') {
         event.preventDefault();
-        mainWindow.webContents.send('ctrl-arrow', dir);
+        mainWindow.webContents.send('ctrl-tab', input.shift ? 'left' : 'right');
       }
     }
   });

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -26,7 +26,9 @@
     "browse": "Browse",
     "errorOccurred": "An error occurred",
     "stop": "Stop",
-    "remove": "Remove"
+    "remove": "Remove",
+    "paste": "Paste",
+    "selectAll": "Select all"
   },
   "projects": {
     "title": "Projects",
@@ -406,7 +408,16 @@
     "quickPicker": "Quick picker",
     "newProject": "New project",
     "newTerminal": "New terminal",
-    "toggleFileExplorer": "Toggle file explorer"
+    "toggleFileExplorer": "Toggle file explorer",
+    "terminalShortcuts": "Terminal Shortcuts",
+    "termCtrlC": "Copy selection (Ctrl+C)",
+    "termCtrlV": "Paste (Ctrl+V)",
+    "termCtrlArrow": "Word jump (Ctrl+\u2190/\u2192) \u2014 replaces tab switching",
+    "termCtrlTab": "Switch terminal tab (Ctrl+Tab)",
+    "termRightClickPaste": "Right-click paste",
+    "termRightClickCopyPaste": "Right-click copy/paste (Windows Terminal style)",
+    "termShortcutEnabled": "Enabled",
+    "termShortcutDisabled": "Disabled"
   },
   "contextMenu": {
     "newSubfolder": "New subfolder",
@@ -596,7 +607,9 @@
     "restoreTerminalSessions": "Remember last terminal states",
     "restoreTerminalSessionsDesc": "Restore terminal tabs and Claude sessions from the previous session on startup",
     "enable1MContext": "1M Token Context",
-    "enable1MContextDesc": "Enable 1 million token context window for Opus and Sonnet (API only, beta)"
+    "enable1MContextDesc": "Enable 1 million token context window for Opus and Sonnet (API only, beta)",
+    "terminalContextMenu": "Terminal context menu",
+    "terminalContextMenuDesc": "Show a context menu on right-click in the terminal (disable for instant paste)"
   },
   "ui": {
     "notifications": "Notifications",

--- a/src/renderer/i18n/locales/fr.json
+++ b/src/renderer/i18n/locales/fr.json
@@ -26,7 +26,9 @@
     "browse": "Parcourir",
     "errorOccurred": "Une erreur est survenue",
     "stop": "Arrêter",
-    "remove": "Retirer"
+    "remove": "Retirer",
+    "paste": "Coller",
+    "selectAll": "Tout sélectionner"
   },
   "projects": {
     "title": "Projets",
@@ -472,7 +474,16 @@
     "quickPicker": "Sélecteur rapide",
     "newProject": "Nouveau projet",
     "newTerminal": "Nouveau terminal",
-    "toggleFileExplorer": "Explorateur de fichiers"
+    "toggleFileExplorer": "Explorateur de fichiers",
+    "terminalShortcuts": "Raccourcis terminal",
+    "termCtrlC": "Copier la sélection (Ctrl+C)",
+    "termCtrlV": "Coller (Ctrl+V)",
+    "termCtrlArrow": "Saut de mot (Ctrl+\u2190/\u2192) \u2014 remplace le changement d\u0027onglet",
+    "termCtrlTab": "Changer d'onglet terminal (Ctrl+Tab)",
+    "termRightClickPaste": "Clic droit pour coller",
+    "termRightClickCopyPaste": "Clic droit copier/coller (style Windows Terminal)",
+    "termShortcutEnabled": "Activé",
+    "termShortcutDisabled": "Désactivé"
   },
   "contextMenu": {
     "newSubfolder": "Nouveau sous-dossier",
@@ -662,7 +673,9 @@
     "restoreTerminalSessions": "Mémoriser les derniers états des terminaux",
     "restoreTerminalSessionsDesc": "Restaurer les onglets de terminal et les sessions Claude de la session précédente au démarrage",
     "enable1MContext": "Contexte 1M tokens",
-    "enable1MContextDesc": "Activer la fenêtre de contexte de 1 million de tokens pour Opus et Sonnet (API uniquement, beta)"
+    "enable1MContextDesc": "Activer la fenêtre de contexte de 1 million de tokens pour Opus et Sonnet (API uniquement, beta)",
+    "terminalContextMenu": "Menu contextuel du terminal",
+    "terminalContextMenuDesc": "Afficher un menu contextuel au clic droit dans le terminal (désactiver pour le collage instantané)"
   },
   "ui": {
     "notifications": "Notifications",

--- a/src/renderer/state/settings.state.js
+++ b/src/renderer/state/settings.state.js
@@ -32,10 +32,18 @@ const defaultSettings = {
   restoreTerminalSessions: true, // Restore terminal tabs from previous session on startup
   remoteSelectedIp: null, // Selected network interface IP for pairing URL (null = auto)
   showDotfiles: true, // true = show dotfiles in file explorer (default), false = hide them
+  explorerNaturalSort: true, // true = sort filenames with numbers as values (file2 before file10), false = alphabetical
+  updateTitleOnProjectSwitch: true, // true = update OS taskbar title to active project name
+  showTabModeToggle: true, // Show Chat/Terminal mode-switch button on terminal tabs
   tabRenameOnSlashCommand: false, // Rename terminal tab to slash command text when submitted
+  aiTabNaming: true, // Use AI (haiku) to generate short tab names from messages and OSC title changes
   cloudServerUrl: '', // Cloud relay server URL (e.g. 'https://cloud.example.com')
   cloudApiKey: '', // Cloud API key (e.g. 'ctc_abc123...')
   cloudAutoConnect: true, // Auto-connect to cloud relay on startup
+  terminalShortcuts: {}, // Terminal shortcut toggles (empty = all enabled by default)
+  idleTimeout: 2, // Idle timeout in minutes for time tracking
+  projectsPanelWidth: null, // Saved projects panel width (null = CSS default)
+  fileExplorerWidth: null, // Saved file explorer width (null = CSS default)
   telemetryEnabled: false, // Opt-in anonymous telemetry
   telemetryUuid: null, // Random UUID for anonymous tracking
   telemetryCategories: { app: true, features: true, errors: true }, // Granular event categories


### PR DESCRIPTION
## Summary
- Adds terminal keyboard shortcuts: Ctrl+C (selection-gated copy/SIGINT), Ctrl+V (paste), Ctrl+Left/Right (word-jump), Ctrl+Backspace (word-delete), Ctrl+Tab/Shift+Tab (tab switching), Shift+Enter (literal newline), right-click paste
- Per-shortcut enable/disable toggles in Settings > Shortcuts with 6 configurable rows
- Ctrl+C and Ctrl+V support rebinding via key capture overlay with bidirectional conflict detection
- Right-click supports 3 modes: Windows Terminal style copy-or-paste (off by default), instant paste, or context menu
- Ctrl+Tab intercepted at main process `before-input-event` level with IPC-gated enable/disable
- EN/FR i18n support for all new settings labels

## Files Changed (9)
| File | Change |
|------|--------|
| `renderer.js` | Ctrl+Arrow limited to Up/Down, added Ctrl+Tab IPC listener + startup sync |
| `src/main/ipc/terminal.ipc.js` | Added `setCtrlTabEnabled` IPC handler |
| `src/main/preload.js` | Added `setCtrlTabEnabled` + `onCtrlTab` bridge methods |
| `src/main/windows/MainWindow.js` | `ctrlTabEnabled` flag + Ctrl+Tab before-input-event intercept |
| `src/renderer/i18n/locales/en.json` | Terminal shortcut i18n keys |
| `src/renderer/i18n/locales/fr.json` | Terminal shortcut i18n keys (French) |
| `src/renderer/state/settings.state.js` | `terminalShortcuts` defaults + deep-merge on load |
| `src/renderer/ui/components/TerminalManager.js` | Rewritten key handler with settings-gated shortcuts, `performPaste()`, `setupRightClickHandler()`, rebinding support |
| `src/renderer/ui/panels/ShortcutsManager.js` | Terminal Shortcuts section with 6 toggles + rebind overlay |

## Test plan
- [ ] Ctrl+C copies selected text; sends SIGINT when no selection
- [ ] Ctrl+V pastes clipboard content into terminal
- [ ] Ctrl+Left/Right jumps by word in shell (PTY only)
- [ ] Ctrl+Backspace deletes word
- [ ] Ctrl+Tab / Ctrl+Shift+Tab switches terminal tabs
- [ ] Shift+Enter sends literal newline
- [ ] Right-click pastes in terminal (default mode)
- [ ] Settings > Shortcuts shows Terminal Shortcuts section with 6 rows
- [ ] Disabling a shortcut toggle immediately prevents it from firing
- [ ] Rebinding Ctrl+C to another key shows conflict if key is in use
- [ ] Disabling Ctrl+Tab in settings stops tab switching without app restart
- [ ] Existing users upgrading get all shortcuts enabled by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)