### PR TITLE
fix(notifications): persist notification bell state across restarts

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -47,6 +47,8 @@ const {
   saveSettingsImmediate,
   getSetting,
   setSetting,
+  isNotificationsEnabled,
+  toggleNotifications,
   createFolder,
   deleteFolder,
   renameFolder,
@@ -115,7 +117,6 @@ function closeModal() {
 
 // ========== LOCAL STATE ==========
 const localState = {
-  notificationsEnabled: true,
   fivemServers: new Map(),
   gitOperations: new Map(),
   gitRepoStatus: new Map(),
@@ -237,6 +238,8 @@ const { loadSessionData, clearProjectSessions, saveTerminalSessions } = require(
   if (settingsState.get().reduceMotion) {
     document.body.classList.add('reduce-motion');
   }
+  // Restore notification bell state from persisted settings
+  document.getElementById('btn-notifications').classList.toggle('active', isNotificationsEnabled());
 
   // ========== PANELS INIT (must run after state is loaded) ==========
   MemoryEditor.init({ showModal, closeModal });
@@ -336,7 +339,7 @@ async function _tryCloudAutoConnect() {
 
 // ========== NOTIFICATIONS ==========
 function showNotification(type, title, body, terminalId) {
-  if (!localState.notificationsEnabled) return;
+  if (!isNotificationsEnabled()) return;
   if (document.hasFocus() && terminalsState.get().activeTerminal === terminalId) return;
   const labels = { show: t('terminals.notifBtnShow') };
   api.notification.show({ type: type || 'done', title, body, terminalId, autoDismiss: 8000, labels });
@@ -2152,9 +2155,10 @@ function showCloseDialog() {
 }
 
 document.getElementById('btn-notifications').onclick = () => {
-  localState.notificationsEnabled = !localState.notificationsEnabled;
-  document.getElementById('btn-notifications').classList.toggle('active', localState.notificationsEnabled);
-  if (localState.notificationsEnabled && 'Notification' in window && Notification.permission === 'default') {
+  toggleNotifications();
+  const enabled = isNotificationsEnabled();
+  document.getElementById('btn-notifications').classList.toggle('active', enabled);
+  if (enabled && 'Notification' in window && Notification.permission === 'default') {
     Notification.requestPermission();
   }
 };


### PR DESCRIPTION
## Summary
- The notification bell toggle was using a volatile `localState.notificationsEnabled` variable that reset to `true` on every app launch
- Wired the bell toggle to the existing `settingsState` persistence (`isNotificationsEnabled()` / `toggleNotifications()`) which already existed but was unused in `renderer.js`
- Restored bell UI state (active/inactive class) on startup from persisted settings

## Changes
- `renderer.js`: Replace `localState.notificationsEnabled` with persisted `settingsState` functions, restore bell icon state on init

## Test plan
- [ ] Toggle notification bell off, restart app → bell should remain off
- [ ] Toggle notification bell on, restart app → bell should remain on
- [ ] Trigger a notification (e.g. Claude task completion while unfocused) → notification respects bell state
- [ ] Verify no regressions in notification behavior when bell is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)