### PR TITLE
fix(chat): show installed skills in slash command dropdown

### DIFF
--- a/src/renderer/ui/components/ChatView.js
+++ b/src/renderer/ui/components/ChatView.js
@@ -1208,6 +1208,9 @@ class ChatView extends BaseComponent {
       return;
     }
     const query = text.slice(1).toLowerCase();
+    // Add user-invocable skills as slash commands
+    const skills = (skillsAgentsState.get().skills || []).filter(s => s.userInvocable !== false);
+    const skillCommands = skills.map(s => '/' + s.name.replace(/\s+/g, '-').toLowerCase());
     // Commands that work in Agent SDK environment
     const builtinDefaults = [
       // SDK built-in commands
@@ -1218,9 +1221,6 @@ class ChatView extends BaseComponent {
       // Claude Terminal own commands
       '/parallel-task', '/reload-plugins',
     ];
-    // Add user-invocable skills as slash commands
-    const skills = (skillsAgentsState.get().skills || []).filter(s => s.userInvocable !== false);
-    const skillCommands = skills.map(s => '/' + s.name.replace(/\s+/g, '-').toLowerCase());
     // Normalize to '/name' lowercase so SDK-provided commands (sometimes without leading '/')
     // match our '/name' skill/builtin entries and don't show up twice.
     const normKey = (c) => ('/' + String(c).replace(/^\//, '')).toLowerCase();
@@ -1250,7 +1250,7 @@ class ChatView extends BaseComponent {
       return;
     }
 
-    slashDropdown.innerHTML = filtered.map((cmd, i) => {
+    const html = filtered.map((cmd, i) => {
       const name = cmd.startsWith('/') ? cmd : '/' + cmd;
       const desc = getSlashCommandDescription(name);
       return `<div class="chat-slash-item${i === slashSelectedIndex ? ' active' : ''}" data-command="${escapeHtml(name)}">
@@ -1258,6 +1258,7 @@ class ChatView extends BaseComponent {
         <span class="chat-slash-desc">${escapeHtml(desc)}</span>
       </div>`;
     }).join('');
+    slashDropdown.innerHTML = html;
 
     slashDropdown.style.display = '';
     // Clamp selected index
@@ -4745,6 +4746,14 @@ class ChatView extends BaseComponent {
     }
   });
   unsubscribers.push(unsubMessage);
+
+  // Subscribe to skills state changes to refresh slash dropdown when skills load
+  const unsubSkills = skillsAgentsState.subscribe((state) => {
+    if (state.skills && getInputText().startsWith('/')) {
+      updateSlashDropdown();
+    }
+  });
+  unsubscribers.push(unsubSkills);
 
   // IPC: Native SDK prompt suggestions (piggybacked on the stream, nearly free)
   const unsubPromptSuggestion = api.chat.onPromptSuggestion(({ sessionId: sid, suggestion }) => {

--- a/src/renderer/utils/frontmatter.js
+++ b/src/renderer/utils/frontmatter.js
@@ -57,7 +57,7 @@ function parseFrontmatter(content) {
     description,
     tools,
     sections,
-    userInvocable: metadata['user-invocable'] === 'true',
+    userInvocable: (metadata['user-invocable'] || metadata.userInvocable) !== 'false',
     model: metadata.model || null
   };
 


### PR DESCRIPTION
Two bugs prevented skills from appearing in the '/' autocomplete:

1. frontmatter.js parsed userInvocable as `=== 'true'`, which excluded all skills without an explicit `user-invocable: true` field (148/153). Changed to `!== 'false'` to default invocable, also supporting camelCase `userInvocable` field name.

2. ChatView did not subscribe to skillsAgentsState changes, so the slash dropdown never refreshed when async skill loading completed. Added subscription to auto-update the dropdown when skills arrive.

## Summary
- Fix `userInvocable` default value in `frontmatter.js`: changed from `=== 'true'` (only 5/153 skills passed) to `!== 'false'` (default invocable), also added camelCase `userInvocable` field support
- Add `skillsAgentsState.subscribe` in ChatView to auto-refresh slash dropdown when async skill loading completes

## Test plan
- [x] `npm run build:renderer` passes
- [x] `npm test` passes (42 suites, 1442 tests)
- [x] `npm start` manual test: type `/` in chat input shows all installed skills
- [x] No console errors
- [x] Existing features still work