### PR TITLE
feat(ui): add resume session button in terminal toolbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -282,6 +282,12 @@
               </button>
               <div class="terminals-filter" id="terminals-filter" style="display: none;">
                 <span class="filter-project" id="filter-project-name"></span>
+                <button class="filter-resume-session-btn" id="btn-resume-session" data-i18n-title="terminals.resumeSession">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M9 21h6"/>
+                    <path d="M12 2a7 7 0 0 1 4 12.9V17a1 1 0 0 1-1 1H9a1 1 0 0 1-1-1v-2.1A7 7 0 0 1 12 2z"/>
+                  </svg>
+                </button>
                 <button class="filter-new-terminal-btn" id="btn-new-terminal" title="New terminal (Ctrl+T)">
                   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <line x1="12" y1="5" x2="12" y2="19"/>

--- a/renderer.js
+++ b/renderer.js
@@ -1489,6 +1489,18 @@ if (btnToggleExplorer) {
   btnToggleExplorer.onclick = () => FileExplorer.toggle();
 }
 
+// Wire lightbulb resume session button
+const btnResumeSession = document.getElementById('btn-resume-session');
+if (btnResumeSession) {
+  btnResumeSession.onclick = () => {
+    const selectedFilter = projectsState.get().selectedProjectFilter;
+    const projects = projectsState.get().projects;
+    if (selectedFilter !== null && projects[selectedFilter]) {
+      showSessionsModal(projects[selectedFilter]);
+    }
+  };
+}
+
 // Wire "+" new terminal button
 const btnNewTerminal = document.getElementById('btn-new-terminal');
 if (btnNewTerminal) {

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -82,7 +82,8 @@
     "resumeError": "Unable to resume session",
     "messages": "{count} msgs",
     "loading": "Initializing Claude Code...",
-    "loadingHint": "This may take a few seconds"
+    "loadingHint": "This may take a few seconds",
+    "resumeSession": "Resume Claude session"
   },
   "git": {
     "noRemote": "No remote",

--- a/src/renderer/i18n/locales/fr.json
+++ b/src/renderer/i18n/locales/fr.json
@@ -82,7 +82,8 @@
     "resumeError": "Impossible de reprendre la session",
     "messages": "{count} msgs",
     "loading": "Initialisation de Claude Code...",
-    "loadingHint": "Cela peut prendre quelques secondes"
+    "loadingHint": "Cela peut prendre quelques secondes",
+    "resumeSession": "Reprendre une session Claude"
   },
   "mcp": {
     "notFound": "MCP introuvable",

--- a/styles/terminal.css
+++ b/styles/terminal.css
@@ -104,6 +104,32 @@
   color: white;
 }
 
+.filter-resume-session-btn {
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s;
+  flex-shrink: 0;
+}
+
+.filter-resume-session-btn:hover {
+  background: var(--accent-dim);
+  color: var(--accent);
+}
+
+.filter-resume-session-btn svg {
+  width: 14px;
+  height: 14px;
+}
+
 .filter-new-terminal-btn {
   width: 22px;
   height: 22px;


### PR DESCRIPTION
## Summary
- Adds a lightbulb button next to the + (new terminal) button in the terminal toolbar
- Clicking it opens the existing sessions modal for the currently selected project, enabling quick session resume
- Styled identically to the existing new terminal button with hover accent highlight
- Includes i18n tooltip strings for English and French

## Changes
| File | Change |
|------|--------|
| `index.html` | Add `#btn-resume-session` with lightbulb SVG before `#btn-new-terminal` |
| `styles/terminal.css` | Add `.filter-resume-session-btn` CSS rules (22x22px, hover accent, 14px SVG) |
| `renderer.js` | Wire `onclick` handler to `showSessionsModal()` with project guard |
| `en.json` / `fr.json` | Add `terminals.resumeSession` tooltip key |

## Test plan
- [ ] Open app with a project selected — lightbulb button visible left of + button
- [ ] Hover over lightbulb — tooltip shows "Resume Claude session" (EN) / "Reprendre une session Claude" (FR)
- [ ] Click lightbulb — sessions modal opens for the current project
- [ ] Both buttons same size and share hover highlight style

🤖 Generated with [Claude Code](https://claude.com/claude-code)