### PR TITLE
feat(terminal): remember last active tab on tab closing

### DIFF
--- a/src/renderer/ui/components/TerminalManager.js
+++ b/src/renderer/ui/components/TerminalManager.js
@@ -1172,7 +1172,11 @@ function setActiveTerminal(id) {
       if (!tabActivationHistory.has(newProjectId)) {
         tabActivationHistory.set(newProjectId, []);
       }
-      tabActivationHistory.get(newProjectId).push(id);
+      const history = tabActivationHistory.get(newProjectId);
+      if (history[history.length - 1] !== id) {
+        history.push(id);
+        if (history.length > 50) history.shift();
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Adds per-project tab activation history stack so closing a tab returns to the **previously-active tab** (browser-like UX) instead of the first neighbor in insertion order
- History is per-project and survives project switches
- Original neighbor scan kept as fallback for empty history

## Files Changed (1)
| File | Change |
|------|--------|
| `src/renderer/ui/components/TerminalManager.js` | Added `tabActivationHistory` Map, push in `setActiveTerminal`, walk-back in `closeTerminal` with fallback |

## Test plan
- [ ] Open 3+ tabs (A, B, C), activate in order A → B → C
- [ ] Close C → should return to B (not A)
- [ ] Close B → should return to A
- [ ] Open tabs across 2 projects, close tab in project 1 → should return to last active in project 1 (not project 2)
- [ ] Close all tabs in a project → fallback behavior (no crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)