### PR TITLE
fix(sessions): stop long sessions from freezing the app

### DIFF
--- a/src/main/ipc/claude.ipc.js
+++ b/src/main/ipc/claude.ipc.js
@@ -381,147 +381,167 @@ function sanitizeToolInput(input) {
   return input;
 }
 
+// The replay panel scrubs a whole session, but a session can hold tens of
+// thousands of steps. Counters are computed over the entire file; only a window
+// of steps is materialized and shipped to the renderer.
+const DEFAULT_REPLAY_LIMIT = 2000;
+// Tool results follow their call within a line or two, so this cap only matters
+// for calls whose result never arrives (session cut mid-run).
+const MAX_PENDING_TOOLS = 500;
+
 /**
  * Parse a session JSONL file into a flat, ordered list of replay steps.
  * Each step is one of: prompt | tool | response | thinking
  * @param {string} projectPath
  * @param {string} sessionId
+ * @param {object} [options]
+ * @param {number} [options.offset] - Index of the first step to return
+ * @param {number} [options.limit] - Max steps to return. 0 = no limit.
  * @returns {Promise<{steps: Array, summary: object}>}
  */
-async function parseSessionReplay(projectPath, sessionId) {
+async function parseSessionReplay(projectPath, sessionId, options = {}) {
   const sessionsDir = getProjectSessionsDir(projectPath);
+  const offset = Math.max(0, options.offset || 0);
+  const limit = options.limit === 0 ? 0 : (options.limit || DEFAULT_REPLAY_LIMIT);
+
+  const emptySummary = () => ({
+    totalSteps: 0, totalEstimatedTokens: 0, uniqueFileCount: 0,
+    toolBreakdown: {}, offset, returned: 0, truncated: false
+  });
 
   // Find the JSONL file — uses indexed lookup
   const filePath = await resolveSessionFile(sessionsDir, sessionId);
-  if (!filePath) return { steps: [], summary: { totalSteps: 0, totalEstimatedTokens: 0, uniqueFileCount: 0, toolBreakdown: {} } };
+  if (!filePath) return { steps: [], summary: emptySummary() };
 
-  // Read all lines from the JSONL file
-  const rawLines = await new Promise((resolve) => {
-    const lines = [];
+  // Single streaming pass: summary counters cover the whole file, but only the
+  // requested window of steps is materialized. Buffering the raw lines first
+  // retained 546 MB of heap on a 207 MB session before parsing even started.
+  return new Promise((resolve) => {
+    const steps = [];
+    // Map toolUseId -> step object, so a later tool_result can be attached to it.
+    // Holds out-of-window steps too, so their output still counts toward the summary.
+    const pendingTools = new Map();
+    const uniqueFiles = new Set();
+    const toolBreakdown = {};
+    let totalSteps = 0;
+    let totalEstimatedTokens = 0;
+
+    /** True when the step at this global index belongs to the requested window. */
+    function keeps(index) {
+      return limit === 0 || (index >= offset && steps.length < limit);
+    }
+
+    /** Count a text-ish step, and materialize it only if it is in the window. */
+    function addTextStep(type, text, maxLen) {
+      const index = totalSteps++;
+      const tokens = Math.ceil(text.length / 4);
+      totalEstimatedTokens += tokens;
+      if (!keeps(index)) return;
+      steps.push({ index, type, text: text.slice(0, maxLen), estimatedTokens: tokens });
+    }
+
+    function trackPendingTool(id, step) {
+      if (id === undefined || id === null) return;
+      pendingTools.set(id, step);
+      // Results follow their call almost immediately; this only bounds the map
+      // when a session was cut mid-call and a result never arrives.
+      if (pendingTools.size > MAX_PENDING_TOOLS) {
+        pendingTools.delete(pendingTools.keys().next().value);
+      }
+    }
+
+    function attachToolResult(block) {
+      const pending = pendingTools.get(block.tool_use_id);
+      if (!pending) return;
+      const out = typeof block.content === 'string' ? block.content
+        : Array.isArray(block.content) ? block.content.map(b => b.text || '').join('\n') : '';
+      pending.toolOutput = out.slice(0, 3000);
+      pending.estimatedOutputTokens = Math.ceil(out.length / 4);
+      totalEstimatedTokens += pending.estimatedOutputTokens;
+      pendingTools.delete(block.tool_use_id);
+    }
+
     const stream = fs.createReadStream(filePath, { encoding: 'utf8' });
     const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
-    rl.on('line', line => { if (line.trim()) lines.push(line); });
-    rl.on('close', () => resolve(lines));
-    rl.on('error', () => resolve([]));
+
+    rl.on('line', (line) => {
+      if (!line.trim()) return;
+      try {
+        const obj = JSON.parse(line);
+
+        // ── User message ────────────────────────────────────────────────────
+        if (obj.type === 'user' && obj.message) {
+          const content = obj.message.content;
+          if (typeof content === 'string') {
+            if (content.trim()) addTextStep('prompt', content, 5000);
+          } else if (Array.isArray(content)) {
+            for (const block of content) {
+              if (block.type === 'tool_result') attachToolResult(block);
+            }
+            // Any plain text blocks are user prompts (rare but possible)
+            const textBlocks = content.filter(b => b.type === 'text');
+            if (textBlocks.length > 0) {
+              const text = textBlocks.map(b => b.text).join('\n');
+              if (text.trim()) addTextStep('prompt', text, 5000);
+            }
+          }
+        }
+
+        // ── Assistant message ───────────────────────────────────────────────
+        if ((obj.type === 'assistant' || (!obj.type && obj.message?.role === 'assistant')) && obj.message?.content) {
+          for (const block of obj.message.content) {
+            if (block.type === 'text' && block.text && block.text.trim()) {
+              addTextStep('response', block.text, 5000);
+            } else if (block.type === 'tool_use') {
+              const index = totalSteps++;
+              const fp = extractFilePath(block.name, block.input);
+              const inputStr = JSON.stringify(block.input || {});
+              const estimatedInputTokens = Math.ceil(inputStr.length / 4);
+              totalEstimatedTokens += estimatedInputTokens;
+              toolBreakdown[block.name] = (toolBreakdown[block.name] || 0) + 1;
+              if (fp) uniqueFiles.add(fp);
+              // Built even out of window: its result still feeds the token total,
+              // and pendingTools is the only thing holding it.
+              const step = {
+                index, type: 'tool',
+                toolName: block.name,
+                toolInput: sanitizeToolInput(block.input),
+                toolOutput: null,
+                filePath: fp,
+                estimatedInputTokens,
+                estimatedOutputTokens: 0
+              };
+              if (keeps(index)) steps.push(step);
+              trackPendingTool(block.id, step);
+            } else if (block.type === 'thinking' && block.thinking) {
+              addTextStep('thinking', block.thinking, 3000);
+            }
+          }
+        }
+
+        // ── Standalone tool_result (alternate JSONL format) ─────────────────
+        if (obj.type === 'tool_result' && obj.message?.content) {
+          for (const block of obj.message.content) {
+            if (block.type === 'tool_result') attachToolResult(block);
+          }
+        }
+      } catch { /* skip malformed lines */ }
+    });
+
+    rl.on('close', () => resolve({
+      steps,
+      summary: {
+        totalSteps,
+        totalEstimatedTokens,
+        uniqueFileCount: uniqueFiles.size,
+        toolBreakdown,
+        offset,
+        returned: steps.length,
+        truncated: limit > 0 && steps.length < totalSteps
+      }
+    }));
+    rl.on('error', () => resolve({ steps: [], summary: emptySummary() }));
   });
-
-  const steps = [];
-  // Map toolUseId -> step object (already in steps array) for result attachment
-  const pendingTools = new Map();
-
-  for (const line of rawLines) {
-    try {
-      const obj = JSON.parse(line);
-
-      // ── User message ──────────────────────────────────────────────────────
-      if (obj.type === 'user' && obj.message) {
-        const content = obj.message.content;
-        if (typeof content === 'string') {
-          if (content.trim()) {
-            steps.push({
-              index: steps.length, type: 'prompt',
-              text: content.slice(0, 5000),
-              estimatedTokens: Math.ceil(content.length / 4)
-            });
-          }
-        } else if (Array.isArray(content)) {
-          for (const block of content) {
-            if (block.type === 'tool_result') {
-              // Attach output to the matching pending tool step
-              const pending = pendingTools.get(block.tool_use_id);
-              if (pending) {
-                const out = typeof block.content === 'string' ? block.content
-                  : Array.isArray(block.content) ? block.content.map(b => b.text || '').join('\n') : '';
-                pending.toolOutput = out.slice(0, 3000);
-                pending.estimatedOutputTokens = Math.ceil(out.length / 4);
-                pendingTools.delete(block.tool_use_id);
-              }
-            }
-          }
-          // Any plain text blocks are user prompts (rare but possible)
-          const textBlocks = content.filter(b => b.type === 'text');
-          if (textBlocks.length > 0) {
-            const text = textBlocks.map(b => b.text).join('\n');
-            if (text.trim()) {
-              steps.push({
-                index: steps.length, type: 'prompt',
-                text: text.slice(0, 5000),
-                estimatedTokens: Math.ceil(text.length / 4)
-              });
-            }
-          }
-        }
-      }
-
-      // ── Assistant message ─────────────────────────────────────────────────
-      if ((obj.type === 'assistant' || (!obj.type && obj.message?.role === 'assistant')) && obj.message?.content) {
-        for (const block of obj.message.content) {
-          if (block.type === 'text' && block.text && block.text.trim()) {
-            steps.push({
-              index: steps.length, type: 'response',
-              text: block.text.slice(0, 5000),
-              estimatedTokens: Math.ceil(block.text.length / 4)
-            });
-          } else if (block.type === 'tool_use') {
-            const fp = extractFilePath(block.name, block.input);
-            const inputStr = JSON.stringify(block.input || {});
-            const step = {
-              index: steps.length, type: 'tool',
-              toolName: block.name,
-              toolInput: sanitizeToolInput(block.input),
-              toolOutput: null,
-              filePath: fp,
-              estimatedInputTokens: Math.ceil(inputStr.length / 4),
-              estimatedOutputTokens: 0
-            };
-            steps.push(step);
-            pendingTools.set(block.id, step);
-          } else if (block.type === 'thinking' && block.thinking) {
-            steps.push({
-              index: steps.length, type: 'thinking',
-              text: block.thinking.slice(0, 3000),
-              estimatedTokens: Math.ceil(block.thinking.length / 4)
-            });
-          }
-        }
-      }
-
-      // ── Standalone tool_result (alternate JSONL format) ───────────────────
-      if (obj.type === 'tool_result' && obj.message?.content) {
-        for (const block of obj.message.content) {
-          if (block.type === 'tool_result') {
-            const pending = pendingTools.get(block.tool_use_id);
-            if (pending) {
-              const out = typeof block.content === 'string' ? block.content
-                : Array.isArray(block.content) ? block.content.map(b => b.text || '').join('\n') : '';
-              pending.toolOutput = out.slice(0, 3000);
-              pending.estimatedOutputTokens = Math.ceil(out.length / 4);
-              pendingTools.delete(block.tool_use_id);
-            }
-          }
-        }
-      }
-    } catch { /* skip malformed lines */ }
-  }
-
-  // Compute summary statistics
-  const totalEstimatedTokens = steps.reduce((acc, s) =>
-    acc + (s.estimatedInputTokens || 0) + (s.estimatedOutputTokens || s.estimatedTokens || 0), 0);
-  const uniqueFiles = new Set(steps.filter(s => s.filePath).map(s => s.filePath));
-  const toolBreakdown = {};
-  for (const s of steps.filter(s => s.type === 'tool')) {
-    toolBreakdown[s.toolName] = (toolBreakdown[s.toolName] || 0) + 1;
-  }
-
-  return {
-    steps,
-    summary: {
-      totalSteps: steps.length,
-      totalEstimatedTokens,
-      uniqueFileCount: uniqueFiles.size,
-      toolBreakdown
-    }
-  };
 }
 
 // ─── Session index cache ────────────────────────────────────────────────────
@@ -690,9 +710,9 @@ function registerClaudeHandlers() {
   });
 
   // Parse a session JSONL into ordered replay steps for the Session Replay panel
-  ipcMain.handle('claude-session-replay', async (event, { projectPath, sessionId }) => {
+  ipcMain.handle('claude-session-replay', async (event, { projectPath, sessionId, offset, limit }) => {
     try {
-      return { success: true, ...(await parseSessionReplay(projectPath, sessionId)) };
+      return { success: true, ...(await parseSessionReplay(projectPath, sessionId, { offset, limit })) };
     } catch (err) {
       console.error('[claude-session-replay] Error:', err.message);
       return { success: false, error: err.message, steps: [], summary: {} };
@@ -720,4 +740,4 @@ function registerClaudeHandlers() {
   });
 }
 
-module.exports = { registerClaudeHandlers, getClaudeSessions, loadSessionHistory };
+module.exports = { registerClaudeHandlers, getClaudeSessions, loadSessionHistory, parseSessionReplay };

--- a/src/main/ipc/claude.ipc.js
+++ b/src/main/ipc/claude.ipc.js
@@ -315,9 +315,12 @@ async function loadSessionHistory(projectPath, sessionId, options = {}) {
 
     rl.on('close', () => {
       // Realign the tail onto a user turn so the replay never opens mid tool-run
+      // `dropped > 0` matters on its own: a trim leaves exactly `limit` entries, so a
+      // file ending right on a trim boundary would otherwise skip the realignment and
+      // open mid tool-run.
       let window = messages;
-      if (limit && messages.length > limit) {
-        let start = messages.length - limit;
+      if (limit && (messages.length > limit || dropped > 0)) {
+        let start = Math.max(0, messages.length - limit);
         for (let i = start; i < messages.length; i++) {
           if (messages[i].role === 'user') { start = i; break; }
         }

--- a/src/main/ipc/claude.ipc.js
+++ b/src/main/ipc/claude.ipc.js
@@ -184,27 +184,62 @@ async function getClaudeSessions(projectPath) {
   }
 }
 
+// Replaying every message of a very long session melts both processes: the array
+// crosses IPC by structured clone and then becomes one DOM node per entry. Sessions
+// in the wild reach 70k lines / 200 MB, so only the tail is loaded by default and
+// the UI asks for more on demand.
+const DEFAULT_HISTORY_LIMIT = 400;
+
 /**
- * Load full conversation history from a session JSONL file.
- * Returns an array of simplified messages for the chat UI replay.
+ * Load conversation history from a session JSONL file.
+ * Returns the last `limit` simplified messages for the chat UI replay.
  * @param {string} projectPath - The project path
  * @param {string} sessionId - The session ID (UUID)
- * @returns {Promise<Array>} - Array of { role, type, content, toolName, toolInput, toolOutput, thinking, ... }
+ * @param {object} [options]
+ * @param {number} [options.limit] - Max messages to return (tail). 0 = no limit.
+ * @param {string} [options.until] - Stop reading after this message uuid (fork point).
+ * @returns {Promise<{messages: Array, total: number, truncated: boolean}>}
  */
-async function loadSessionHistory(projectPath, sessionId) {
+async function loadSessionHistory(projectPath, sessionId, options = {}) {
   const sessionsDir = getProjectSessionsDir(projectPath);
+  const limit = options.limit === 0 ? 0 : (options.limit || DEFAULT_HISTORY_LIMIT);
+  const until = options.until || null;
 
   // Find the JSONL file — uses indexed lookup
   const filePath = await resolveSessionFile(sessionsDir, sessionId);
-  if (!filePath) return [];
+  if (!filePath) return { messages: [], total: 0, truncated: false };
 
-  // Read all lines from the JSONL file
+  // Read the JSONL file, keeping only a bounded window of messages in memory
   return new Promise((resolve) => {
     const messages = [];
+    // Keep some slack above `limit` so the tail can be realigned onto a user-turn
+    // boundary without re-reading the file.
+    const maxKept = limit ? limit * 2 : Infinity;
+    let total = 0;
+    let dropped = 0;
+    let done = false;
     const stream = fs.createReadStream(filePath, { encoding: 'utf8' });
     const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
 
+    const push = (msg) => {
+      total++;
+      messages.push(msg);
+      if (messages.length > maxKept) {
+        const excess = messages.length - limit;
+        messages.splice(0, excess);
+        dropped += excess;
+      }
+    };
+
+    const finish = () => {
+      if (done) return;
+      done = true;
+      rl.close();
+      stream.destroy();
+    };
+
     rl.on('line', (line) => {
+      if (done) return;
       try {
         const obj = JSON.parse(line);
 
@@ -231,7 +266,7 @@ async function loadSessionHistory(projectPath, sessionId) {
             if (images.length > 0) msg.images = images;
             // Carried so a fork can name the turn it discards (resumeDropsTurn)
             if (obj.uuid) msg.uuid = obj.uuid;
-            messages.push(msg);
+            push(msg);
           }
         }
 
@@ -240,9 +275,9 @@ async function loadSessionHistory(projectPath, sessionId) {
           const blocks = obj.message.content;
           for (const block of blocks) {
             if (block.type === 'text' && block.text) {
-              messages.push({ role: 'assistant', type: 'text', text: block.text, ...(obj.uuid ? { uuid: obj.uuid } : {}) });
+              push({ role: 'assistant', type: 'text', text: block.text, ...(obj.uuid ? { uuid: obj.uuid } : {}) });
             } else if (block.type === 'tool_use') {
-              messages.push({
+              push({
                 role: 'assistant',
                 type: 'tool_use',
                 toolName: block.name,
@@ -250,7 +285,7 @@ async function loadSessionHistory(projectPath, sessionId) {
                 toolUseId: block.id
               });
             } else if (block.type === 'thinking' && block.thinking) {
-              messages.push({ role: 'assistant', type: 'thinking', text: block.thinking });
+              push({ role: 'assistant', type: 'thinking', text: block.thinking });
             }
           }
         }
@@ -263,7 +298,7 @@ async function loadSessionHistory(projectPath, sessionId) {
               if (block.type === 'tool_result') {
                 const output = typeof block.content === 'string' ? block.content
                   : Array.isArray(block.content) ? block.content.map(b => b.text || '').join('\n') : '';
-                messages.push({
+                push({
                   role: 'tool_result',
                   toolUseId: block.tool_use_id,
                   output: output.slice(0, 2000) // Limit output size for IPC
@@ -272,11 +307,26 @@ async function loadSessionHistory(projectPath, sessionId) {
             }
           }
         }
+
+        // Fork point reached — everything after it is discarded by the fork anyway
+        if (until && obj.uuid === until) finish();
       } catch { /* skip malformed lines */ }
     });
 
-    rl.on('close', () => resolve(messages));
-    rl.on('error', () => resolve([]));
+    rl.on('close', () => {
+      // Realign the tail onto a user turn so the replay never opens mid tool-run
+      let window = messages;
+      if (limit && messages.length > limit) {
+        let start = messages.length - limit;
+        for (let i = start; i < messages.length; i++) {
+          if (messages[i].role === 'user') { start = i; break; }
+        }
+        dropped += start;
+        window = messages.slice(start);
+      }
+      resolve({ messages: window, total, truncated: dropped > 0 });
+    });
+    rl.on('error', () => resolve({ messages: [], total: 0, truncated: false }));
   });
 }
 
@@ -629,12 +679,13 @@ function registerClaudeHandlers() {
   });
 
   // Load full session history for chat UI replay
-  ipcMain.handle('chat-load-history', async (event, { projectPath, sessionId }) => {
+  ipcMain.handle('chat-load-history', async (event, { projectPath, sessionId, limit, until }) => {
     try {
-      return { success: true, messages: await loadSessionHistory(projectPath, sessionId) };
+      const { messages, total, truncated } = await loadSessionHistory(projectPath, sessionId, { limit, until });
+      return { success: true, messages, total, truncated };
     } catch (err) {
       console.error('[chat-load-history] Error:', err.message);
-      return { success: false, error: err.message, messages: [] };
+      return { success: false, error: err.message, messages: [], total: 0, truncated: false };
     }
   });
 
@@ -669,4 +720,4 @@ function registerClaudeHandlers() {
   });
 }
 
-module.exports = { registerClaudeHandlers, getClaudeSessions };
+module.exports = { registerClaudeHandlers, getClaudeSessions, loadSessionHistory };

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -1719,6 +1719,7 @@
     "resuming": "Resuming conversation...",
     "conversationResumed": "Conversation resumed",
     "loadingHistory": "Loading conversation...",
+    "olderMessages": "{count} earlier messages",
     "loading": "Loading...",
     "tabConversation": "Conversation",
     "tabChanges": "Changes",

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -1349,6 +1349,7 @@
     "emptyStepProject": "Project",
     "emptyStepSession": "Session",
     "noSteps": "No steps found in this session",
+    "showingSteps": "{shown} of {total} steps",
     "steps": "steps",
     "estimated": "estimated",
     "files": "files",

--- a/src/renderer/i18n/locales/es.json
+++ b/src/renderer/i18n/locales/es.json
@@ -1711,6 +1711,7 @@
     "resuming": "Reanudando conversación...",
     "conversationResumed": "Conversación reanudada",
     "loadingHistory": "Cargando conversación...",
+    "olderMessages": "{count} mensajes anteriores",
     "loading": "Cargando...",
     "tabConversation": "Conversación",
     "tabChanges": "Cambios",

--- a/src/renderer/i18n/locales/es.json
+++ b/src/renderer/i18n/locales/es.json
@@ -1346,6 +1346,7 @@
     "emptyStepProject": "Proyecto",
     "emptyStepSession": "Sesión",
     "noSteps": "No se encontraron pasos en esta sesión",
+    "showingSteps": "{shown} de {total} pasos",
     "steps": "pasos",
     "estimated": "estimado",
     "files": "archivos",

--- a/src/renderer/i18n/locales/fr.json
+++ b/src/renderer/i18n/locales/fr.json
@@ -1349,6 +1349,7 @@
     "emptyStepProject": "Projet",
     "emptyStepSession": "Session",
     "noSteps": "Aucune étape trouvée dans cette session",
+    "showingSteps": "{shown} étapes sur {total}",
     "steps": "étapes",
     "estimated": "estimés",
     "files": "fichiers",

--- a/src/renderer/i18n/locales/fr.json
+++ b/src/renderer/i18n/locales/fr.json
@@ -1719,6 +1719,7 @@
     "resuming": "Reprise de la conversation...",
     "conversationResumed": "Conversation reprise",
     "loadingHistory": "Chargement de la conversation...",
+    "olderMessages": "{count} messages plus anciens",
     "loading": "Chargement...",
     "tabConversation": "Conversation",
     "tabChanges": "Modifications",

--- a/src/renderer/i18n/locales/id.json
+++ b/src/renderer/i18n/locales/id.json
@@ -1349,6 +1349,7 @@
     "emptyStepProject": "Proyek",
     "emptyStepSession": "Sesi",
     "noSteps": "Tidak ada langkah ditemukan pada sesi ini",
+    "showingSteps": "{shown} dari {total} langkah",
     "steps": "langkah",
     "estimated": "perkiraan",
     "files": "file",

--- a/src/renderer/i18n/locales/id.json
+++ b/src/renderer/i18n/locales/id.json
@@ -1719,6 +1719,7 @@
     "resuming": "Melanjutkan percakapan...",
     "conversationResumed": "Percakapan dilanjutkan",
     "loadingHistory": "Memuat percakapan...",
+    "olderMessages": "{count} pesan sebelumnya",
     "loading": "Memuat...",
     "tabConversation": "Percakapan",
     "tabChanges": "Perubahan",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -1349,6 +1349,7 @@
     "emptyStepProject": "项目",
     "emptyStepSession": "会话",
     "noSteps": "在此会话中找不到步骤",
+    "showingSteps": "{total} 个步骤中的 {shown} 个",
     "steps": "步骤",
     "estimated": "估计的",
     "files": "文件",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -1719,6 +1719,7 @@
     "resuming": "继续谈话...",
     "conversationResumed": "谈话继续",
     "loadingHistory": "正在加载对话...",
+    "olderMessages": "更早的 {count} 条消息",
     "loading": "正在加载...",
     "tabConversation": "对话",
     "tabChanges": "变化",

--- a/src/renderer/services/markdown/postProcess.js
+++ b/src/renderer/services/markdown/postProcess.js
@@ -43,16 +43,67 @@ function setCachedMermaid(source, svg) {
 
 // ── Post-render processing ──
 
+// One observer for the whole renderer, created on first use. Replaying a long
+// session calls postProcess() once per render batch; allocating an observer per
+// call left thousands of them alive, each re-observing every block already
+// handled by the previous ones.
+let _lazyObserver = null;
+
+function getLazyObserver() {
+  if (_lazyObserver) return _lazyObserver;
+  _lazyObserver = new IntersectionObserver((entries) => {
+    entries.forEach(entry => {
+      if (!entry.isIntersecting) return;
+      const el = entry.target;
+      _lazyObserver.unobserve(el);
+
+      if (el.classList.contains('chat-preview-container')) {
+        initializePreviewIframe(el);
+      } else if (el.classList.contains('chat-mermaid-block')) {
+        initMermaidBlocks([el]);
+      } else if (el.classList.contains('chat-math-block')) {
+        initMathBlocks([el]);
+      }
+    });
+  }, { rootMargin: '200px' });
+  return _lazyObserver;
+}
+
 /**
- * Post-render processing: initialize special blocks in a container.
- * Call after inserting rendered HTML into the DOM.
- * Uses IntersectionObserver for off-screen blocks (lazy rendering).
+ * Normalize a postProcess target into a list of DOM roots.
+ * Accepts an element/fragment, or an array/NodeList of elements (a render batch).
  */
-function postProcess(container) {
-  const previews = container.querySelectorAll('.chat-preview-container');
-  const mermaidBlocks = container.querySelectorAll('.chat-mermaid-block');
-  const mathBlocks = container.querySelectorAll('.chat-math-block');
-  const inlineMathEls = container.querySelectorAll('.chat-math-inline[data-math-source]');
+function toRoots(target) {
+  if (!target) return [];
+  if (typeof target.querySelectorAll === 'function') return [target];
+  return Array.from(target).filter(el => el && typeof el.querySelectorAll === 'function');
+}
+
+function queryWithin(roots, selector) {
+  const found = [];
+  for (const root of roots) {
+    if (typeof root.matches === 'function' && root.matches(selector)) found.push(root);
+    found.push(...root.querySelectorAll(selector));
+  }
+  return found;
+}
+
+/**
+ * Post-render processing: initialize special blocks after HTML insertion.
+ * Uses IntersectionObserver for off-screen blocks (lazy rendering).
+ *
+ * @param {Element|DocumentFragment|Element[]|NodeList} target - Container, or the
+ *   nodes of a single render batch. Passing the batch (rather than the whole
+ *   message list) keeps replay linear instead of quadratic.
+ */
+function postProcess(target) {
+  const roots = toRoots(target);
+  if (roots.length === 0) return;
+
+  const previews = queryWithin(roots, '.chat-preview-container');
+  const mermaidBlocks = queryWithin(roots, '.chat-mermaid-block');
+  const mathBlocks = queryWithin(roots, '.chat-math-block');
+  const inlineMathEls = queryWithin(roots, '.chat-math-inline[data-math-source]');
 
   // Render inline math with KaTeX
   if (inlineMathEls.length > 0) {
@@ -69,25 +120,15 @@ function postProcess(container) {
   }
 
   // Use IntersectionObserver for lazy initialization of many blocks
-  const observer = new IntersectionObserver((entries) => {
-    entries.forEach(entry => {
-      if (!entry.isIntersecting) return;
-      const el = entry.target;
-      observer.unobserve(el);
-
-      if (el.classList.contains('chat-preview-container')) {
-        initializePreviewIframe(el);
-      } else if (el.classList.contains('chat-mermaid-block')) {
-        initMermaidBlocks([el]);
-      } else if (el.classList.contains('chat-math-block')) {
-        initMathBlocks([el]);
-      }
-    });
-  }, { rootMargin: '200px' });
-
-  previews.forEach(el => observer.observe(el));
-  mermaidBlocks.forEach(el => observer.observe(el));
-  mathBlocks.forEach(el => observer.observe(el));
+  const observer = getLazyObserver();
+  const observe = (el) => {
+    if (el.dataset.lazyObserved) return;
+    el.dataset.lazyObserved = '1';
+    observer.observe(el);
+  };
+  previews.forEach(observe);
+  mermaidBlocks.forEach(observe);
+  mathBlocks.forEach(observe);
 }
 
 // ── Lazy-loaded Mermaid ──

--- a/src/renderer/ui/components/ChatView.js
+++ b/src/renderer/ui/components/ChatView.js
@@ -5228,6 +5228,8 @@ class ChatView extends BaseComponent {
 
   let userHasScrolled = false;
   let hasNewMessages = false;
+  // Set by the resume path: pulls in older history as the user scrolls up
+  let onNearHistoryTop = null;
 
   // Create scroll-to-bottom button
   const scrollButton = document.createElement('button');
@@ -5253,6 +5255,8 @@ class ChatView extends BaseComponent {
   messagesEl.addEventListener('scroll', () => {
     const isAtBottom = messagesEl.scrollTop + messagesEl.clientHeight >= messagesEl.scrollHeight - 50;
     userHasScrolled = !isAtBottom && messagesEl.scrollHeight > messagesEl.clientHeight;
+
+    if (onNearHistoryTop) onNearHistoryTop();
 
     if (isAtBottom) {
       userHasScrolled = false;
@@ -6467,27 +6471,25 @@ class ChatView extends BaseComponent {
 
   // If resuming, load and display conversation history
   if (pendingResumeId) {
+    // Sessions can reach tens of thousands of messages. Only the tail is replayed;
+    // the rest streams in page by page as the user scrolls back up.
+    const HISTORY_PAGE = 400;
+    // Start fetching before the user actually hits the top, so the older messages
+    // are usually already in place by the time they get there.
+    const HISTORY_PREFETCH_PX = 800;
+    let historyLimit = HISTORY_PAGE;
+    let historyTopEl = null;
+    let previousCount = 0;
+    let historyExhausted = false;
+    let loadingEarlier = false;
+
     const welcomeEl = wrapperEl.querySelector('.chat-welcome');
     if (welcomeEl) {
       welcomeEl.querySelector('.chat-welcome-text').textContent = t('chat.loadingHistory') || 'Loading conversation...';
       welcomeEl.querySelector('.chat-welcome-logo').classList.add('loading-pulse');
     }
 
-    // Load history async then render
-    api.chat.loadHistory({ projectPath: project.path, sessionId: pendingResumeId }).then(result => {
-      if (welcomeEl) welcomeEl.remove();
-
-      if (result?.success && result.messages?.length > 0) {
-        // When forking at a specific message, only show history up to that point
-        let msgs = result.messages;
-        if (pendingResumeAt) {
-          const cutIdx = msgs.findIndex(m => m.uuid === pendingResumeAt);
-          if (cutIdx >= 0) msgs = msgs.slice(0, cutIdx + 1);
-        }
-        renderHistoryMessages(msgs);
-      }
-
-      // Show resume/fork divider
+    function appendHistoryDivider() {
       const dividerText = pendingForkSession
         ? (t('chat.forkedFrom') || 'Forked conversation')
         : (t('chat.conversationResumed') || 'Conversation resumed');
@@ -6497,6 +6499,117 @@ class ChatView extends BaseComponent {
       messagesEl.appendChild(divider);
       userHasScrolled = false;
       scrollToBottom();
+    }
+
+    /** Top-of-list marker: how much history is still on disk, and the load spinner. */
+    function syncHistoryTop(result, shown) {
+      if (!result?.truncated) {
+        historyExhausted = true;
+        if (historyTopEl) { historyTopEl.remove(); historyTopEl = null; }
+        return;
+      }
+      if (!historyTopEl) {
+        historyTopEl = document.createElement('div');
+        historyTopEl.className = 'chat-history-top';
+      }
+      const hidden = Math.max(0, (result.total || 0) - shown);
+      historyTopEl.dataset.hidden = String(hidden);
+      setHistoryTopIdle();
+      messagesEl.prepend(historyTopEl);
+    }
+
+    function setHistoryTopIdle() {
+      if (!historyTopEl) return;
+      const hidden = Number(historyTopEl.dataset.hidden || 0);
+      historyTopEl.classList.remove('loading');
+      historyTopEl.textContent = t('chat.olderMessages', { count: hidden });
+    }
+
+    function setHistoryTopLoading() {
+      if (!historyTopEl) return;
+      historyTopEl.classList.add('loading');
+      historyTopEl.innerHTML = `<span class="chat-tool-spinner"></span><span>${escapeHtml(t('chat.loadingHistory') || 'Loading conversation...')}</span>`;
+    }
+
+    /** Called on every scroll: pull the next page in once the top is in reach. */
+    function maybeLoadEarlier() {
+      if (loadingEarlier || historyExhausted || !historyTopEl) return;
+      if (messagesEl.scrollTop > HISTORY_PREFETCH_PX) return;
+      loadEarlier();
+    }
+
+    function loadEarlier() {
+      loadingEarlier = true;
+      setHistoryTopLoading();
+      const nextLimit = historyLimit + HISTORY_PAGE;
+      fetchHistory(nextLimit).then(result => {
+        historyLimit = nextLimit;
+        const msgs = result?.messages || [];
+        // The window grows from the end, so the new messages are its prefix
+        const older = msgs.slice(0, Math.max(0, msgs.length - previousCount));
+        previousCount = msgs.length;
+        if (older.length === 0) {
+          loadingEarlier = false;
+          syncHistoryTop({ ...result, truncated: false }, msgs.length);
+          return;
+        }
+        // Prepending shifts the viewport — keep the reading position stable
+        const anchor = historyTopEl.nextSibling;
+        const beforeHeight = messagesEl.scrollHeight;
+        const beforeTop = messagesEl.scrollTop;
+        renderHistoryMessages(older, {
+          anchor,
+          onComplete: () => {
+            messagesEl.scrollTop = beforeTop + (messagesEl.scrollHeight - beforeHeight);
+            syncHistoryTop(result, msgs.length);
+            loadingEarlier = false;
+            // Short page against a tall viewport: keep pulling until the top moves away
+            maybeLoadEarlier();
+          }
+        });
+      }).catch(() => {
+        loadingEarlier = false;
+        setHistoryTopIdle();
+      });
+    }
+
+    function fetchHistory(limit) {
+      return api.chat.loadHistory({
+        projectPath: project.path,
+        sessionId: pendingResumeId,
+        limit,
+        until: pendingResumeAt || undefined
+      });
+    }
+
+    fetchHistory(historyLimit).then(result => {
+      if (welcomeEl) welcomeEl.remove();
+
+      let msgs = (result?.success && result.messages) || [];
+      // Older main processes truncate client-side; harmless double safety for forks
+      if (pendingResumeAt) {
+        const cutIdx = msgs.findIndex(m => m.uuid === pendingResumeAt);
+        if (cutIdx >= 0) msgs = msgs.slice(0, cutIdx + 1);
+      }
+      previousCount = msgs.length;
+
+      if (msgs.length === 0) {
+        appendHistoryDivider();
+        return;
+      }
+
+      renderHistoryMessages(msgs, {
+        onComplete: () => {
+          syncHistoryTop(result, msgs.length);
+          appendHistoryDivider();
+          // Arm the scroll-driven loader only once the initial replay is in place.
+          // The double rAF lets appendHistoryDivider's scroll-to-bottom land first,
+          // so the check below sees the real position (and only pulls another page
+          // when the tail is too short to fill the viewport).
+          onNearHistoryTop = maybeLoadEarlier;
+          requestAnimationFrame(() => requestAnimationFrame(maybeLoadEarlier));
+        }
+      });
     }).catch(() => {
       if (welcomeEl) {
         welcomeEl.querySelector('.chat-welcome-text').textContent = t('chat.conversationResumed') || 'Conversation resumed — type a message to continue.';
@@ -6508,8 +6621,16 @@ class ChatView extends BaseComponent {
   /**
    * Render history messages from JSONL data into the chat UI.
    * Creates static (non-interactive) message elements.
+   *
+   * @param {Array} messages
+   * @param {object} [options]
+   * @param {Node} [options.anchor] - Insert before this node instead of appending
+   *   (used when prepending older messages).
+   * @param {Function} [options.onComplete] - Called once every batch is in the DOM.
    */
-  function renderHistoryMessages(messages) {
+  function renderHistoryMessages(messages, options = {}) {
+    const { anchor = null, onComplete = null } = options;
+
     // Build a map of tool_use_id -> tool_result output for enriching tool cards
     const toolResults = new Map();
     for (const msg of messages) {
@@ -6518,15 +6639,22 @@ class ChatView extends BaseComponent {
       }
     }
 
-    // Batch rendering: build DOM in a fragment, process in chunks to avoid blocking UI
-    const BATCH_SIZE = 20;
+    // Time-sliced rendering: build DOM in a fragment and yield once the frame
+    // budget is spent, so a long replay never freezes the UI.
+    const BATCH_BUDGET_MS = 12;
+    const MIN_BATCH = 20;
     let idx = 0;
 
     function renderBatch() {
       const fragment = document.createDocumentFragment();
-      const end = Math.min(idx + BATCH_SIZE, messages.length);
+      const deadline = Date.now() + BATCH_BUDGET_MS;
+      let end = Math.min(idx + MIN_BATCH, messages.length);
 
       for (; idx < end; idx++) {
+        // Keep filling the frame budget once the minimum batch is done
+        if (idx === end - 1 && end < messages.length && Date.now() < deadline) {
+          end = Math.min(end + MIN_BATCH, messages.length);
+        }
         const msg = messages[idx];
         if (msg.role === 'user') {
           const el = document.createElement('div');
@@ -6663,10 +6791,16 @@ class ChatView extends BaseComponent {
         }
       }
 
-      messagesEl.appendChild(fragment);
-      MarkdownRenderer.postProcess(messagesEl);
+      // Scope post-processing to this batch: running it over the whole message
+      // list once per batch made replay quadratic in the number of messages.
+      const batchNodes = Array.from(fragment.children);
+      if (anchor) messagesEl.insertBefore(fragment, anchor);
+      else messagesEl.appendChild(fragment);
+      MarkdownRenderer.postProcess(batchNodes);
 
       if (idx < messages.length) {
+        // Keep the view pinned to the newest content while the tail streams in
+        if (!anchor) scrollToBottom();
         // Schedule next batch during idle time
         if (typeof requestIdleCallback === 'function') {
           requestIdleCallback(() => renderBatch(), { timeout: 100 });
@@ -6674,8 +6808,11 @@ class ChatView extends BaseComponent {
           setTimeout(renderBatch, 0);
         }
       } else {
-        userHasScrolled = false;
-        scrollToBottom();
+        if (!anchor) {
+          userHasScrolled = false;
+          scrollToBottom();
+        }
+        if (onComplete) onComplete();
       }
     }
 

--- a/src/renderer/ui/components/ChatView.js
+++ b/src/renderer/ui/components/ChatView.js
@@ -6479,9 +6479,23 @@ class ChatView extends BaseComponent {
     const HISTORY_PREFETCH_PX = 800;
     let historyLimit = HISTORY_PAGE;
     let historyTopEl = null;
-    let previousCount = 0;
+    // Size of the window the main process returned last time. The paging maths runs
+    // against the raw window, not against what survived the fork cut below — a cut
+    // that trims anything would otherwise re-render its first messages as "older".
+    let previousRawCount = 0;
+    // First user prompt currently on screen. A prepended page ends right before it,
+    // so it is the turn a fork off that page's last message would discard.
+    let oldestUserUuid = null;
     let historyExhausted = false;
     let loadingEarlier = false;
+
+    /** UUID of the first user prompt in a window, for the fork guard. */
+    function firstUserUuid(list) {
+      for (const msg of list) {
+        if (msg.role === 'user') return msg.uuid || null;
+      }
+      return null;
+    }
 
     const welcomeEl = wrapperEl.querySelector('.chat-welcome');
     if (welcomeEl) {
@@ -6546,8 +6560,8 @@ class ChatView extends BaseComponent {
         historyLimit = nextLimit;
         const msgs = result?.messages || [];
         // The window grows from the end, so the new messages are its prefix
-        const older = msgs.slice(0, Math.max(0, msgs.length - previousCount));
-        previousCount = msgs.length;
+        const older = msgs.slice(0, Math.max(0, msgs.length - previousRawCount));
+        previousRawCount = msgs.length;
         if (older.length === 0) {
           loadingEarlier = false;
           syncHistoryTop({ ...result, truncated: false }, msgs.length);
@@ -6557,8 +6571,11 @@ class ChatView extends BaseComponent {
         const anchor = historyTopEl.nextSibling;
         const beforeHeight = messagesEl.scrollHeight;
         const beforeTop = messagesEl.scrollTop;
+        const nextUserUuid = oldestUserUuid;
+        oldestUserUuid = firstUserUuid(older) || oldestUserUuid;
         renderHistoryMessages(older, {
           anchor,
+          nextUserUuid,
           onComplete: () => {
             messagesEl.scrollTop = beforeTop + (messagesEl.scrollHeight - beforeHeight);
             syncHistoryTop(result, msgs.length);
@@ -6585,13 +6602,16 @@ class ChatView extends BaseComponent {
     fetchHistory(historyLimit).then(result => {
       if (welcomeEl) welcomeEl.remove();
 
-      let msgs = (result?.success && result.messages) || [];
+      const rawMsgs = (result?.success && result.messages) || [];
+      previousRawCount = rawMsgs.length;
+
+      let msgs = rawMsgs;
       // Older main processes truncate client-side; harmless double safety for forks
       if (pendingResumeAt) {
         const cutIdx = msgs.findIndex(m => m.uuid === pendingResumeAt);
         if (cutIdx >= 0) msgs = msgs.slice(0, cutIdx + 1);
       }
-      previousCount = msgs.length;
+      oldestUserUuid = firstUserUuid(msgs);
 
       if (msgs.length === 0) {
         appendHistoryDivider();
@@ -6626,10 +6646,14 @@ class ChatView extends BaseComponent {
    * @param {object} [options]
    * @param {Node} [options.anchor] - Insert before this node instead of appending
    *   (used when prepending older messages).
+   * @param {string|null} [options.nextUserUuid] - Prompt that opens the turn following
+   *   this page. `messages` is only one page of the session, so the last assistant
+   *   messages have no user prompt after them *within the page* — without this the
+   *   fork guard would read them as forks off the tail and stay unarmed.
    * @param {Function} [options.onComplete] - Called once every batch is in the DOM.
    */
   function renderHistoryMessages(messages, options = {}) {
-    const { anchor = null, onComplete = null } = options;
+    const { anchor = null, nextUserUuid = null, onComplete = null } = options;
 
     // Build a map of tool_use_id -> tool_result output for enriching tool cards
     const toolResults = new Map();
@@ -6682,7 +6706,7 @@ class ChatView extends BaseComponent {
             el.dataset.messageUuid = msg.uuid;
             // The turn this fork would discard starts at the next user prompt.
             // Naming it arms the CLI guard; null (fork off the tail) leaves it unarmed.
-            const dropsTurn = findNextUserUuid(messages, idx);
+            const dropsTurn = findNextUserUuid(messages, idx) || nextUserUuid;
             const forkBtn = document.createElement('button');
             forkBtn.className = 'chat-msg-fork-btn';
             forkBtn.title = t('chat.forkSession') || 'Fork from here';

--- a/src/renderer/ui/panels/SessionReplayPanel.js
+++ b/src/renderer/ui/panels/SessionReplayPanel.js
@@ -303,13 +303,16 @@ async function loadMoreSteps() {
     renderTimeline(more, { append: true });
     syncTimelineFooter();
   } catch {
-    // Leave the footer in place so the next scroll retries
+    // Leave the footer in place so the next scroll retries. Nothing was appended,
+    // so the bottom is still in reach — chaining another load here would spin the
+    // main process on a full re-parse of the transcript, forever.
     syncTimelineFooter();
+    return;
   } finally {
     loadingMoreSteps = false;
-    // Page shorter than the viewport: keep pulling until the bottom moves away
-    if (!replayExhausted) maybeLoadMoreSteps();
   }
+  // Page shorter than the viewport: keep pulling until the bottom moves away
+  if (!replayExhausted) maybeLoadMoreSteps();
 }
 
 function renderNormalStep(step, i) {

--- a/src/renderer/ui/panels/SessionReplayPanel.js
+++ b/src/renderer/ui/panels/SessionReplayPanel.js
@@ -186,24 +186,51 @@ function renderSummary(summary) {
     </div>`;
 }
 
-function renderTimeline(steps) {
+/**
+ * @param {Array} steps - Steps to render (a full session, or one appended page)
+ * @param {object} [options]
+ * @param {boolean} [options.append] - Append after the existing steps instead of replacing
+ */
+function renderTimeline(steps, options = {}) {
+  const { append = false } = options;
+
   if (!steps || steps.length === 0) {
-    timeline.innerHTML = `<div class="sr-empty">${t('sessionReplay.noSteps')}</div>`;
+    if (!append) timeline.innerHTML = `<div class="sr-empty">${t('sessionReplay.noSteps')}</div>`;
     return;
   }
 
   // Fix 2: group consecutive identical tool calls
   const displaySteps = groupConsecutiveAgents(steps);
+  // data-step-index has to match the DOM position among .sr-step, which
+  // focusStep() indexes into, so an appended page continues the numbering.
+  const startIndex = append ? timeline.querySelectorAll('.sr-step').length : 0;
 
-  timeline.innerHTML = displaySteps.map((step, i) => {
+  const html = displaySteps.map((step, i) => {
+    const idx = startIndex + i;
     if (step.type === 'group') {
-      return renderGroupStep(step, i);
+      return renderGroupStep(step, idx);
     }
-    return renderNormalStep(step, i);
+    return renderNormalStep(step, idx);
   }).join('');
 
-  // Attach click handlers for normal steps
-  timeline.querySelectorAll('.sr-step:not(.sr-step--grouped)').forEach(el => {
+  if (append) {
+    const footer = timeline.querySelector('.sr-timeline-more');
+    if (footer) footer.insertAdjacentHTML('beforebegin', html);
+    else timeline.insertAdjacentHTML('beforeend', html);
+  } else {
+    timeline.innerHTML = html;
+  }
+
+  // Attach handlers to the steps that do not have them yet (appended pages)
+  timeline.querySelectorAll('.sr-step:not([data-sr-bound])').forEach(el => {
+    el.dataset.srBound = '1';
+    if (el.classList.contains('sr-step--grouped')) {
+      el.addEventListener('click', () => toggleGroupStep(el));
+      el.addEventListener('keydown', e => {
+        if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleGroupStep(el); }
+      });
+      return;
+    }
     el.addEventListener('click', () => toggleStep(el));
     el.addEventListener('keydown', e => {
       if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleStep(el); }
@@ -211,14 +238,78 @@ function renderTimeline(steps) {
       if (e.key === 'ArrowUp') { e.preventDefault(); focusStep(+el.dataset.stepIndex - 1); }
     });
   });
+}
 
-  // Attach click handlers for grouped steps (toggle accordion)
-  timeline.querySelectorAll('.sr-step--grouped').forEach(el => {
-    el.addEventListener('click', () => toggleGroupStep(el));
-    el.addEventListener('keydown', e => {
-      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleGroupStep(el); }
+// ── Timeline paging ───────────────────────────────────────────────────────────
+// A session can hold tens of thousands of steps. The panel loads the first page
+// and pulls the next ones in as the user scrolls down the timeline.
+
+const REPLAY_PAGE = 2000;
+const REPLAY_PREFETCH_PX = 800;
+let replayExhausted = false;
+let loadingMoreSteps = false;
+
+/** Footer marker: how far into the session we are, and the load spinner. */
+function syncTimelineFooter() {
+  const total = currentSummary?.totalSteps || 0;
+  let footer = timeline.querySelector('.sr-timeline-more');
+  if (currentSteps.length >= total) {
+    replayExhausted = true;
+    if (footer) footer.remove();
+    return;
+  }
+  if (!footer) {
+    footer = document.createElement('div');
+    footer.className = 'sr-timeline-more';
+    timeline.appendChild(footer);
+  } else {
+    timeline.appendChild(footer); // keep it last after an append
+  }
+  footer.classList.remove('loading');
+  footer.textContent = t('sessionReplay.showingSteps', { shown: currentSteps.length, total });
+}
+
+function maybeLoadMoreSteps() {
+  if (loadingMoreSteps || replayExhausted || currentView !== 'timeline') return;
+  if (!currentProjectPath || !currentSessionId) return;
+  const distanceToBottom = timeline.scrollHeight - timeline.scrollTop - timeline.clientHeight;
+  if (distanceToBottom > REPLAY_PREFETCH_PX) return;
+  loadMoreSteps();
+}
+
+async function loadMoreSteps() {
+  loadingMoreSteps = true;
+  const footer = timeline.querySelector('.sr-timeline-more');
+  if (footer) {
+    footer.classList.add('loading');
+    footer.innerHTML = `<div class="sr-spinner"></div>${escapeHtml(t('sessionReplay.parsing'))}`;
+  }
+  try {
+    const result = await window.electron_api.claude.sessionReplay({
+      projectPath: currentProjectPath,
+      sessionId: currentSessionId,
+      offset: currentSteps.length,
+      limit: REPLAY_PAGE
     });
-  });
+    if (!result.success) throw new Error(result.error || 'Unknown error');
+    const more = result.steps || [];
+    if (more.length === 0) {
+      replayExhausted = true;
+      timeline.querySelector('.sr-timeline-more')?.remove();
+      return;
+    }
+    currentSteps = currentSteps.concat(more);
+    currentSummary = result.summary || currentSummary;
+    renderTimeline(more, { append: true });
+    syncTimelineFooter();
+  } catch {
+    // Leave the footer in place so the next scroll retries
+    syncTimelineFooter();
+  } finally {
+    loadingMoreSteps = false;
+    // Page shorter than the viewport: keep pulling until the bottom moves away
+    if (!replayExhausted) maybeLoadMoreSteps();
+  }
 }
 
 function renderNormalStep(step, i) {
@@ -749,8 +840,11 @@ async function loadReplay() {
   timeline.innerHTML = `<div class="sr-loading"><div class="sr-spinner"></div>${t('sessionReplay.parsing')}</div>`;
   summaryBar.innerHTML = '';
 
+  replayExhausted = false;
+  loadingMoreSteps = false;
+
   try {
-    const result = await window.electron_api.claude.sessionReplay({ projectPath, sessionId });
+    const result = await window.electron_api.claude.sessionReplay({ projectPath, sessionId, offset: 0, limit: REPLAY_PAGE });
     if (!result.success) throw new Error(result.error || 'Unknown error');
     currentSteps = result.steps || [];
     currentSummary = result.summary || {};
@@ -760,6 +854,7 @@ async function loadReplay() {
     renderSummary(currentSummary);
     currentView = 'timeline';
     renderTimeline(currentSteps);
+    syncTimelineFooter();
     _renderViewToggle();
     // Show export button
     const exportBtn = container.querySelector('#sr-export-btn');
@@ -1115,6 +1210,7 @@ function _switchToTimeline() {
   playerBarEl.hidden = true;
   timeline.hidden = false;
   renderTimeline(currentSteps);
+  syncTimelineFooter();
   _renderViewToggle();
 }
 
@@ -1357,6 +1453,7 @@ function init(containerEl, opts = {}) {
   summaryBar = container.querySelector('#sr-summary');
   viewToggleEl = container.querySelector('#sr-view-toggle');
   timeline = container.querySelector('#sr-timeline');
+  timeline.addEventListener('scroll', maybeLoadMoreSteps);
   playerChatEl = container.querySelector('#sr-player-chat');
   playerBarEl = container.querySelector('#sr-player-bar');
 

--- a/styles/chat.css
+++ b/styles/chat.css
@@ -779,6 +779,24 @@ mark.chat-search-hit.current {
   white-space: nowrap;
 }
 
+/* ── Top-of-history marker: long sessions replay their tail and stream the
+      rest in as the user scrolls up ── */
+.chat-history-top {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 28px;
+  margin: 4px 0 14px;
+  color: var(--text-muted);
+  font-size: var(--font-2xs);
+  letter-spacing: 0.02em;
+  user-select: none;
+}
+.chat-history-top.loading {
+  color: var(--text-secondary);
+}
+
 /* History messages: slightly dimmed to distinguish from live messages */
 .chat-msg.history,
 .chat-tool-card.history,

--- a/styles/session-replay.css
+++ b/styles/session-replay.css
@@ -491,6 +491,30 @@
   font-size: var(--font-sm);
 }
 
+/* Foot of the timeline: paging marker for sessions too long to ship at once */
+.sr-timeline-more {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 32px;
+  margin-top: 8px;
+  color: var(--text-muted);
+  font-size: var(--font-2xs);
+  letter-spacing: 0.02em;
+  user-select: none;
+}
+
+.sr-timeline-more.loading {
+  color: var(--text-secondary);
+}
+
+.sr-timeline-more .sr-spinner {
+  width: 13px;
+  height: 13px;
+  border-width: 1.5px;
+}
+
 .sr-spinner {
   width: 18px;
   height: 18px;

--- a/tests/ipc/claude.ipc.test.js
+++ b/tests/ipc/claude.ipc.test.js
@@ -1,0 +1,123 @@
+// Claude session-history IPC tests
+//
+// Long sessions in the wild reach tens of thousands of messages; the loader must
+// return a bounded tail instead of the whole transcript.
+
+const realOs = require('os');
+const fs = require('fs');
+const path = require('path');
+
+const TMP_HOME = fs.mkdtempSync(path.join(realOs.tmpdir(), 'ct-claude-ipc-'));
+
+jest.mock('electron', () => ({
+  ipcMain: { handle: jest.fn(), removeHandler: jest.fn() }
+}));
+
+jest.mock('os', () => ({
+  ...jest.requireActual('os'),
+  homedir: () => global.__CT_TMP_HOME__
+}));
+
+global.__CT_TMP_HOME__ = TMP_HOME;
+
+const { loadSessionHistory } = require('../../src/main/ipc/claude.ipc');
+
+const PROJECT_PATH = '/tmp/demo-project';
+const SESSION_ID = '11111111-2222-3333-4444-555555555555';
+
+function sessionsDir() {
+  return path.join(TMP_HOME, '.claude', 'projects', PROJECT_PATH.replace(/[^a-zA-Z0-9]/g, '-'));
+}
+
+/** Write a transcript of `turns` user/assistant/tool exchanges. */
+function writeSession(turns) {
+  const dir = sessionsDir();
+  fs.mkdirSync(dir, { recursive: true });
+  const lines = [];
+  for (let i = 0; i < turns; i++) {
+    lines.push(JSON.stringify({
+      type: 'user', uuid: `u-${i}`, sessionId: SESSION_ID,
+      message: { role: 'user', content: `prompt ${i}` }
+    }));
+    lines.push(JSON.stringify({
+      type: 'assistant', uuid: `a-${i}`, sessionId: SESSION_ID,
+      message: {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: `thinking ${i}` },
+          { type: 'tool_use', id: `t-${i}`, name: 'Bash', input: { command: `echo ${i}` } },
+          { type: 'text', text: `answer ${i}` }
+        ]
+      }
+    }));
+    lines.push(JSON.stringify({
+      type: 'user', uuid: `r-${i}`, sessionId: SESSION_ID,
+      message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: `t-${i}`, content: `out ${i}` }] }
+    }));
+  }
+  fs.writeFileSync(path.join(dir, `${SESSION_ID}.jsonl`), lines.join('\n') + '\n');
+}
+
+afterAll(() => {
+  fs.rmSync(TMP_HOME, { recursive: true, force: true });
+});
+
+describe('loadSessionHistory', () => {
+  test('returns every message and total when the session fits in the window', async () => {
+    writeSession(3);
+    const { messages, total, truncated } = await loadSessionHistory(PROJECT_PATH, SESSION_ID);
+
+    // 3 turns x (user + thinking + tool_use + text + tool_result)
+    expect(total).toBe(15);
+    expect(messages).toHaveLength(15);
+    expect(truncated).toBe(false);
+    expect(messages[0]).toMatchObject({ role: 'user', text: 'prompt 0' });
+  });
+
+  test('caps a long session to the tail and reports it as truncated', async () => {
+    writeSession(200); // 1000 messages
+    const { messages, total, truncated } = await loadSessionHistory(PROJECT_PATH, SESSION_ID, { limit: 50 });
+
+    expect(total).toBe(1000);
+    expect(truncated).toBe(true);
+    expect(messages.length).toBeLessThanOrEqual(50);
+    // The tail is realigned onto a user turn, never mid tool-run
+    expect(messages[0].role).toBe('user');
+    // ...and it really is the end of the conversation
+    expect(messages[messages.length - 1]).toMatchObject({ role: 'tool_result', output: 'out 199' });
+  });
+
+  test('a larger limit returns a superset ending on the same message', async () => {
+    writeSession(200);
+    const small = await loadSessionHistory(PROJECT_PATH, SESSION_ID, { limit: 50 });
+    const large = await loadSessionHistory(PROJECT_PATH, SESSION_ID, { limit: 150 });
+
+    expect(large.messages.length).toBeGreaterThan(small.messages.length);
+    const overlap = large.messages.slice(large.messages.length - small.messages.length);
+    expect(overlap).toEqual(small.messages);
+  });
+
+  test('limit 0 disables truncation', async () => {
+    writeSession(200);
+    const { messages, total, truncated } = await loadSessionHistory(PROJECT_PATH, SESSION_ID, { limit: 0 });
+
+    expect(messages).toHaveLength(1000);
+    expect(total).toBe(1000);
+    expect(truncated).toBe(false);
+  });
+
+  test('stops at the fork point named by `until`', async () => {
+    writeSession(200);
+    const { messages } = await loadSessionHistory(PROJECT_PATH, SESSION_ID, { limit: 0, until: 'a-4' });
+
+    const last = messages[messages.length - 1];
+    expect(last).toMatchObject({ role: 'assistant', type: 'text', text: 'answer 4' });
+    expect(messages.some(m => m.text === 'prompt 5')).toBe(false);
+  });
+
+  test('returns an empty result for an unknown session', async () => {
+    writeSession(1);
+    const result = await loadSessionHistory(PROJECT_PATH, 'does-not-exist');
+    expect(result).toEqual({ messages: [], total: 0, truncated: false });
+  });
+});

--- a/tests/ipc/claude.ipc.test.js
+++ b/tests/ipc/claude.ipc.test.js
@@ -87,6 +87,19 @@ describe('loadSessionHistory', () => {
     expect(messages[messages.length - 1]).toMatchObject({ role: 'tool_result', output: 'out 199' });
   });
 
+  test('realigns even when the sliding window ends exactly on a trim', async () => {
+    // 15 messages against limit 7: the buffer is trimmed back to exactly 7 on the
+    // very last push, so the tail is left starting mid-turn unless the realignment
+    // also triggers on a trim that already happened.
+    writeSession(3);
+    const { messages, total, truncated } = await loadSessionHistory(PROJECT_PATH, SESSION_ID, { limit: 7 });
+
+    expect(total).toBe(15);
+    expect(truncated).toBe(true);
+    expect(messages[0]).toMatchObject({ role: 'user', text: 'prompt 2' });
+    expect(messages[messages.length - 1]).toMatchObject({ role: 'tool_result', output: 'out 2' });
+  });
+
   test('a larger limit returns a superset ending on the same message', async () => {
     writeSession(200);
     const small = await loadSessionHistory(PROJECT_PATH, SESSION_ID, { limit: 50 });

--- a/tests/ipc/claude.ipc.test.js
+++ b/tests/ipc/claude.ipc.test.js
@@ -20,7 +20,7 @@ jest.mock('os', () => ({
 
 global.__CT_TMP_HOME__ = TMP_HOME;
 
-const { loadSessionHistory } = require('../../src/main/ipc/claude.ipc');
+const { loadSessionHistory, parseSessionReplay } = require('../../src/main/ipc/claude.ipc');
 
 const PROJECT_PATH = '/tmp/demo-project';
 const SESSION_ID = '11111111-2222-3333-4444-555555555555';
@@ -119,5 +119,68 @@ describe('loadSessionHistory', () => {
     writeSession(1);
     const result = await loadSessionHistory(PROJECT_PATH, 'does-not-exist');
     expect(result).toEqual({ messages: [], total: 0, truncated: false });
+  });
+});
+
+describe('parseSessionReplay', () => {
+  test('counts the whole session but only ships the first page', async () => {
+    writeSession(200); // 200 turns -> prompt + thinking + tool + response each
+    const { steps, summary } = await parseSessionReplay(PROJECT_PATH, SESSION_ID, { limit: 50 });
+
+    expect(summary.totalSteps).toBe(800);
+    expect(summary.returned).toBe(50);
+    expect(summary.truncated).toBe(true);
+    expect(steps).toHaveLength(50);
+    expect(steps[0].index).toBe(0);
+    expect(steps[49].index).toBe(49);
+  });
+
+  test('a page equals the same slice of the unbounded parse', async () => {
+    writeSession(60);
+    const full = await parseSessionReplay(PROJECT_PATH, SESSION_ID, { limit: 0 });
+    const page = await parseSessionReplay(PROJECT_PATH, SESSION_ID, { offset: 100, limit: 40 });
+
+    expect(full.summary.truncated).toBe(false);
+    expect(page.steps).toEqual(full.steps.slice(100, 140));
+    expect(page.steps[0].index).toBe(100);
+  });
+
+  test('summary totals do not depend on the window', async () => {
+    writeSession(60);
+    const full = await parseSessionReplay(PROJECT_PATH, SESSION_ID, { limit: 0 });
+    const page = await parseSessionReplay(PROJECT_PATH, SESSION_ID, { offset: 200, limit: 10 });
+
+    expect(page.summary.totalSteps).toBe(full.summary.totalSteps);
+    expect(page.summary.totalEstimatedTokens).toBe(full.summary.totalEstimatedTokens);
+    expect(page.summary.toolBreakdown).toEqual(full.summary.toolBreakdown);
+    expect(page.summary.uniqueFileCount).toBe(full.summary.uniqueFileCount);
+  });
+
+  test('attaches tool output to a windowed tool step', async () => {
+    writeSession(5);
+    const { steps } = await parseSessionReplay(PROJECT_PATH, SESSION_ID, { limit: 0 });
+    const tools = steps.filter(s => s.type === 'tool');
+
+    expect(tools).toHaveLength(5);
+    expect(tools[0].toolName).toBe('Bash');
+    expect(tools[0].toolOutput).toBe('out 0');
+    expect(tools[0].estimatedOutputTokens).toBeGreaterThan(0);
+  });
+
+  test('counts output tokens of tool steps outside the window', async () => {
+    writeSession(5);
+    // Window starts past every tool step, yet their results still count
+    const tail = await parseSessionReplay(PROJECT_PATH, SESSION_ID, { offset: 19, limit: 1 });
+    const full = await parseSessionReplay(PROJECT_PATH, SESSION_ID, { limit: 0 });
+
+    expect(tail.steps).toHaveLength(1);
+    expect(tail.summary.totalEstimatedTokens).toBe(full.summary.totalEstimatedTokens);
+  });
+
+  test('returns an empty result for an unknown session', async () => {
+    writeSession(1);
+    const { steps, summary } = await parseSessionReplay(PROJECT_PATH, 'does-not-exist');
+    expect(steps).toEqual([]);
+    expect(summary.totalSteps).toBe(0);
   });
 });


### PR DESCRIPTION
Fixes #83

Opening a very long session made Claude Terminal unusable, in two independent places: the chat replay and the Session Replay panel. Both loaded the entire transcript at once.

Reference session used throughout: `69 325` lines, `207 MB` on disk.

---

## 1. Chat replay (`ChatView` + `loadSessionHistory`)

### Problem

The conversation opened scrolled to the **top** with no practical way to reach the end, and the app stayed sluggish afterwards — including in other tabs.

| | Before |
|---|---|
| Messages returned by `loadSessionHistory` | 35 713 |
| IPC payload (structured clone) | 37.7 MB |
| Main-process heap | 160 MB |
| Markdown renders in the renderer | ~25 000 |

Two things made the replay quadratic rather than merely large:

1. `renderHistoryMessages()` called `MarkdownRenderer.postProcess(messagesEl)` once **per 20-message batch**, so each of the ~2 400 batches re-walked the entire message list (~460 M node visits).
2. `postProcess()` allocated a fresh `IntersectionObserver` on every call and never released it, leaving ~2 400 live observers that kept firing on every later scroll. That is why the slowdown outlived the session tab.

The scroll position was a consequence: `scrollToBottom()` only ran after the last batch, which in practice never arrived.

### Changes

**`src/main/ipc/claude.ipc.js`** — `loadSessionHistory` streams with a sliding window and returns only the tail (400 messages by default) plus `{ total, truncated }`. The tail is realigned onto a user turn so a replay never opens mid tool-run. New `until` option stops the read at the fork point, which also makes forking near the start of a long session fast.

**`src/renderer/services/markdown/postProcess.js`** — one shared `IntersectionObserver` for the whole renderer, guarded by `data-lazy-observed`. `postProcess()` now accepts a list of nodes (a render batch) in addition to a container, and tolerates a `null` target.

**`src/renderer/ui/components/ChatView.js`** — `postProcess` is scoped to the batch, batches are cut on a 12 ms frame budget instead of a fixed 20, the view is pinned to the bottom while the tail streams in, and older pages load automatically as the user scrolls within 800 px of the top. Prepending preserves the reading position by re-applying the `scrollHeight` delta.

**Fix along the way:** the "Conversation resumed" divider was appended right after the first batch, so on a long history it landed around message 20 instead of at the end.

### Result

| | After |
|---|---|
| Messages returned | 397 (of 35 713) |
| IPC payload | 0.4 MB |
| Main-process heap | 12 MB |
| Read time | 1.1 s |

---

## 2. Session Replay panel (`parseSessionReplay`)

### Problem

`parseSessionReplay` collected every line into an array before parsing any of it:

```js
const rawLines = await new Promise(...)   // 69 325 strings retained
for (const line of rawLines) { JSON.parse(line); ... }
```

That array alone retained **546 MB of heap** before the first `JSON.parse`. Even past it, the session yields **23 834 steps** / **25.1 MB** over IPC.

### Changes

Single streaming pass. Summary counters (`totalSteps`, tokens, unique files, tool breakdown) still cover the whole file; only the requested window of steps is materialized.

A tool step outside the window is still built, because its `tool_result` arrives later and its output tokens belong in the summary — only `pendingTools` holds it, and that map is now capped (results follow their call within a line or two, so the cap only matters when a session was cut mid-run).

`renderTimeline()` gained an append mode, and the panel pulls the next page in as the user scrolls toward the bottom, mirroring the chat side. Step indices continue across pages because `focusStep()` indexes positionally into the rendered `.sr-step` nodes.

### Result

| | Before | After |
|---|---|---|
| Main-process heap | 546 MB (raw lines only) | 32 MB |
| IPC payload | 25.1 MB | 2.0 MB |
| Steps shipped | 23 834 | 2 000 per page |

Verified against the real session: a page is identical to the matching slice of the unbounded parse, and the summary is the same whatever the window.

```
limit 0 -> steps: 23834 | totalSteps: 23834 | truncated: false
page2 first/last index: 2000 3999 | returned 2000
page 2 identical to full.slice(2000,4000): true
token totals equal across windows: true
```

Note: the summary bar now shows the session's true `totalSteps`. It previously showed `steps.length`, which happened to be the same number only because everything was loaded.

---

## Tests

12 new tests in `tests/ipc/claude.ipc.test.js`.

`loadSessionHistory`: full-session pass-through, tail truncation, user-turn realignment, superset consistency between two limits, `until` fork point, unknown session.

`parseSessionReplay`: paging, page/slice equivalence against the unbounded parse, summary stability across windows, tool-output attachment, output tokens counted for out-of-window steps, unknown session.

```
Test Suites: 72 passed, 72 total
Tests:       2126 passed, 2126 total
```

New i18n keys `chat.olderMessages` and `sessionReplay.showingSteps` in all five locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
