### PR TITLE
feat(settings): add AI tab naming toggle

### DIFF
--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -587,6 +587,8 @@
     "terminalGroup": "Terminal",
     "tabRenameOnSlashCommand": "Rename tab on slash command",
     "tabRenameOnSlashCommandDesc": "Automatically rename the terminal tab to the last slash command executed (e.g. /gsd:verify-work 12)",
+    "aiTabNaming": "AI tab naming",
+    "aiTabNamingDesc": "Use AI to generate short tab names from messages",
     "hooks": {
       "title": "Smart Hooks",
       "enable": "Enable Smart Hooks",

--- a/src/renderer/i18n/locales/fr.json
+++ b/src/renderer/i18n/locales/fr.json
@@ -653,6 +653,8 @@
     "terminalGroup": "Terminal",
     "tabRenameOnSlashCommand": "Renommer l'onglet sur commande slash",
     "tabRenameOnSlashCommandDesc": "Renomme automatiquement l'onglet terminal avec la dernière commande slash exécutée (ex. /gsd:verify-work 12)",
+    "aiTabNaming": "Nommage IA des onglets",
+    "aiTabNamingDesc": "Utiliser l'IA pour générer des noms courts pour les onglets à partir des messages",
     "hooks": {
       "title": "Hooks intelligents",
       "enable": "Activer les hooks intelligents",

--- a/src/renderer/state/settings.state.js
+++ b/src/renderer/state/settings.state.js
@@ -33,6 +33,7 @@ const defaultSettings = {
   remoteSelectedIp: null, // Selected network interface IP for pairing URL (null = auto)
   showDotfiles: true, // true = show dotfiles in file explorer (default), false = hide them
   tabRenameOnSlashCommand: false, // Rename terminal tab to slash command text when submitted
+  aiTabNaming: true, // Use AI (Haiku) to generate short tab names from messages
   cloudServerUrl: '', // Cloud relay server URL (e.g. 'https://cloud.example.com')
   cloudApiKey: '', // Cloud API key (e.g. 'ctc_abc123...')
   cloudAutoConnect: true, // Auto-connect to cloud relay on startup

--- a/src/renderer/ui/components/ChatView.js
+++ b/src/renderer/ui/components/ChatView.js
@@ -1526,7 +1526,7 @@ function createChatView(wrapperEl, project, options = {}) {
     }
 
     // Tab rename: instant truncation + async haiku polish
-    if (onTabRename && !text.startsWith('/')) {
+    if (onTabRename && !text.startsWith('/') && getSetting('aiTabNaming') !== false) {
       // Immediate: smart truncation
       const words = text.split(/\s+/).slice(0, 5).join(' ');
       onTabRename(words.length > 30 ? words.slice(0, 28) + '...' : words);
@@ -3195,7 +3195,7 @@ function createChatView(wrapperEl, project, options = {}) {
     if (sid !== sessionId) return;
     appendUserMessage(text, images || [], [], isStreaming);
     // Trigger tab rename for remote messages (same logic as _send)
-    if (onTabRename && text && !text.startsWith('/')) {
+    if (onTabRename && text && !text.startsWith('/') && getSetting('aiTabNaming') !== false) {
       const words = text.split(/\s+/).slice(0, 5).join(' ');
       onTabRename(words.length > 30 ? words.slice(0, 28) + '...' : words);
       if (!tabNamePending) {

--- a/src/renderer/ui/components/TerminalManager.js
+++ b/src/renderer/ui/components/TerminalManager.js
@@ -375,7 +375,7 @@ function handleClaudeTitleChange(id, title, options = {}) {
 
     // Auto-name tab from Claude's task name (not tool names)
     if (parsed.taskName) {
-      if (!shouldSkipOscRename(id)) {
+      if (!shouldSkipOscRename(id) && getSetting('aiTabNaming') !== false) {
         updateTerminalTabName(id, parsed.taskName);
       }
     }
@@ -389,7 +389,7 @@ function handleClaudeTitleChange(id, title, options = {}) {
     if (parsed.taskName) {
       if (!terminalContext.has(id)) terminalContext.set(id, { taskName: null, lastTool: null, toolCount: 0, duration: null });
       terminalContext.get(id).taskName = parsed.taskName;
-      if (!shouldSkipOscRename(id)) {
+      if (!shouldSkipOscRename(id) && getSetting('aiTabNaming') !== false) {
         updateTerminalTabName(id, parsed.taskName);
       }
     }

--- a/src/renderer/ui/panels/SettingsPanel.js
+++ b/src/renderer/ui/panels/SettingsPanel.js
@@ -687,6 +687,16 @@ async function renderSettingsTab(initialTab = 'general') {
                   <span class="settings-toggle-slider"></span>
                 </label>
               </div>
+              <div class="settings-toggle-row">
+                <div class="settings-toggle-label">
+                  <div>${t('settings.aiTabNaming')}</div>
+                  <div class="settings-toggle-desc">${t('settings.aiTabNamingDesc')}</div>
+                </div>
+                <label class="settings-toggle">
+                  <input type="checkbox" id="ai-tab-naming-toggle" ${settings.aiTabNaming !== false ? 'checked' : ''}>
+                  <span class="settings-toggle-slider"></span>
+                </label>
+              </div>
             </div>
           </div>
           <div class="settings-group">
@@ -1162,6 +1172,8 @@ async function renderSettingsTab(initialTab = 'general') {
     const newAiCommitMessages = aiCommitToggle ? aiCommitToggle.checked : true;
     const tabRenameSlashToggle = document.getElementById('tab-rename-slash-toggle');
     const newTabRenameOnSlashCommand = tabRenameSlashToggle ? tabRenameSlashToggle.checked : false;
+    const aiTabNamingToggle = document.getElementById('ai-tab-naming-toggle');
+    const newAiTabNaming = aiTabNamingToggle ? aiTabNamingToggle.checked : true;
     const hooksToggle = document.getElementById('hooks-enabled-toggle');
     const newHooksEnabled = hooksToggle ? hooksToggle.checked : settings.hooksEnabled;
     const context1MToggle = document.getElementById('enable-1m-context-toggle');
@@ -1196,6 +1208,7 @@ async function renderSettingsTab(initialTab = 'general') {
       enable1MContext: newEnable1MContext,
       showDotfiles: newShowDotfiles,
       tabRenameOnSlashCommand: newTabRenameOnSlashCommand,
+      aiTabNaming: newAiTabNaming,
       telemetryEnabled: newTelemetryEnabled,
       telemetryCategories: newTelemetryCategories
     };


### PR DESCRIPTION
## Summary
- Add `aiTabNaming` setting (default: `true`) to let users disable AI-generated tab names
- Gate chat send, remote message, and OSC title tab renaming behind the new setting
- Add toggle in Settings > Terminal group with EN/FR i18n

## Test plan
- [ ] Toggle OFF → send chat message → tab keeps default name (no haiku call)
- [ ] Toggle ON → send chat message → tab gets AI-generated name
- [ ] OSC title changes from Claude CLI respect the toggle
- [ ] `npm test` passes (281 tests)
- [ ] `npm run build:renderer` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)