### PR TITLE
fix(chat): stop capping chat sessions at 100 turns

### DIFF
--- a/src/main/services/ChatService.js
+++ b/src/main/services/ChatService.js
@@ -637,7 +637,11 @@ class ChatService {
       const options = {
         cwd: effectiveCwd,
         abortController,
-        maxTurns: maxTurns || 100,
+        // No cap by default. This is a single long-lived query per tab fed by an
+        // async iterable, so maxTurns counts every API round-trip of the whole
+        // conversation, not per prompt — a hard-coded value kills a busy tab
+        // mid-work with no way back. Omitted, the CLI applies no limit.
+        ...(maxTurns ? { maxTurns } : {}),
         includePartialMessages: true,
         permissionMode,
         executable: runtime.executable,

--- a/src/renderer/state/settings.state.js
+++ b/src/renderer/state/settings.state.js
@@ -72,7 +72,7 @@ const defaultSettings = {
   activeTab: 'claude', // Last active sidebar tab (restored on restart)
   tabsOrder: null, // null = canonical order, otherwise array of all tabIds in custom order
   parallelMaxAgents: 3, // Default number of parallel agents for Parallel Task Manager (1-10)
-  maxTurns: null, // null = SDK default (100), or custom number for max agentic turns per session
+  maxTurns: null, // null = no limit (SDK/CLI default), or a cap on API round-trips for the whole tab
   autoClaudeMdUpdate: true, // Suggest CLAUDE.md updates after chat sessions
   dailyGoal: 0, // Daily time goal in minutes (0 = disabled)
   githubApiUrl: 'https://api.github.com', // GitHub API base URL (for GitHub Enterprise)

--- a/src/renderer/ui/components/ChatView.js
+++ b/src/renderer/ui/components/ChatView.js
@@ -5433,7 +5433,7 @@ class ChatView extends BaseComponent {
         if (!isAborting) {
           let errorMsg;
           if (message.subtype === 'error_max_turns') {
-            errorMsg = t('chat.errorMaxTurns', { count: getSetting('maxTurns') || 100 });
+            errorMsg = t('chat.errorMaxTurns', { count: getSetting('maxTurns') || message.num_turns || '?' });
           } else if (message.subtype === 'error_max_budget_usd') {
             errorMsg = t('chat.errorMaxBudget', { cost: message.total_cost_usd?.toFixed(2) || '?' });
           } else if (message.subtype === 'error_during_execution') {


### PR DESCRIPTION
## Summary

A chat tab dies after 100 turns with *"Claude reached the 100-turn limit. Start a new session to continue."* — a limit no other Claude Code client shows, because the 100 is ours, not the SDK's.

```js
// src/main/services/ChatService.js:640
maxTurns: maxTurns || 100,
```

`maxTurns` is optional in the Agent SDK (`maxTurns?: number`) with **no default value** — omit it and the CLI applies no limit at all.

What makes it bite: a chat tab is a **single long-lived `sdk.query()`** fed by an async iterable (`messageQueue.iterable`, `ChatService.js:726`). Follow-up messages are pushed into that queue rather than starting a new query, so the turn counter is **cumulative over the whole tab lifetime** — every user prompt *and* every tool round-trip. A session doing real work with heavy tool use exhausts 100 long before the context window fills.

It is also unrecoverable: on `error_max_turns` the query generator returns, so the tab is dead. And since `maxTurns` was never surfaced in `SettingsPanel`, the only workaround was hand-editing `~/.claude-terminal/settings.json`.

## Changes

- `ChatService.js` — omit `maxTurns` unless the caller actually set one (`...(maxTurns ? { maxTurns } : {})`), restoring CLI behaviour. The `maxTurns` setting still works for anyone who wants a guard rail.
- `ChatView.js` — the `error_max_turns` message reported a hard-coded `100` (`getSetting('maxTurns') || 100`), which becomes a phantom number once the default is unset; it now falls back to the real `message.num_turns`.
- `settings.state.js` — the comment claimed `null = SDK default (100)`, crediting the SDK for our own cap.

3 files, +7 −3. No behaviour change for anyone who set `maxTurns` explicitly.

Other `maxTurns` call sites are deliberately untouched: workflow nodes (30), parallel tasks (10/30/50) and `runSinglePrompt` (30) are bounded one-shot runs where a cap is the correct design. Only the interactive chat session was wrong.

## Testing

- [ ] Tested on Windows 10
- [ ] Tested on Windows 11
- [x] No console errors
- [x] Existing features still work

Validated on **macOS** (Darwin 25.5.0) — I don't have a Windows machine to hand, so those two boxes are honestly unchecked. The change is platform-agnostic (one SDK option in the main process, one i18n interpolation in the renderer), so I'd expect no platform-specific risk, but a Windows confirmation before merge would be welcome.

- `npm test` — 68 suites, 2040 tests pass
- `npm run build:renderer` — clean
- Manual: long chat session with heavy tool use no longer terminates at 100 turns; setting `"maxTurns": 5` in `settings.json` still stops the session and now reports `5`, not `100`.

## Related Issues

Closes #81

## Notes

Two things deliberately left out of this PR to keep it focused, glad to add either here or in a follow-up:

1. Exposing `maxTurns` in `SettingsPanel` — the setting exists in `defaultSettings` but has no UI.
2. The `chat.errorMaxTurns` string still reads *"Start a new session to continue"* in all locales, whereas **Resume** is enough and preserves history. With this fix the message should be near-unreachable without an explicit cap, so it felt out of scope to retranslate across `en`/`fr`/`es`/`id`/`zh-CN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

