### PR TITLE
feat(settings): add toggle to hide tab mode switch

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -157,6 +157,12 @@ const { loadSessionData, clearProjectSessions, saveTerminalSessions } = require(
 (async () => {
   ensureDirectories();
   await initializeState(); // Loads settings, projects AND initializes time tracking
+
+  // Apply body classes for settings that affect global CSS
+  if (getSetting('showTabModeToggle') === false) {
+    document.body.classList.add('hide-tab-mode-toggle');
+  }
+
   initI18n(settingsState.get().language); // Initialize i18n with saved language preference
 
   // Initialize Claude event bus and provider (hooks or scraping)

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -504,6 +504,8 @@
     "checking": "Checking...",
     "upToDate": "Up to date",
     "defaultTerminalMode": "Default terminal mode",
+    "showTabModeToggle": "Show mode switch on tabs",
+    "showTabModeToggleDesc": "Show the Chat/Terminal switch button on terminal tabs (hover to reveal)",
     "modeTerminal": "Terminal",
     "modeTerminalDesc": "Classic terminal with xterm.js",
     "modeChat": "Chat UI",

--- a/src/renderer/i18n/locales/fr.json
+++ b/src/renderer/i18n/locales/fr.json
@@ -570,6 +570,8 @@
     "checking": "Vérification...",
     "upToDate": "À jour",
     "defaultTerminalMode": "Mode terminal par défaut",
+    "showTabModeToggle": "Afficher le bouton de changement de mode",
+    "showTabModeToggleDesc": "Afficher le bouton Chat/Terminal sur les onglets (visible au survol)",
     "modeTerminal": "Terminal",
     "modeTerminalDesc": "Terminal classique avec xterm.js",
     "modeChat": "Chat UI",

--- a/src/renderer/state/settings.state.js
+++ b/src/renderer/state/settings.state.js
@@ -32,6 +32,7 @@ const defaultSettings = {
   restoreTerminalSessions: true, // Restore terminal tabs from previous session on startup
   remoteSelectedIp: null, // Selected network interface IP for pairing URL (null = auto)
   showDotfiles: true, // true = show dotfiles in file explorer (default), false = hide them
+  showTabModeToggle: true, // Show Chat/Terminal mode-switch button on terminal tabs
   tabRenameOnSlashCommand: false, // Rename terminal tab to slash command text when submitted
   cloudServerUrl: '', // Cloud relay server URL (e.g. 'https://cloud.example.com')
   cloudApiKey: '', // Cloud API key (e.g. 'ctc_abc123...')

--- a/src/renderer/ui/panels/SettingsPanel.js
+++ b/src/renderer/ui/panels/SettingsPanel.js
@@ -678,6 +678,16 @@ async function renderSettingsTab(initialTab = 'general') {
             <div class="settings-card">
               <div class="settings-toggle-row">
                 <div class="settings-toggle-label">
+                  <div>${t('settings.showTabModeToggle')}</div>
+                  <div class="settings-toggle-desc">${t('settings.showTabModeToggleDesc')}</div>
+                </div>
+                <label class="settings-toggle">
+                  <input type="checkbox" id="show-tab-mode-toggle" ${settings.showTabModeToggle !== false ? 'checked' : ''}>
+                  <span class="settings-toggle-slider"></span>
+                </label>
+              </div>
+              <div class="settings-toggle-row">
+                <div class="settings-toggle-label">
                   <div>${t('settings.tabRenameOnSlashCommand')}</div>
                   <div class="settings-toggle-desc">${t('settings.tabRenameOnSlashCommandDesc')}</div>
                 </div>
@@ -1160,6 +1170,8 @@ async function renderSettingsTab(initialTab = 'general') {
     const newEnable1MContext = context1MToggle ? context1MToggle.checked : settings.enable1MContext || false;
     const showDotfilesToggle = document.getElementById('show-dotfiles-toggle');
     const newShowDotfiles = showDotfilesToggle ? showDotfilesToggle.checked : true;
+    const showTabModeToggleEl = document.getElementById('show-tab-mode-toggle');
+    const newShowTabModeToggle = showTabModeToggleEl ? showTabModeToggleEl.checked : true;
     const telemetryEnabledToggle = document.getElementById('telemetry-enabled-toggle');
     const newTelemetryEnabled = telemetryEnabledToggle ? telemetryEnabledToggle.checked : false;
     const telemetryCatApp = document.getElementById('telemetry-cat-app');
@@ -1187,6 +1199,7 @@ async function renderSettingsTab(initialTab = 'general') {
       hooksEnabled: newHooksEnabled,
       enable1MContext: newEnable1MContext,
       showDotfiles: newShowDotfiles,
+      showTabModeToggle: newShowTabModeToggle,
       tabRenameOnSlashCommand: newTabRenameOnSlashCommand,
       telemetryEnabled: newTelemetryEnabled,
       telemetryCategories: newTelemetryCategories
@@ -1209,6 +1222,7 @@ async function renderSettingsTab(initialTab = 'general') {
 
     document.body.classList.toggle('compact-projects', newCompactProjects);
     document.body.classList.toggle('reduce-motion', newReduceMotion);
+    document.body.classList.toggle('hide-tab-mode-toggle', !newShowTabModeToggle);
     ctx.applyAccentColor(newSettings.accentColor);
 
     if (newTerminalTheme !== settings.terminalTheme) {

--- a/styles/terminal.css
+++ b/styles/terminal.css
@@ -1552,3 +1552,7 @@
   width: 13px;
   height: 13px;
 }
+
+body.hide-tab-mode-toggle .tab-mode-toggle {
+  display: none !important;
+}


### PR DESCRIPTION
## Summary
- Adds a **Show mode switch on tabs** toggle in Settings > Terminal that controls visibility of the Chat/Terminal switch button on terminal tabs
- When disabled, the mode-switch button is hidden via a `body.hide-tab-mode-toggle` CSS class, locking tabs to the configured default terminal mode
- Setting persists across restarts (body class applied on startup) and defaults to **shown** for safe upgrade path (`!== false` guard)

## Changes (6 files, +29 lines)
- `settings.state.js` — `showTabModeToggle: true` default
- `SettingsPanel.js` — Toggle UI + save handler + body class toggle
- `renderer.js` — Apply `hide-tab-mode-toggle` body class on startup
- `terminal.css` — CSS rule: `body.hide-tab-mode-toggle .tab-mode-toggle { display: none !important }`
- `en.json` / `fr.json` — i18n strings for label and description

## Test plan
- [ ] Open Settings > Terminal, verify "Show mode switch on tabs" toggle appears (default: on)
- [ ] Disable toggle → mode-switch buttons disappear on all tabs immediately
- [ ] Re-enable toggle → buttons reappear on hover
- [ ] Restart app with toggle disabled → buttons stay hidden after relaunch
- [ ] Fresh install (no saved settings) → buttons shown by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)