### PR TITLE
feat(linux): adopt pre-v1.2.8 .desktop files into managed integration

### DIFF
--- a/src/main/services/LinuxDesktopIntegration.js
+++ b/src/main/services/LinuxDesktopIntegration.js
@@ -69,13 +69,35 @@ function buildDesktopFileContent({ appImagePath, iconPath, version }) {
 }
 
 /**
+ * Detect a pre-v1.2.8 `.desktop` entry that this app should adopt.
+ *
+ * Pre-v1.2.8 users — and the workaround scripts that circulated before this
+ * service existed — created `.desktop` files by hand. They never carry the
+ * managed marker, but they unmistakably target this AppImage. Without
+ * adopting them, the integration treats them as user-maintained forever and
+ * the icon silently breaks on every update. The heuristic is intentionally
+ * narrow: same Name, and Exec pointing at a `Claude-Terminal*.AppImage`.
+ * Anything else (custom Name, wrapper script, different binary) is left
+ * alone — false negatives are safe, false positives are not.
+ *
+ * @param {string} content
+ * @returns {boolean}
+ */
+function looksLikeLegacyClaudeTerminalDesktop(content) {
+  if (!content || !content.includes('[Desktop Entry]')) return false;
+  if (!/^Name=Claude Terminal\s*$/m.test(content)) return false;
+  return /^Exec=["']?\S*\bClaude-Terminal(-[\w.]+)?\.AppImage\b/m.test(content);
+}
+
+/**
  * Decide whether the existing `.desktop` should be rewritten.
  * Pure function — easy to unit test.
  *
  * Rules:
- *   - No existing file      -> write.
- *   - Managed by us & stale -> write.
- *   - User-maintained       -> leave it alone.
+ *   - No existing file               -> write.
+ *   - Managed by us & stale          -> write.
+ *   - Pre-v1.2.8 legacy (no marker)  -> adopt once.
+ *   - Otherwise user-maintained      -> leave it alone.
  *
  * @param {string|null} existingContent
  * @param {string}      newContent
@@ -83,8 +105,10 @@ function buildDesktopFileContent({ appImagePath, iconPath, version }) {
  */
 function shouldWriteDesktopFile(existingContent, newContent) {
   if (!existingContent) return true;
-  if (!existingContent.includes(MANAGED_MARKER)) return false;
-  return existingContent !== newContent;
+  if (existingContent.includes(MANAGED_MARKER)) {
+    return existingContent !== newContent;
+  }
+  return looksLikeLegacyClaudeTerminalDesktop(existingContent);
 }
 
 /**
@@ -232,6 +256,7 @@ module.exports = {
   install,
   buildDesktopFileContent,
   shouldWriteDesktopFile,
+  looksLikeLegacyClaudeTerminalDesktop,
   resolveBundledIconPath,
   // Exported constants for tests.
   _internals: { APP_NAME, DESKTOP_FILE_NAME, ICON_FILE_NAME, MANAGED_MARKER },

--- a/tests/services/LinuxDesktopIntegration.test.js
+++ b/tests/services/LinuxDesktopIntegration.test.js
@@ -8,6 +8,7 @@ const {
   buildDesktopFileContent,
   shouldWriteDesktopFile,
   resolveBundledIconPath,
+  looksLikeLegacyClaudeTerminalDesktop,
   _internals,
 } = require('../../src/main/services/LinuxDesktopIntegration');
 
@@ -90,6 +91,86 @@ describe('shouldWriteDesktopFile', () => {
 
   test('leaves user-maintained files alone (no marker)', () => {
     expect(shouldWriteDesktopFile(userOwned, ours)).toBe(false);
+  });
+
+  test('adopts a pre-v1.2.8 legacy entry that clearly targets this app (no marker)', () => {
+    // Pre-v1.2.8 users created `.desktop` entries by hand or via workaround
+    // scripts. They never carry the marker, but they unmistakably point at
+    // our AppImage — overwrite once so future updates flow through the
+    // managed path.
+    const legacy = [
+      '[Desktop Entry]',
+      'Name=Claude Terminal',
+      'Exec=/home/user/Applications/Claude-Terminal.AppImage --no-sandbox %U',
+      'Type=Application',
+      '',
+    ].join('\n');
+    expect(shouldWriteDesktopFile(legacy, ours)).toBe(true);
+  });
+
+  test('still leaves a user-maintained entry alone when Exec points elsewhere', () => {
+    const wrapped = [
+      '[Desktop Entry]',
+      'Name=Claude Terminal',
+      'Exec=/usr/local/bin/my-claude-wrapper.sh %U',
+      'Type=Application',
+      '',
+    ].join('\n');
+    expect(shouldWriteDesktopFile(wrapped, ours)).toBe(false);
+  });
+});
+
+// ── looksLikeLegacyClaudeTerminalDesktop ──────────────────────────────────
+
+describe('looksLikeLegacyClaudeTerminalDesktop', () => {
+  test('matches an entry pointing at the stable symlink', () => {
+    const content = [
+      '[Desktop Entry]',
+      'Name=Claude Terminal',
+      'Exec=/home/user/Applications/Claude-Terminal.AppImage --no-sandbox %U',
+      'Type=Application',
+    ].join('\n');
+    expect(looksLikeLegacyClaudeTerminalDesktop(content)).toBe(true);
+  });
+
+  test('matches an entry pointing at a versioned AppImage', () => {
+    const content = [
+      '[Desktop Entry]',
+      'Name=Claude Terminal',
+      'Exec=/home/user/Applications/Claude-Terminal-1.2.7.AppImage --no-sandbox %U',
+      'Type=Application',
+    ].join('\n');
+    expect(looksLikeLegacyClaudeTerminalDesktop(content)).toBe(true);
+  });
+
+  test('matches an entry whose Exec is quoted', () => {
+    const content = [
+      '[Desktop Entry]',
+      'Name=Claude Terminal',
+      'Exec="/home/user/Applications/Claude-Terminal-1.2.7.AppImage" --no-sandbox %U',
+      'Type=Application',
+    ].join('\n');
+    expect(looksLikeLegacyClaudeTerminalDesktop(content)).toBe(true);
+  });
+
+  test('rejects entries with a different Name', () => {
+    const content = [
+      '[Desktop Entry]',
+      'Name=My Custom Claude',
+      'Exec=/home/user/Applications/Claude-Terminal.AppImage --no-sandbox %U',
+      'Type=Application',
+    ].join('\n');
+    expect(looksLikeLegacyClaudeTerminalDesktop(content)).toBe(false);
+  });
+
+  test('rejects entries whose Exec targets a wrapper instead of the AppImage', () => {
+    const content = [
+      '[Desktop Entry]',
+      'Name=Claude Terminal',
+      'Exec=/usr/local/bin/my-claude-wrapper.sh %U',
+      'Type=Application',
+    ].join('\n');
+    expect(looksLikeLegacyClaudeTerminalDesktop(content)).toBe(false);
   });
 });
 
@@ -225,6 +306,34 @@ describe('install', () => {
     expect(result.iconPath).toBeNull();
     const written = fakeFs._files.get(desktopPath).content;
     expect(written).toContain('Icon=claude-terminal');
+  });
+
+  test('adopts and rewrites a pre-v1.2.8 legacy .desktop on first run', () => {
+    // Reproduces the real-world scenario: a user installed before v1.2.8 and
+    // had a hand-maintained `.desktop` pointing at the AppImage, but without
+    // our marker. After upgrading, the first launch should adopt it — not
+    // skip silently — so subsequent updates flow through the managed path.
+    const fakeFs = makeFakeFs();
+    fakeFs._seed(iconSourcePath, 'PNGDATA');
+    const legacyContent = [
+      '[Desktop Entry]',
+      'Name=Claude Terminal',
+      'Exec=/home/user/Applications/Claude-Terminal.AppImage --no-sandbox %U',
+      'Type=Application',
+      '',
+    ].join('\n');
+    fakeFs._seed(desktopPath, legacyContent);
+
+    const result = install({
+      home, appImagePath, iconSourcePath, version,
+      fsImpl: fakeFs, refreshFn: () => {},
+    });
+
+    expect(result.written).toBe(true);
+    const written = fakeFs._files.get(desktopPath).content;
+    expect(written).toContain(MANAGED_MARKER);
+    expect(written).toContain(`Exec="${appImagePath}" --no-sandbox %U`);
+    expect(written).not.toBe(legacyContent);
   });
 });
 


### PR DESCRIPTION
## Summary

#53 added `LinuxDesktopIntegration`, which keeps `~/.local/share/applications/claude-terminal.desktop` in sync with the current `$APPIMAGE` and tags every file it manages with `X-Claude-Terminal-ManagedBy=app`. The defensive rule for files without that marker is "leave it alone" — correct for hand-rolled entries from power users, but it also permanently strands **anyone who installed before v1.2.8 and integrated the app manually** (or via the workaround scripts that circulated when the icon-disappears-after-update issue was first reported).

For those users, the auto-fix never engages: their `.desktop` keeps pointing at a versioned `Claude-Terminal-X.Y.Z.AppImage` that gets deleted on the next update, and the icon disappears again — exactly the bug #53 was meant to solve. I'm one of those users; the icon vanished after upgrading to v1.2.9 even though the integration was already in place.

This PR refines the heuristic: a `.desktop` without the marker is adopted **once** if it clearly targets this app (`Name=Claude Terminal` AND `Exec=` points at a `Claude-Terminal*.AppImage`). Anything else — custom Name, wrapper script, different binary — is still left untouched.

## Changes

- `src/main/services/LinuxDesktopIntegration.js`
  - New pure function `looksLikeLegacyClaudeTerminalDesktop(content)`. Regex-based, intentionally narrow: only matches files that already encode the intent of integrating this exact app.
  - `shouldWriteDesktopFile` now consults the heuristic for entries without the marker. The marker-present and no-existing-file branches are unchanged.
  - JSDoc updated to reflect the four-rule decision.
  - `looksLikeLegacyClaudeTerminalDesktop` added to the exports for direct testing.
- `tests/services/LinuxDesktopIntegration.test.js`
  - 5 tests for `looksLikeLegacyClaudeTerminalDesktop` (symlink path, versioned path, quoted Exec, rejects different Name, rejects wrapper Exec).
  - 2 tests added to the existing `shouldWriteDesktopFile` suite (adopt-legacy positive, leave-wrapper negative).
  - 1 end-to-end `install()` test that reproduces the real-world scenario: a legacy `.desktop` is seeded into the fake fs, `install()` runs, the file is overwritten and now carries the marker.

## Why this approach

- **Conservative by design.** False negatives are safe (the user keeps what they wrote and updates won't break anything new — this is the status quo). False positives would silently overwrite a custom configuration. The regex requires both an exact `Name=Claude Terminal` match and an `Exec=` pointing at our AppImage, so anything bespoke fails the check and is preserved.
- **Self-healing.** After a single launch, the legacy entry is now managed and tracks future updates automatically. No further user action is ever required.
- **Minimal surface.** Only `shouldWriteDesktopFile` and one new pure helper change. No effect on macOS, Windows, non-AppImage Linux launches, or any caller outside `install()`.

## Testing

- [x] `npm test` — **1442 / 1442 passing** (1434 baseline + 8 new tests).
- [x] `npm test -- --testPathPattern=LinuxDesktopIntegration` — 28 / 28 passing.
- [x] Manual verification on my machine: deleted the marker from the `.desktop` file, ran the app, confirmed it adopted the file and re-added the marker on the next launch.

## Repro for reviewers

Create a legacy `.desktop` without the marker:

```
[Desktop Entry]
Name=Claude Terminal
Exec=/home/me/Applications/Claude-Terminal-1.2.7.AppImage --no-sandbox %U
Type=Application
```

- Pre-PR (v1.2.8 / v1.2.9): launching the app does NOT update the file.
- After this PR: launching the app rewrites it with the current `$APPIMAGE` and adds `X-Claude-Terminal-ManagedBy=app`.

## Related

- Builds on #53 — same service, same managed-marker convention, same fail-soft philosophy.
