### PR TITLE
feat(sessions): show the real session title, and make ids searchable

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -8,6 +8,7 @@
 const api = window.electron_api;
 const { path, fs, process: nodeProcess, __dirname } = window.electron_nodeModules;
 const { fileExists, fsp, ensureDirs } = require('./src/renderer/utils/fs-async');
+const { matchesSessionQuery } = require('./src/renderer/utils/sessionSearch');
 
 document.body.classList.add(`platform-${nodeProcess.platform}`);
 
@@ -1813,6 +1814,17 @@ async function _saveModalPins() {
   try { await fsp.writeFile(_modalPinsFile, JSON.stringify(_modalPinsCache || {}, null, 2), 'utf8'); } catch {}
 }
 
+// Names given to sessions inside Claude Terminal, written by the Sessions panel.
+// Read fresh on every modal open rather than cached, so a rename made in the
+// panel shows up here instead of the two lists disagreeing.
+const _modalNamesFile = path.join(window.electron_nodeModules.os.homedir(), '.claude-terminal', 'session-names.json');
+
+async function _loadModalNames() {
+  try {
+    return JSON.parse(await fsp.readFile(_modalNamesFile, 'utf8')) || {};
+  } catch { return {}; }
+}
+
 async function _toggleModalPin(sessionId) {
   const pins = await _loadModalPins();
   if (pins[sessionId]) delete pins[sessionId]; else pins[sessionId] = true;
@@ -1873,23 +1885,26 @@ function _truncateModalText(text, max) {
 async function _preprocessModalSessions(sessions) {
   const now = Date.now();
   const pins = await _loadModalPins();
+  const names = await _loadModalNames();
   return sessions.map(session => {
     const promptResult = _cleanModalSessionText(session.firstPrompt);
     const summaryResult = _cleanModalSessionText(session.summary);
     const skillName = promptResult.skillName || summaryResult.skillName;
+    const customName = names[session.sessionId] || '';
     let displayTitle = '', displaySubtitle = '', isSkill = false;
-    // The title Claude Code carries in the transcript (`custom-title`, else
-    // `ai-title`) beats the opening prompt, which can run to thousands of chars
-    if (session.title) { displayTitle = session.title; displaySubtitle = summaryResult.text || promptResult.text; }
+    // Same order as the Sessions panel: a name given inside Claude Terminal wins,
+    // then the title Claude Code carries in the transcript (`custom-title`, else
+    // `ai-title`), then the opening prompt, which can run to thousands of chars
+    if (customName) { displayTitle = customName; displaySubtitle = session.title || summaryResult.text || promptResult.text; }
+    else if (session.title) { displayTitle = session.title; displaySubtitle = summaryResult.text || promptResult.text; }
     else if (summaryResult.text) { displayTitle = summaryResult.text; displaySubtitle = promptResult.text; }
     else if (promptResult.text) { displayTitle = promptResult.text; }
     else if (skillName) { displayTitle = '/' + skillName; isSkill = true; }
     else { displayTitle = t('newProject.untitledConversation'); }
     const hoursAgo = (now - new Date(session.modified).getTime()) / 3600000;
     const freshness = hoursAgo < 1 ? 'hot' : hoursAgo < 24 ? 'warm' : '';
-    // sessionId is in there so pasting an id (or a prefix of one) finds the card
     const searchText = (displayTitle + ' ' + displaySubtitle + ' ' + (session.gitBranch || '')
-      + ' ' + (session.sessionId || '')).toLowerCase();
+      + ' ' + customName).toLowerCase();
     const pinned = !!pins[session.sessionId];
     return { ...session, displayTitle, displaySubtitle, isSkill, freshness, searchText, pinned };
   });
@@ -2161,7 +2176,7 @@ async function showSessionsModal(project) {
           cards.forEach(card => {
             const sid = card.dataset.sid;
             const session = sessionMap.get(sid);
-            visibility.push({ card, match: !query || (session && session.searchText.includes(query)) });
+            visibility.push({ card, match: matchesSessionQuery(session, query) });
           });
           visibility.forEach(({ card, match }) => { card.style.display = match ? '' : 'none'; });
           groupEls.forEach(group => {

--- a/renderer.js
+++ b/renderer.js
@@ -1878,13 +1878,18 @@ async function _preprocessModalSessions(sessions) {
     const summaryResult = _cleanModalSessionText(session.summary);
     const skillName = promptResult.skillName || summaryResult.skillName;
     let displayTitle = '', displaySubtitle = '', isSkill = false;
-    if (summaryResult.text) { displayTitle = summaryResult.text; displaySubtitle = promptResult.text; }
+    // The title Claude Code carries in the transcript (`custom-title`, else
+    // `ai-title`) beats the opening prompt, which can run to thousands of chars
+    if (session.title) { displayTitle = session.title; displaySubtitle = summaryResult.text || promptResult.text; }
+    else if (summaryResult.text) { displayTitle = summaryResult.text; displaySubtitle = promptResult.text; }
     else if (promptResult.text) { displayTitle = promptResult.text; }
     else if (skillName) { displayTitle = '/' + skillName; isSkill = true; }
     else { displayTitle = t('newProject.untitledConversation'); }
     const hoursAgo = (now - new Date(session.modified).getTime()) / 3600000;
     const freshness = hoursAgo < 1 ? 'hot' : hoursAgo < 24 ? 'warm' : '';
-    const searchText = (displayTitle + ' ' + displaySubtitle + ' ' + (session.gitBranch || '')).toLowerCase();
+    // sessionId is in there so pasting an id (or a prefix of one) finds the card
+    const searchText = (displayTitle + ' ' + displaySubtitle + ' ' + (session.gitBranch || '')
+      + ' ' + (session.sessionId || '')).toLowerCase();
     const pinned = !!pins[session.sessionId];
     return { ...session, displayTitle, displaySubtitle, isSkill, freshness, searchText, pinned };
   });

--- a/src/main/ipc/claude.ipc.js
+++ b/src/main/ipc/claude.ipc.js
@@ -102,6 +102,51 @@ async function extractSessionInfo(filePath) {
   });
 }
 
+// Claude Code appends `custom-title` (renamed by the user) and `ai-title`
+// (generated) lines as the session goes, so the current title is near the END of
+// the file. Reading forward to find it would mean streaming the whole transcript,
+// which reaches 200 MB — so only the tail is read.
+const TITLE_TAIL_BYTES = 128 * 1024;
+
+/**
+ * Read the session's current title from the tail of its JSONL file.
+ * @param {string} filePath
+ * @param {number} size - File size in bytes (from a stat the caller already did)
+ * @returns {Promise<{customTitle: string, aiTitle: string}>}
+ */
+async function readSessionTitle(filePath, size) {
+  let handle;
+  try {
+    handle = await fs.promises.open(filePath, 'r');
+    const length = Math.min(size, TITLE_TAIL_BYTES);
+    const start = Math.max(0, size - length);
+    const buffer = Buffer.alloc(length);
+    await handle.read(buffer, 0, length, start);
+
+    const lines = buffer.toString('utf8').split('\n');
+    // The first line is cut in half unless the read started at the beginning
+    if (start > 0) lines.shift();
+
+    let customTitle = '';
+    let aiTitle = '';
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const line = lines[i];
+      if (!line || line.indexOf('-title"') === -1) continue; // cheap pre-filter
+      try {
+        const obj = JSON.parse(line);
+        if (!customTitle && obj.type === 'custom-title' && obj.customTitle) customTitle = obj.customTitle;
+        else if (!aiTitle && obj.type === 'ai-title' && obj.aiTitle) aiTitle = obj.aiTitle;
+        if (customTitle && aiTitle) break;
+      } catch { /* skip malformed lines */ }
+    }
+    return { customTitle, aiTitle };
+  } catch {
+    return { customTitle: '', aiTitle: '' };
+  } finally {
+    await handle?.close().catch(() => {});
+  }
+}
+
 /**
  * Get Claude sessions for a project by scanning .jsonl files directly
  * @param {string} projectPath - The project path
@@ -139,10 +184,14 @@ async function getClaudeSessions(projectPath) {
         if (stat.size < 200) return null;
 
         const sessionId = info.sessionId || file.replace('.jsonl', '');
+        const { customTitle, aiTitle } = await readSessionTitle(filePath, stat.size);
 
         return {
           sessionId,
           summary: '',
+          title: customTitle || aiTitle || '',
+          customTitle,
+          aiTitle,
           firstPrompt: info.firstPrompt || '',
           messageCount: info.messageCount || 0,
           modified: stat.mtime.toISOString(),
@@ -963,4 +1012,4 @@ function registerClaudeHandlers() {
   });
 }
 
-module.exports = { registerClaudeHandlers, getClaudeSessions, loadSessionHistory, parseSessionReplay, moveSession, findStraySidecars };
+module.exports = { registerClaudeHandlers, getClaudeSessions, loadSessionHistory, parseSessionReplay, moveSession, findStraySidecars, readSessionTitle };

--- a/src/main/ipc/claude.ipc.js
+++ b/src/main/ipc/claude.ipc.js
@@ -184,18 +184,18 @@ async function getClaudeSessions(projectPath) {
         if (stat.size < 200) return null;
 
         const sessionId = info.sessionId || file.replace('.jsonl', '');
-        const { customTitle, aiTitle } = await readSessionTitle(filePath, stat.size);
 
         return {
           sessionId,
           summary: '',
-          title: customTitle || aiTitle || '',
-          customTitle,
-          aiTitle,
+          title: '',
+          customTitle: '',
+          aiTitle: '',
           firstPrompt: info.firstPrompt || '',
           messageCount: info.messageCount || 0,
           modified: stat.mtime.toISOString(),
           size: stat.size,
+          filePath,
           gitBranch: info.gitBranch
         };
       } catch {
@@ -223,10 +223,20 @@ async function getClaudeSessions(projectPath) {
     } catch { /* index may not exist or be stale, that's ok */ }
 
     // Sort by modified date (most recent first) and limit to 50
-    return allSessions
+    const top = allSessions
       .sort((a, b) => new Date(b.modified) - new Date(a.modified))
-      .slice(0, 50)
-      .map(({ size, ...session }) => session);
+      .slice(0, 50);
+
+    // Titles are read only for the sessions actually returned: a 128 KB tail read
+    // per file is wasted on the ones the slice above just dropped.
+    await Promise.all(top.map(async (session) => {
+      const { customTitle, aiTitle } = await readSessionTitle(session.filePath, session.size);
+      session.title = customTitle || aiTitle || '';
+      session.customTitle = customTitle;
+      session.aiTitle = aiTitle;
+    }));
+
+    return top.map(({ size, filePath, ...session }) => session);
   } catch (error) {
     console.error('Error reading Claude sessions:', error);
     return [];

--- a/src/renderer/features/QuickPicker.js
+++ b/src/renderer/features/QuickPicker.js
@@ -335,7 +335,7 @@ function buildSections(query, mode, currentProject) {
       sections.push({ key: 'sessions', label: t('quickPicker.section.sessions'), error: true, items: [] });
     } else if (sessions !== null) {
       const items = sessions.map(s => {
-        const label = s.summary || s.firstPrompt || s.sessionId;
+        const label = s.title || s.summary || s.firstPrompt || s.sessionId;
         const { match, score, labelHtml } = scoreItem(q, label, s.sessionId);
         if (!match) return null;
         return {

--- a/src/renderer/services/mention-sources/session.source.js
+++ b/src/renderer/services/mention-sources/session.source.js
@@ -52,7 +52,7 @@ module.exports = {
     const sessions = await loadSessions(ctx.project?.path);
     return sessions.slice(0, 60).map(s => ({
       id: s.sessionId,
-      firstPrompt: s.firstPrompt || s.summary || s.sessionId?.slice(0, 8) || '?',
+      firstPrompt: s.title || s.firstPrompt || s.summary || s.sessionId?.slice(0, 8) || '?',
       summary: s.summary || '',
       modified: s.modified,
       messageCount: s.messageCount || 0,

--- a/src/renderer/ui/components/TerminalManager.js
+++ b/src/renderer/ui/components/TerminalManager.js
@@ -5,6 +5,7 @@
  */
 
 const { BaseComponent } = require('../../core/BaseComponent');
+const { matchesSessionQuery } = require('../../utils/sessionSearch');
 
 const { Terminal } = require('@xterm/xterm');
 const { FitAddon } = require('@xterm/addon-fit');
@@ -2566,9 +2567,8 @@ class TerminalManager extends BaseComponent {
       const hoursAgo = (now - new Date(session.modified).getTime()) / 3600000;
       const freshness = hoursAgo < 1 ? 'hot' : hoursAgo < 24 ? 'warm' : '';
 
-      // sessionId is in there so pasting an id (or a prefix of one) finds the card
       const searchText = (displayTitle + ' ' + displaySubtitle + ' ' + (session.gitBranch || '')
-        + ' ' + customName + ' ' + (session.sessionId || '')).toLowerCase();
+        + ' ' + customName).toLowerCase();
 
       const pinned = await this._isSessionPinned(session.sessionId);
       results.push({ ...session, displayTitle, displaySubtitle, isSkill, isRenamed, freshness, searchText, pinned });
@@ -2810,7 +2810,7 @@ class TerminalManager extends BaseComponent {
             cards.forEach(card => {
               const sid = card.dataset.sid;
               const session = sessionMap.get(sid);
-              const match = !query || (session && session.searchText.includes(query));
+              const match = matchesSessionQuery(session, query);
               visibility.push({ card, match });
             });
 

--- a/src/renderer/ui/components/TerminalManager.js
+++ b/src/renderer/ui/components/TerminalManager.js
@@ -2542,8 +2542,15 @@ class TerminalManager extends BaseComponent {
 
       if (customName) {
         displayTitle = customName;
-        displaySubtitle = summaryResult.text || promptResult.text;
+        displaySubtitle = session.title || summaryResult.text || promptResult.text;
         isRenamed = true;
+      } else if (session.title) {
+        // Title Claude Code itself carries in the transcript: `custom-title` when
+        // renamed there, `ai-title` otherwise. Far more useful than the raw
+        // opening prompt, which can be thousands of characters long.
+        displayTitle = session.title;
+        displaySubtitle = summaryResult.text || promptResult.text;
+        isRenamed = Boolean(session.customTitle);
       } else if (summaryResult.text) {
         displayTitle = summaryResult.text;
         displaySubtitle = promptResult.text;
@@ -2559,7 +2566,9 @@ class TerminalManager extends BaseComponent {
       const hoursAgo = (now - new Date(session.modified).getTime()) / 3600000;
       const freshness = hoursAgo < 1 ? 'hot' : hoursAgo < 24 ? 'warm' : '';
 
-      const searchText = (displayTitle + ' ' + displaySubtitle + ' ' + (session.gitBranch || '') + ' ' + customName).toLowerCase();
+      // sessionId is in there so pasting an id (or a prefix of one) finds the card
+      const searchText = (displayTitle + ' ' + displaySubtitle + ' ' + (session.gitBranch || '')
+        + ' ' + customName + ' ' + (session.sessionId || '')).toLowerCase();
 
       const pinned = await this._isSessionPinned(session.sessionId);
       results.push({ ...session, displayTitle, displaySubtitle, isSkill, isRenamed, freshness, searchText, pinned });

--- a/src/renderer/utils/sessionSearch.js
+++ b/src/renderer/utils/sessionSearch.js
@@ -1,0 +1,30 @@
+/**
+ * Session list filtering.
+ *
+ * Shared by the "Resume a conversation" modal (renderer.js) and the Sessions
+ * panel (TerminalManager), which each keep their own copy of the card-building
+ * logic but must agree on what a query matches.
+ */
+
+// A session id is 32 hex characters. Folding it into the free-text haystack made
+// short hex queries ("db", "42", "fe") collide with roughly one card in ten by
+// chance, so ids are matched separately, as a prefix, from this length up.
+// Below it a query is far more likely to be a word than a pasted id.
+const SESSION_ID_MIN_QUERY = 4;
+
+/**
+ * Does a session card match the search query?
+ * @param {{searchText: string, sessionId?: string}} session - Preprocessed session
+ * @param {string} query - Already lowercased and trimmed
+ * @returns {boolean}
+ */
+function matchesSessionQuery(session, query) {
+  if (!query) return true;
+  if (!session) return false;
+  if (session.searchText && session.searchText.includes(query)) return true;
+  // Pasting an id, or the front of one, still finds the card it belongs to
+  return query.length >= SESSION_ID_MIN_QUERY
+    && (session.sessionId || '').toLowerCase().startsWith(query);
+}
+
+module.exports = { matchesSessionQuery, SESSION_ID_MIN_QUERY };

--- a/tests/ipc/claudeSessionTitle.test.js
+++ b/tests/ipc/claudeSessionTitle.test.js
@@ -1,0 +1,130 @@
+// Session titles come from the transcript, and an id must be searchable.
+//
+// Claude Code appends `custom-title` / `ai-title` lines as a session runs, so the
+// current title sits near the END of the file — which can be hundreds of MB.
+
+const realOs = require('os');
+const fs = require('fs');
+const path = require('path');
+
+const TMP_HOME = fs.mkdtempSync(path.join(realOs.tmpdir(), 'ct-session-title-'));
+
+jest.mock('electron', () => ({
+  ipcMain: { handle: jest.fn(), removeHandler: jest.fn() }
+}));
+
+jest.mock('os', () => ({
+  ...jest.requireActual('os'),
+  homedir: () => global.__CT_TMP_HOME__
+}));
+
+global.__CT_TMP_HOME__ = TMP_HOME;
+
+const { getClaudeSessions, readSessionTitle } = require('../../src/main/ipc/claude.ipc');
+
+const PROJECT_PATH = '/tmp/title-demo';
+const sessionsDir = () => path.join(TMP_HOME, '.claude', 'projects', PROJECT_PATH.replace(/[^a-zA-Z0-9]/g, '-'));
+
+/** @param {{sessionId: string, customTitle?: string, aiTitle?: string, padding?: number}} opts */
+function writeSession({ sessionId, customTitle, aiTitle, padding = 0 }) {
+  const dir = sessionsDir();
+  fs.mkdirSync(dir, { recursive: true });
+
+  const lines = [JSON.stringify({
+    type: 'user', uuid: 'u-0', sessionId, cwd: PROJECT_PATH, gitBranch: 'main',
+    message: { role: 'user', content: 'the opening prompt' }
+  })];
+  if (aiTitle) lines.push(JSON.stringify({ type: 'ai-title', aiTitle, sessionId }));
+  for (let i = 0; i < padding; i++) {
+    lines.push(JSON.stringify({
+      type: 'assistant', uuid: `a-${i}`, sessionId, cwd: PROJECT_PATH,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'x'.repeat(200) }] }
+    }));
+  }
+  // Titles are re-emitted as the conversation goes: the live one is the last
+  if (customTitle) lines.push(JSON.stringify({ type: 'custom-title', customTitle, sessionId }));
+
+  const filePath = path.join(dir, `${sessionId}.jsonl`);
+  fs.writeFileSync(filePath, lines.join('\n') + '\n');
+  return filePath;
+}
+
+afterAll(() => {
+  fs.rmSync(TMP_HOME, { recursive: true, force: true });
+});
+
+describe('readSessionTitle', () => {
+  test('prefers custom-title over ai-title', async () => {
+    const file = writeSession({ sessionId: 'a1', customTitle: 'Renamed by hand', aiTitle: 'Generated' });
+    const { size } = fs.statSync(file);
+
+    expect(await readSessionTitle(file, size)).toEqual({
+      customTitle: 'Renamed by hand',
+      aiTitle: 'Generated'
+    });
+  });
+
+  test('falls back to ai-title when the session was never renamed', async () => {
+    const file = writeSession({ sessionId: 'a2', aiTitle: 'Only generated' });
+    const { size } = fs.statSync(file);
+
+    const { customTitle, aiTitle } = await readSessionTitle(file, size);
+    expect(customTitle).toBe('');
+    expect(aiTitle).toBe('Only generated');
+  });
+
+  test('finds a title far past the head of a long transcript', async () => {
+    // ~2000 lines of 200 chars: well beyond the 30-line head scan used elsewhere
+    const file = writeSession({ sessionId: 'a3', customTitle: 'Title at the very end', padding: 2000 });
+    const { size } = fs.statSync(file);
+
+    expect((await readSessionTitle(file, size)).customTitle).toBe('Title at the very end');
+  });
+
+  test('reads only the tail, so a title left behind by a huge body is missed rather than costly', async () => {
+    // Title emitted early, then more than 128 KB of body after it
+    const dir = sessionsDir();
+    const lines = [
+      JSON.stringify({ type: 'custom-title', customTitle: 'Stale early title', sessionId: 'a4' }),
+      ...Array.from({ length: 1200 }, (_, i) => JSON.stringify({
+        type: 'assistant', uuid: `a-${i}`, sessionId: 'a4', cwd: PROJECT_PATH,
+        message: { role: 'assistant', content: [{ type: 'text', text: 'y'.repeat(200) }] }
+      }))
+    ];
+    const file = path.join(dir, 'a4.jsonl');
+    fs.writeFileSync(file, lines.join('\n') + '\n');
+    const { size } = fs.statSync(file);
+    expect(size).toBeGreaterThan(128 * 1024);
+
+    expect((await readSessionTitle(file, size)).customTitle).toBe('');
+  });
+
+  test('returns empty titles for an unreadable file', async () => {
+    expect(await readSessionTitle(path.join(sessionsDir(), 'nope.jsonl'), 10)).toEqual({
+      customTitle: '', aiTitle: ''
+    });
+  });
+});
+
+describe('getClaudeSessions', () => {
+  test('carries the transcript title alongside the opening prompt', async () => {
+    writeSession({ sessionId: 'b1', customTitle: 'Renamed by hand', aiTitle: 'Generated' });
+
+    const sessions = await getClaudeSessions(PROJECT_PATH);
+    const session = sessions.find(s => s.sessionId === 'b1');
+
+    expect(session.title).toBe('Renamed by hand');
+    expect(session.customTitle).toBe('Renamed by hand');
+    expect(session.aiTitle).toBe('Generated');
+    // The opening prompt is still there, it just stops being the label
+    expect(session.firstPrompt).toBe('the opening prompt');
+  });
+
+  test('leaves title empty when the transcript has none', async () => {
+    // padding clears the 200-byte floor that skips empty/aborted sessions
+    writeSession({ sessionId: 'b2', padding: 1 });
+
+    const sessions = await getClaudeSessions(PROJECT_PATH);
+    expect(sessions.find(s => s.sessionId === 'b2').title).toBe('');
+  });
+});

--- a/tests/ipc/claudeSessionTitle.test.js
+++ b/tests/ipc/claudeSessionTitle.test.js
@@ -127,4 +127,46 @@ describe('getClaudeSessions', () => {
     const sessions = await getClaudeSessions(PROJECT_PATH);
     expect(sessions.find(s => s.sessionId === 'b2').title).toBe('');
   });
+
+  test('reads a title only for the sessions it returns', async () => {
+    // The result is capped at 50, so on a project with more sessions than that a
+    // tail read per file would be spent on transcripts nobody is about to see.
+    const dir = sessionsDir();
+    fs.rmSync(dir, { recursive: true, force: true });
+
+    const total = 60;
+    for (let i = 0; i < total; i++) {
+      const id = `c${String(i).padStart(2, '0')}`;
+      const file = writeSession({ sessionId: id, customTitle: `Title ${i}`, padding: 1 });
+      // Explicit mtimes: writing in a loop can land several files on the same ms
+      const when = new Date(Date.UTC(2026, 0, 1) + i * 60_000);
+      fs.utimesSync(file, when, when);
+    }
+
+    // fs.promises.open is reached from readSessionTitle and nowhere else here
+    const openSpy = jest.spyOn(fs.promises, 'open');
+    try {
+      const sessions = await getClaudeSessions(PROJECT_PATH);
+
+      expect(sessions).toHaveLength(50);
+      expect(openSpy).toHaveBeenCalledTimes(50);
+      // The 50 kept are the most recent ones, and each carries its title
+      expect(sessions[0].sessionId).toBe('c59');
+      expect(sessions[0].title).toBe('Title 59');
+      expect(sessions.every(s => s.title.startsWith('Title '))).toBe(true);
+    } finally {
+      openSpy.mockRestore();
+    }
+  });
+
+  test('does not leak the internal filePath into the returned sessions', async () => {
+    writeSession({ sessionId: 'd1', customTitle: 'Kept', padding: 1 });
+
+    const sessions = await getClaudeSessions(PROJECT_PATH);
+    const session = sessions.find(s => s.sessionId === 'd1');
+
+    expect(session).toBeDefined();
+    expect(session).not.toHaveProperty('filePath');
+    expect(session).not.toHaveProperty('size');
+  });
 });

--- a/tests/utils/sessionSearch.test.js
+++ b/tests/utils/sessionSearch.test.js
@@ -1,0 +1,65 @@
+const { matchesSessionQuery, SESSION_ID_MIN_QUERY } = require('../../src/renderer/utils/sessionSearch');
+
+const session = (overrides = {}) => ({
+  searchText: 'flaky integration test on ci feat/find-session-by-id',
+  sessionId: 'a3f9c210-4b7d-4e11-9c02-7fd8e6b41c55',
+  ...overrides
+});
+
+describe('matchesSessionQuery', () => {
+  test('an empty query matches every card', () => {
+    expect(matchesSessionQuery(session(), '')).toBe(true);
+  });
+
+  test('a missing session never matches a non-empty query', () => {
+    expect(matchesSessionQuery(undefined, 'flaky')).toBe(false);
+  });
+
+  test('matches on the free-text haystack', () => {
+    expect(matchesSessionQuery(session(), 'flaky')).toBe(true);
+    expect(matchesSessionQuery(session(), 'find-session')).toBe(true);
+  });
+
+  test('does not match text absent from the haystack', () => {
+    expect(matchesSessionQuery(session(), 'kubernetes')).toBe(false);
+  });
+
+  test('a full session id finds its card', () => {
+    expect(matchesSessionQuery(session(), 'a3f9c210-4b7d-4e11-9c02-7fd8e6b41c55')).toBe(true);
+  });
+
+  test('a prefix of a session id finds its card', () => {
+    expect(matchesSessionQuery(session(), 'a3f9')).toBe(true);
+    expect(matchesSessionQuery(session(), 'a3f9c210-4b7d')).toBe(true);
+  });
+
+  test('an id query is matched case-insensitively', () => {
+    expect(matchesSessionQuery(session({ sessionId: 'A3F9C210-4B7D-4E11' }), 'a3f9')).toBe(true);
+  });
+
+  // The point of the length gate: short hex queries used to collide with roughly
+  // one card in ten, because a session id carries 32 hex characters.
+  test('a short hex query does not match an id it happens to contain', () => {
+    expect(matchesSessionQuery(session(), 'f9c')).toBe(false);
+    expect(matchesSessionQuery(session(), 'c2')).toBe(false);
+  });
+
+  test('an id fragment that is not a prefix does not match', () => {
+    expect(matchesSessionQuery(session(), '7fd8e6b41c55')).toBe(false);
+  });
+
+  test('the gate sits at SESSION_ID_MIN_QUERY characters', () => {
+    const id = 'abcdef01-2345-6789-abcd-ef0123456789';
+    const s = session({ searchText: '', sessionId: id });
+    const justUnder = id.slice(0, SESSION_ID_MIN_QUERY - 1);
+    const atGate = id.slice(0, SESSION_ID_MIN_QUERY);
+    expect(matchesSessionQuery(s, justUnder)).toBe(false);
+    expect(matchesSessionQuery(s, atGate)).toBe(true);
+  });
+
+  test('a session with no id still matches on its text', () => {
+    const s = { searchText: 'a session without an id' };
+    expect(matchesSessionQuery(s, 'without')).toBe(true);
+    expect(matchesSessionQuery(s, 'a3f9')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

Two things make a session hard to recognise, or to find, in the lists.

### Sessions are labelled with their opening prompt

Claude Code records a session's own title in the transcript — `custom-title` when the user renamed it, `ai-title` otherwise — but nothing reads it. So a session shows up as the first eighty characters of whatever was typed to start it:

| | |
|---|---|
| Shown today | `can you take a look at the failing integration test on the…` |
| Actual title | `Flaky integration test on CI` |

### Pasting a session id into the search box matches nothing

The search index is built from title, subtitle, git branch and custom name. The id itself is never in it — even though it is the one thing you have when a session reference is copied out of a log, a hook payload, or the Control Tower.

## Changes

### Reading the title

The catch is *where* those lines live. They are appended as the session runs, so the current title sits near the **end** of the file, and a transcript can reach 200 MB — reading forward to find it is not an option.

`readSessionTitle` reads the last 128 KB, splits it, discards the half-line at the front, and scans backwards, with a cheap substring pre-filter before any `JSON.parse`. `custom-title` wins over `ai-title`; a rename made inside Claude Terminal still wins over both.

The read runs **after** the sort and the `slice(0, 50)`, so it only touches transcripts that are actually returned.

The bound is a deliberate trade: a title emitted early and then buried under more than 128 KB of conversation is not found, and the session keeps its old label. There is a test pinning that behaviour, so the cost of raising the bound is explicit rather than accidental.

### Making ids searchable

Ids are matched by `matchesSessionQuery` (`src/renderer/utils/sessionSearch.js`), separately from the free-text haystack: a query of four characters or more is also tried as a prefix of the session id. So a full id, or the front of one, filters the list, while a short hex query like `db` or `42` no longer collides with the 32 hex characters every id carries.

### Applied to every list

Three surfaces list sessions and each has its own copy of the logic — they now agree:

- **"Resume a conversation" modal** (header) — `_preprocessModalSessions` in `renderer.js`
- **Sessions panel** — `TerminalManager._preprocessSessions`
- **Command palette** — `QuickPicker.js` (which already matched on id, but showed the prompt as label)

The modal also reads `session-names.json` now, which it did not before: a session renamed inside Claude Terminal used to show one label in the Sessions panel and another in the modal. Both use the same precedence — custom name, then transcript title, then summary, then opening prompt.

The `@session` mention source shows titles too.

## Coverage

How often a transcript actually carries a title depends on how you work: `custom-title` is only written on an explicit rename inside Claude Code, and `ai-title` only when the auto-naming path runs with persist.

Scanning every transcript on my machine: **134 of 155 (86.5%)** have one. On @Sterll's machine, 0 of 648 — he renames sessions inside Claude Terminal rather than in Claude Code.

Where coverage is zero the label falls back to the opening prompt, which is exactly today's behaviour, and with the read moved after the slice it costs 50 tail reads rather than one per transcript. What does help in that case is the `session-names.json` fix above.

## Performance

`getClaudeSessions` on a 253-session, 38 MB fixture (warm cache, median of 7 runs):

| | Reads | Median |
|---|---|---|
| Title read inside the map | 253 | 64 ms |
| Title read after the slice | 50 | 46 ms |

Same 50 sessions returned either way.

## Tests

`tests/ipc/claudeSessionTitle.test.js` (9): `custom-title` over `ai-title`, `ai-title` fallback, a title sitting past a 2 000-line body, the tail bound (a title buried under >128 KB is deliberately missed), unreadable file, the title reaching `getClaudeSessions`, no title staying empty rather than inventing one, **titles read only for the 50 returned sessions**, and `filePath` not leaking into the result.

`tests/utils/sessionSearch.test.js` (11): full id, id prefix, case-insensitivity, the four-character gate, a non-prefix fragment not matching, and short hex queries not matching ids.

```
Test Suites: 75 passed, 75 total
Tests:       2162 passed, 2162 total
```

No new i18n keys.

## Notes

Rebased on `main` with #82, #85 and #86 in.

Scope is deliberately narrow: this makes ids searchable *within* a project's list. Finding a session whose project you do not know is a different feature and is not attempted here.

There is no cache on `getClaudeSessions` — it re-scans on every list open, quick picker and `@session` mention. Worth doing, but it is a separate change from this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
