### PR TITLE
fix(projects): prevent circular folder references in drag-and-drop

### DIFF
--- a/src/renderer/state/projects.state.js
+++ b/src/renderer/state/projects.state.js
@@ -176,8 +176,11 @@ function countProjectsRecursive(folderId) {
  * @returns {boolean}
  */
 function isDescendantOf(folderId, ancestorId) {
+  const visited = new Set();
   let current = getFolder(folderId);
   while (current) {
+    if (visited.has(current.id)) return false;
+    visited.add(current.id);
     if (current.parentId === ancestorId) return true;
     current = getFolder(current.parentId);
   }
@@ -738,6 +741,19 @@ function moveItemToFolder(itemType, itemId, targetFolderId) {
       }
     }
   }
+
+  // Sanitize: prevent direct self-referencing folders (A.parentId === A.id).
+  // Note: multi-hop cycles (A → B → A) are prevented upstream by isDescendantOf().
+  folders = folders.map(f => {
+    const needsParentFix = f.parentId === f.id;
+    const needsChildrenFix = f.children && f.children.includes(f.id);
+    if (!needsParentFix && !needsChildrenFix) return f;
+    return {
+      ...f,
+      parentId: needsParentFix ? null : f.parentId,
+      children: needsChildrenFix ? f.children.filter(c => c !== f.id) : f.children,
+    };
+  });
 
   projectsState.set({ folders, projects, rootOrder });
   saveProjects();

--- a/src/renderer/ui/components/ProjectList.js
+++ b/src/renderer/ui/components/ProjectList.js
@@ -617,6 +617,7 @@ class ProjectList extends BaseComponent {
       }
       if (self._dragState.dropTarget.type === 'folder') {
         if (position === 'into') {
+          if (self._dragState.dragging.type === 'folder' && self._dragState.dragging.id === self._dragState.dropTarget.id) return;
           moveItemToFolder(self._dragState.dragging.type, self._dragState.dragging.id, self._dragState.dropTarget.id);
         } else {
           reorderItem(self._dragState.dragging.type, self._dragState.dragging.id, self._dragState.dropTarget.id, position);

--- a/tests/state/projects.state.test.js
+++ b/tests/state/projects.state.test.js
@@ -245,6 +245,15 @@ describe('isDescendantOf', () => {
     });
     expect(isDescendantOf('f2', 'f1')).toBe(false);
   });
+
+  test('does not infinite loop on circular parentId reference', () => {
+    resetState({
+      folders: [
+        { id: 'f1', name: 'A', parentId: 'f1', children: ['f1'] },
+      ],
+    });
+    expect(isDescendantOf('f1', 'f999')).toBe(false);
+  });
 });
 
 // ── Folder CRUD ──
@@ -478,6 +487,22 @@ describe('moveItemToFolder', () => {
     });
     moveItemToFolder('folder', 'f1', 'f1');
     expect(getFolder('f1').parentId).toBeNull();
+  });
+
+  test('sanitizes circular parentId if it somehow occurs', () => {
+    resetState({
+      folders: [
+        { id: 'f1', name: 'A', parentId: null, collapsed: false, children: ['p1'] },
+        { id: 'f2', name: 'B', parentId: 'f2', collapsed: false, children: ['f2'] },
+      ],
+      projects: [{ id: 'p1', name: 'P', path: '/p', folderId: 'f1' }],
+      rootOrder: ['f1', 'f2'],
+    });
+    moveItemToFolder('project', 'p1', 'f2');
+    const f2 = getFolder('f2');
+    expect(f2.parentId).toBeNull();
+    expect(f2.children).not.toContain('f2');
+    expect(f2.children).toContain('p1');
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes a bug where drag-and-drop can corrupt `projects.json` by creating circular folder references — a folder becomes its own parent, making it and its projects invisible in the sidebar.

Supersedes #49 (rebased on current main, addresses review feedback).

## Changes

- `src/renderer/state/projects.state.js` — Added `visited` Set in `isDescendantOf()` to break infinite loops on corrupted data; added immutable post-operation sanitization in `moveItemToFolder()` using `map+spread` that clears self-referencing `parentId` and `children` on every move
- `src/renderer/ui/components/ProjectList.js` — Added explicit `dragging.id === dropTarget.id` guard in `onDrop()` handler before calling `moveItemToFolder()`
- `tests/state/projects.state.test.js` — 2 new tests: circular `parentId` doesn't infinite loop in `isDescendantOf()`; `moveItemToFolder()` sanitizes pre-existing circular references

### Root Cause

The `dragover` handler validates that a folder can't be dropped into itself, but it's throttled at 50ms. A timing edge case allows the `drop` event to execute without the last validation pass, calling `moveItemToFolder()` with `targetFolderId === itemId`. This fix adds defense in depth with 3 layers: drop guard, cycle detection, and post-op sanitization.

### Review Feedback Addressed (from #49)

1. **Immutable sanitization** — Uses `folders.map()` with spread operator instead of in-place mutation
2. **Scope documentation** — Added comment clarifying that direct self-references are caught here, while multi-hop cycles (A → B → A) are prevented upstream by `isDescendantOf()`

## Testing

- [x] `npm run build:renderer` — builds successfully
- [x] `npm test` — 39 suites, 1324 tests pass (including 2 new)
- [x] Tested on Linux (Ubuntu)
- [x] No console errors
- [x] Existing features still work