### PR TITLE
feat(linux): auto-register .desktop entry for AppImage launches

### DIFF
--- a/main.js
+++ b/main.js
@@ -282,6 +282,17 @@ function bootstrapApp() {
 
   // App lifecycle
   app.whenReady().then(() => {
+    // Linux AppImage: register/refresh the .desktop entry so the app appears
+    // in the application menu (and survives version bumps that change the
+    // AppImage filename). Best-effort, never throws.
+    if (process.platform === 'linux') {
+      try {
+        require('./src/main/services/LinuxDesktopIntegration').run();
+      } catch (e) {
+        console.warn('[LinuxDesktopIntegration] skipped:', e && e.message);
+      }
+    }
+
     // Content Security Policy - allow only local file:// resources
     // Prevents XSS attacks from loading remote scripts/styles/iframes
     session.defaultSession.webRequest.onHeadersReceived((details, callback) => {

--- a/src/main/services/LinuxDesktopIntegration.js
+++ b/src/main/services/LinuxDesktopIntegration.js
@@ -1,0 +1,236 @@
+/**
+ * Linux Desktop Integration
+ *
+ * Registers/updates a XDG `.desktop` file and icon so that the app appears in
+ * the application menu after the user launches the AppImage for the first time,
+ * and so subsequent updates (AppImages with a different filename) keep working.
+ *
+ * Without this, AppImages distributed without AppImageLauncher are invisible
+ * to GNOME/KDE/etc. until the user manually creates a `.desktop` entry —
+ * and any such entry breaks on every release because the versioned filename
+ * changes (e.g. Claude-Terminal-1.2.6.AppImage -> Claude-Terminal-1.2.7.AppImage).
+ *
+ * Strategy:
+ *   - Run on every launch, only when `process.platform === 'linux'` and
+ *     `process.env.APPIMAGE` is set (electron-builder injects it).
+ *   - Write to ~/.local/share/applications/claude-terminal.desktop, pointing
+ *     `Exec=` and `TryExec=` at the current AppImage path.
+ *   - Copy the bundled icon to ~/.local/share/icons/claude-terminal.png and
+ *     reference it by absolute path (works across every DE without relying
+ *     on the hicolor theme cache being regenerated).
+ *   - Mark the file with `X-Claude-Terminal-ManagedBy=app` so we never stomp
+ *     on a file the user maintains by hand.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { execFile } = require('child_process');
+
+const APP_NAME = 'Claude Terminal';
+const DESKTOP_FILE_NAME = 'claude-terminal.desktop';
+const ICON_FILE_NAME = 'claude-terminal.png';
+const MANAGED_MARKER = 'X-Claude-Terminal-ManagedBy=app';
+
+/**
+ * Build the full contents of the `.desktop` file.
+ * Pure function — easy to unit test.
+ *
+ * @param {object} opts
+ * @param {string} opts.appImagePath  Absolute path to the current AppImage.
+ * @param {string} opts.iconPath      Absolute path to the installed icon.
+ * @param {string} [opts.version]     App version (for X-AppImage-Version).
+ * @returns {string}
+ */
+function buildDesktopFileContent({ appImagePath, iconPath, version }) {
+  // Quote the AppImage path so it survives spaces in the filename.
+  const quotedExec = '"' + appImagePath.replace(/"/g, '\\"') + '"';
+
+  const lines = [
+    '[Desktop Entry]',
+    `Name=${APP_NAME}`,
+    'Comment=Terminal for Claude Code projects',
+    `Exec=${quotedExec} --no-sandbox %U`,
+    `TryExec=${appImagePath}`,
+    `Icon=${iconPath}`,
+    'Terminal=false',
+    'Type=Application',
+    'Categories=Development;Utility;',
+    `StartupWMClass=${APP_NAME}`,
+  ];
+  if (version) {
+    lines.push(`X-AppImage-Version=${version}`);
+  }
+  lines.push(MANAGED_MARKER);
+  lines.push('');
+  return lines.join('\n');
+}
+
+/**
+ * Decide whether the existing `.desktop` should be rewritten.
+ * Pure function — easy to unit test.
+ *
+ * Rules:
+ *   - No existing file      -> write.
+ *   - Managed by us & stale -> write.
+ *   - User-maintained       -> leave it alone.
+ *
+ * @param {string|null} existingContent
+ * @param {string}      newContent
+ * @returns {boolean}
+ */
+function shouldWriteDesktopFile(existingContent, newContent) {
+  if (!existingContent) return true;
+  if (!existingContent.includes(MANAGED_MARKER)) return false;
+  return existingContent !== newContent;
+}
+
+/**
+ * Resolve the bundled icon source path.
+ * In development it sits under `<repo>/assets/icon.png`; inside a packaged
+ * AppImage it may live under `process.resourcesPath` (when included via
+ * `extraResources`) or inside the asar archive.
+ *
+ * @param {string} [resourcesPath]
+ * @returns {string|null}
+ */
+function resolveBundledIconPath(resourcesPath) {
+  const candidates = [
+    path.join(__dirname, '..', '..', '..', 'assets', 'icon.png'),
+  ];
+  if (resourcesPath) {
+    candidates.push(path.join(resourcesPath, 'assets', 'icon.png'));
+    candidates.push(path.join(resourcesPath, 'app.asar.unpacked', 'assets', 'icon.png'));
+  }
+  for (const candidate of candidates) {
+    try {
+      if (fs.existsSync(candidate)) return candidate;
+    } catch (_) { /* keep trying */ }
+  }
+  return null;
+}
+
+/**
+ * Perform the actual installation (public for tests — callers should use {@link run}).
+ *
+ * @param {object} opts
+ * @param {string}        opts.home             Home directory.
+ * @param {string}        opts.appImagePath     Current AppImage path.
+ * @param {string|null}   opts.iconSourcePath   Bundled icon source (may be null).
+ * @param {string}        [opts.version]        App version string.
+ * @param {object}        [opts.logger]         Console-like logger.
+ * @param {object}        [opts.fsImpl]         Injected fs (for tests).
+ * @param {Function}      [opts.refreshFn]      Invoked to refresh desktop DB.
+ * @returns {{written: boolean, desktopPath: string, iconPath: string|null, skipped?: string}}
+ */
+function install({ home, appImagePath, iconSourcePath, version, logger, fsImpl, refreshFn }) {
+  const _fs = fsImpl || fs;
+  const applicationsDir = path.join(home, '.local', 'share', 'applications');
+  const iconDir = path.join(home, '.local', 'share', 'icons');
+  const desktopPath = path.join(applicationsDir, DESKTOP_FILE_NAME);
+  const iconPath = path.join(iconDir, ICON_FILE_NAME);
+
+  _fs.mkdirSync(applicationsDir, { recursive: true });
+  _fs.mkdirSync(iconDir, { recursive: true });
+
+  let installedIconPath = null;
+  if (iconSourcePath) {
+    try {
+      const needsIcon =
+        !_fs.existsSync(iconPath) ||
+        _fs.statSync(iconPath).mtimeMs < _fs.statSync(iconSourcePath).mtimeMs;
+      if (needsIcon) {
+        _fs.copyFileSync(iconSourcePath, iconPath);
+      }
+      installedIconPath = iconPath;
+    } catch (e) {
+      logger && logger.warn && logger.warn('[LinuxDesktopIntegration] icon install failed:', e.message);
+    }
+  }
+
+  // If the icon copy failed AND no prior icon exists, fall back to the
+  // AppImage-internal `claude-terminal` name — many themes resolve it.
+  const iconToReference = installedIconPath || 'claude-terminal';
+
+  const newContent = buildDesktopFileContent({ appImagePath, iconPath: iconToReference, version });
+
+  let existing = null;
+  try { existing = _fs.readFileSync(desktopPath, 'utf8'); } catch (_) { /* missing is fine */ }
+
+  if (!shouldWriteDesktopFile(existing, newContent)) {
+    return { written: false, desktopPath, iconPath: installedIconPath, skipped: existing ? 'up-to-date-or-user-managed' : 'unknown' };
+  }
+
+  _fs.writeFileSync(desktopPath, newContent);
+  try { _fs.chmodSync(desktopPath, 0o755); } catch (_) { /* best-effort */ }
+
+  if (refreshFn) {
+    try { refreshFn(applicationsDir); } catch (_) { /* best-effort */ }
+  }
+
+  return { written: true, desktopPath, iconPath: installedIconPath };
+}
+
+/**
+ * Run the integration. Safe to call unconditionally — bails out cleanly on
+ * non-Linux platforms, non-AppImage launches, and any I/O error.
+ *
+ * @param {object} [opts]
+ * @param {object} [opts.logger]
+ * @returns {{written?: boolean, skipped?: string, error?: string}}
+ */
+function run(opts = {}) {
+  const logger = opts.logger || console;
+
+  if (process.platform !== 'linux') return { skipped: 'not-linux' };
+
+  const appImagePath = process.env.APPIMAGE;
+  if (!appImagePath) return { skipped: 'not-appimage' };
+
+  try {
+    const home = os.homedir();
+    const resourcesPath = process.resourcesPath;
+    const iconSourcePath = resolveBundledIconPath(resourcesPath);
+
+    let version = '';
+    try {
+      // eslint-disable-next-line global-require
+      version = require(path.join(__dirname, '..', '..', '..', 'package.json')).version || '';
+    } catch (_) { /* ignore */ }
+
+    const result = install({
+      home,
+      appImagePath,
+      iconSourcePath,
+      version,
+      logger,
+      refreshFn: refreshDesktopDatabase,
+    });
+
+    if (result.written) {
+      logger.log && logger.log(`[LinuxDesktopIntegration] updated ${result.desktopPath} -> ${appImagePath}`);
+    }
+    return result;
+  } catch (e) {
+    logger.warn && logger.warn('[LinuxDesktopIntegration] failed:', e.message);
+    return { error: e.message };
+  }
+}
+
+/**
+ * Best-effort, non-blocking refresh of the desktop entry database.
+ * Missing binary, non-zero exit, or timeout are all silently ignored.
+ */
+function refreshDesktopDatabase(applicationsDir) {
+  execFile('update-desktop-database', [applicationsDir], { timeout: 5000 }, () => { /* ignore */ });
+}
+
+module.exports = {
+  run,
+  install,
+  buildDesktopFileContent,
+  shouldWriteDesktopFile,
+  resolveBundledIconPath,
+  // Exported constants for tests.
+  _internals: { APP_NAME, DESKTOP_FILE_NAME, ICON_FILE_NAME, MANAGED_MARKER },
+};

--- a/src/main/services/LinuxDesktopIntegration.js
+++ b/src/main/services/LinuxDesktopIntegration.js
@@ -50,13 +50,15 @@ function buildDesktopFileContent({ appImagePath, iconPath, version }) {
     '[Desktop Entry]',
     `Name=${APP_NAME}`,
     'Comment=Terminal for Claude Code projects',
+    // --no-sandbox: required for AppImages — Chromium's SUID sandbox needs
+    // permissions that AppImage environments cannot provide.
     `Exec=${quotedExec} --no-sandbox %U`,
     `TryExec=${appImagePath}`,
     `Icon=${iconPath}`,
     'Terminal=false',
     'Type=Application',
     'Categories=Development;Utility;',
-    `StartupWMClass=${APP_NAME}`,
+    'StartupWMClass=claude-terminal',
   ];
   if (version) {
     lines.push(`X-AppImage-Version=${version}`);

--- a/tests/services/LinuxDesktopIntegration.test.js
+++ b/tests/services/LinuxDesktopIntegration.test.js
@@ -1,0 +1,265 @@
+// LinuxDesktopIntegration unit tests — pure functions + install() with injected fs.
+
+const path = require('path');
+
+const {
+  run,
+  install,
+  buildDesktopFileContent,
+  shouldWriteDesktopFile,
+  resolveBundledIconPath,
+  _internals,
+} = require('../../src/main/services/LinuxDesktopIntegration');
+
+const { DESKTOP_FILE_NAME, ICON_FILE_NAME, MANAGED_MARKER } = _internals;
+
+// ── buildDesktopFileContent ───────────────────────────────────────────────
+
+describe('buildDesktopFileContent', () => {
+  const baseArgs = {
+    appImagePath: '/home/user/Applications/Claude-Terminal-1.2.7.AppImage',
+    iconPath: '/home/user/.local/share/icons/claude-terminal.png',
+    version: '1.2.7',
+  };
+
+  test('emits a valid Desktop Entry header', () => {
+    const content = buildDesktopFileContent(baseArgs);
+    expect(content.startsWith('[Desktop Entry]\n')).toBe(true);
+  });
+
+  test('includes Name, Type, and Terminal=false', () => {
+    const content = buildDesktopFileContent(baseArgs);
+    expect(content).toContain('Name=Claude Terminal');
+    expect(content).toContain('Type=Application');
+    expect(content).toContain('Terminal=false');
+  });
+
+  test('quotes the AppImage path in Exec and preserves TryExec', () => {
+    const content = buildDesktopFileContent(baseArgs);
+    expect(content).toContain(`Exec="${baseArgs.appImagePath}" --no-sandbox %U`);
+    expect(content).toContain(`TryExec=${baseArgs.appImagePath}`);
+  });
+
+  test('escapes double quotes in the AppImage path', () => {
+    const content = buildDesktopFileContent({
+      ...baseArgs,
+      appImagePath: '/weird/path with "quotes".AppImage',
+    });
+    expect(content).toContain('Exec="/weird/path with \\"quotes\\".AppImage" --no-sandbox %U');
+  });
+
+  test('uses the provided icon path verbatim', () => {
+    const content = buildDesktopFileContent(baseArgs);
+    expect(content).toContain(`Icon=${baseArgs.iconPath}`);
+  });
+
+  test('includes version when provided', () => {
+    const content = buildDesktopFileContent(baseArgs);
+    expect(content).toContain('X-AppImage-Version=1.2.7');
+  });
+
+  test('omits X-AppImage-Version when version is falsy', () => {
+    const content = buildDesktopFileContent({ ...baseArgs, version: '' });
+    expect(content).not.toContain('X-AppImage-Version=');
+  });
+
+  test('always carries the managed marker', () => {
+    const content = buildDesktopFileContent(baseArgs);
+    expect(content).toContain(MANAGED_MARKER);
+  });
+});
+
+// ── shouldWriteDesktopFile ────────────────────────────────────────────────
+
+describe('shouldWriteDesktopFile', () => {
+  const ours = `[Desktop Entry]\nName=Claude Terminal\n${MANAGED_MARKER}\n`;
+  const stale = `[Desktop Entry]\nName=Claude Terminal\nExec=/old/path\n${MANAGED_MARKER}\n`;
+  const userOwned = '[Desktop Entry]\nName=Claude Terminal\nExec=/my/custom/path\n';
+
+  test('writes when there is no existing file', () => {
+    expect(shouldWriteDesktopFile(null, ours)).toBe(true);
+  });
+
+  test('does not write when content is already up-to-date', () => {
+    expect(shouldWriteDesktopFile(ours, ours)).toBe(false);
+  });
+
+  test('overwrites a previously-managed file when content drifted', () => {
+    expect(shouldWriteDesktopFile(stale, ours)).toBe(true);
+  });
+
+  test('leaves user-maintained files alone (no marker)', () => {
+    expect(shouldWriteDesktopFile(userOwned, ours)).toBe(false);
+  });
+});
+
+// ── install (with injected fs) ────────────────────────────────────────────
+
+function makeFakeFs() {
+  const files = new Map(); // absolute path -> { content, mtimeMs }
+  const dirs = new Set();
+  const now = () => Date.now();
+
+  return {
+    _files: files,
+    _dirs: dirs,
+    mkdirSync(p, _opts) { dirs.add(p); },
+    existsSync(p) { return files.has(p); },
+    statSync(p) {
+      if (!files.has(p)) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      return { mtimeMs: files.get(p).mtimeMs };
+    },
+    readFileSync(p) {
+      if (!files.has(p)) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      return files.get(p).content;
+    },
+    writeFileSync(p, content) { files.set(p, { content, mtimeMs: now() }); },
+    copyFileSync(src, dest) {
+      if (!files.has(src)) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      files.set(dest, { content: files.get(src).content, mtimeMs: now() });
+    },
+    chmodSync() { /* noop */ },
+    // Test helpers
+    _seed(p, content, mtimeMs = now()) { files.set(p, { content, mtimeMs }); },
+  };
+}
+
+describe('install', () => {
+  const home = '/home/user';
+  const appImagePath = '/home/user/Applications/Claude-Terminal-1.2.7.AppImage';
+  const iconSourcePath = '/repo/assets/icon.png';
+  const version = '1.2.7';
+
+  const desktopPath = path.join(home, '.local', 'share', 'applications', DESKTOP_FILE_NAME);
+  const iconPath = path.join(home, '.local', 'share', 'icons', ICON_FILE_NAME);
+
+  test('writes .desktop and copies icon on a clean system', () => {
+    const fakeFs = makeFakeFs();
+    fakeFs._seed(iconSourcePath, 'PNGDATA');
+    const refreshFn = jest.fn();
+
+    const result = install({
+      home, appImagePath, iconSourcePath, version,
+      fsImpl: fakeFs, refreshFn,
+    });
+
+    expect(result.written).toBe(true);
+    expect(result.desktopPath).toBe(desktopPath);
+    expect(result.iconPath).toBe(iconPath);
+
+    const written = fakeFs._files.get(desktopPath).content;
+    expect(written).toContain(`Exec="${appImagePath}" --no-sandbox %U`);
+    expect(written).toContain(`Icon=${iconPath}`);
+    expect(written).toContain(MANAGED_MARKER);
+    expect(fakeFs._files.get(iconPath).content).toBe('PNGDATA');
+    expect(refreshFn).toHaveBeenCalledWith(path.join(home, '.local', 'share', 'applications'));
+  });
+
+  test('rewrites .desktop when AppImage path changed (simulated update)', () => {
+    const fakeFs = makeFakeFs();
+    fakeFs._seed(iconSourcePath, 'PNGDATA');
+
+    // First install at version 1.2.6.
+    const oldPath = '/home/user/Applications/Claude-Terminal-1.2.6.AppImage';
+    install({
+      home, appImagePath: oldPath, iconSourcePath, version: '1.2.6',
+      fsImpl: fakeFs, refreshFn: () => {},
+    });
+    expect(fakeFs._files.get(desktopPath).content).toContain(oldPath);
+
+    // Simulate update → AppImage filename changes, app relaunches.
+    const result = install({
+      home, appImagePath, iconSourcePath, version,
+      fsImpl: fakeFs, refreshFn: () => {},
+    });
+
+    expect(result.written).toBe(true);
+    expect(fakeFs._files.get(desktopPath).content).toContain(appImagePath);
+    expect(fakeFs._files.get(desktopPath).content).not.toContain(oldPath);
+  });
+
+  test('is a no-op when the file is already up-to-date', () => {
+    const fakeFs = makeFakeFs();
+    fakeFs._seed(iconSourcePath, 'PNGDATA');
+
+    install({
+      home, appImagePath, iconSourcePath, version,
+      fsImpl: fakeFs, refreshFn: () => {},
+    });
+
+    const refreshFn = jest.fn();
+    const second = install({
+      home, appImagePath, iconSourcePath, version,
+      fsImpl: fakeFs, refreshFn,
+    });
+
+    expect(second.written).toBe(false);
+    expect(refreshFn).not.toHaveBeenCalled();
+  });
+
+  test('does not overwrite a user-maintained .desktop (missing marker)', () => {
+    const fakeFs = makeFakeFs();
+    fakeFs._seed(iconSourcePath, 'PNGDATA');
+    const userContent = '[Desktop Entry]\nName=Claude Terminal\nExec=/my/own/path\n';
+    fakeFs._seed(desktopPath, userContent);
+
+    const result = install({
+      home, appImagePath, iconSourcePath, version,
+      fsImpl: fakeFs, refreshFn: () => {},
+    });
+
+    expect(result.written).toBe(false);
+    expect(fakeFs._files.get(desktopPath).content).toBe(userContent);
+  });
+
+  test('falls back to icon name when no bundled icon is available', () => {
+    const fakeFs = makeFakeFs();
+    // No icon source seeded.
+
+    const result = install({
+      home, appImagePath, iconSourcePath: null, version,
+      fsImpl: fakeFs, refreshFn: () => {},
+    });
+
+    expect(result.written).toBe(true);
+    expect(result.iconPath).toBeNull();
+    const written = fakeFs._files.get(desktopPath).content;
+    expect(written).toContain('Icon=claude-terminal');
+  });
+});
+
+// ── resolveBundledIconPath ────────────────────────────────────────────────
+
+describe('resolveBundledIconPath', () => {
+  test('returns null when nothing is found (purely tests the no-match branch)', () => {
+    // Pass a resources path we know does not exist.
+    const result = resolveBundledIconPath('/definitely/not/a/real/path/' + Math.random());
+    // Might still resolve to the dev-time assets/icon.png if the suite runs
+    // from the repo root — just assert it is either a string or null.
+    expect(result === null || typeof result === 'string').toBe(true);
+  });
+});
+
+// ── run (platform guards) ─────────────────────────────────────────────────
+
+describe('run', () => {
+  const originalPlatform = process.platform;
+  const originalAppImage = process.env.APPIMAGE;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+    if (originalAppImage === undefined) delete process.env.APPIMAGE;
+    else process.env.APPIMAGE = originalAppImage;
+  });
+
+  test('skips when platform is not Linux', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    expect(run({ logger: { log() {}, warn() {} } })).toEqual({ skipped: 'not-linux' });
+  });
+
+  test('skips when APPIMAGE env var is not set on Linux', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    delete process.env.APPIMAGE;
+    expect(run({ logger: { log() {}, warn() {} } })).toEqual({ skipped: 'not-appimage' });
+  });
+});


### PR DESCRIPTION
## Summary

On Linux the app is distributed as a versioned AppImage (`Claude-Terminal-1.2.7.AppImage`) with no mechanism to install itself into the application menu. Users who just download the AppImage never see it in GNOME / KDE / Cinnamon / etc., and any `.desktop` they create by hand breaks on the next release because the filename changes.

This PR makes the app register (and refresh) its own XDG desktop entry on every launch, so it appears in the application menu after first run and keeps working across updates.

## Changes

- `src/main/services/LinuxDesktopIntegration.js` — new service. When `process.platform === 'linux'` **and** `process.env.APPIMAGE` is set (electron-builder injects it), it:
  - writes `~/.local/share/applications/claude-terminal.desktop` pointing `Exec=` and `TryExec=` at the current `$APPIMAGE` path;
  - copies the bundled `assets/icon.png` to `~/.local/share/icons/claude-terminal.png` and references it by absolute path (works across every DE without relying on the hicolor cache);
  - marks the file with `X-Claude-Terminal-ManagedBy=app` — if the user has a hand-maintained `.desktop` without this marker, we never touch it;
  - best-effort `update-desktop-database` refresh, non-blocking.
- `main.js` — invoke `LinuxDesktopIntegration.run()` inside `app.whenReady()`. Wrapped in try/catch; any failure just logs a warning.
- `tests/services/LinuxDesktopIntegration.test.js` — 20 unit tests covering desktop-file content generation, overwrite policy, the full install flow (with an injected in-memory fs), and platform guards.

## Why this path

- **First-launch registration is the standard AppImage-without-AppImageLauncher workflow** used by VS Code, Obsidian, Cursor, etc.
- **Re-running on every startup** is what keeps the entry valid across releases — the AppImage filename always encodes the version, so anything pinned to the old filename breaks. The rewrite is a cheap no-op when nothing changed.
- **Managed marker** means power users who prefer their own `.desktop` are never stomped on.
- **Never throws** — the bootstrap hook is `try/catch`ed, `run()` internally catches everything, and non-Linux / non-AppImage platforms return `{ skipped }` immediately. macOS and Windows are unaffected.

## Testing

- [x] `npm test` — **1434 / 1434 passing** (includes 20 new tests).
- [x] `npm run build:renderer` — builds clean.
- [x] Manual end-to-end smoke test against a fake `$HOME`:
  - fresh install → `.desktop` + icon written, `Exec="/…/Claude-Terminal-9.9.9.AppImage" --no-sandbox %U`;
  - simulated version bump (AppImage path changes) → `.desktop` rewritten with new path;
  - second launch with no changes → `{ written: false, skipped: 'up-to-date-or-user-managed' }`;
  - user-owned `.desktop` without the marker → left untouched.
- [ ] Tested on Windows 10
- [ ] Tested on Windows 11
- [x] No console errors
- [x] Existing features still work (all tests green)

## Related Issues

Fixes the issue where users report the Claude Terminal icon disappears from the application menu after each update on Linux.