### PR TITLE
fix(ui): hide the project bar in Settings, and repair usage on macOS

### DIFF
--- a/index.html
+++ b/index.html
@@ -278,12 +278,15 @@
       <!-- Project Bar — one tab per open project, shared by every screen.
            Sits inside .content so it reads as secondary to the vertical nav. -->
       <div class="project-bar" id="project-bar">
-        <div class="project-tabs" id="project-tabs" role="tablist" aria-label="Open projects"></div>
+        <!-- The + leads the bar: after the tabs it drifts right as projects open
+             and eventually scrolls out of reach. Here it also lines up with the
+             session row's + one row below. -->
         <button class="project-tab-add" id="btn-open-project" data-i18n-title="projects.openProject" title="Open a project" aria-label="Open a project" aria-haspopup="dialog" aria-expanded="false">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
             <line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>
           </svg>
         </button>
+        <div class="project-tabs" id="project-tabs" role="tablist" aria-label="Open projects"></div>
         <div class="project-bar-tools" id="project-bar-tools">
           <div class="terminals-filter" id="terminals-filter" style="display: none;">
             <!-- CI/CD Status Pill -->

--- a/renderer.js
+++ b/renderer.js
@@ -2997,6 +2997,7 @@ TerminalManager.setCallbacks({
   onCreateTerminal: createTerminalForProject,
   onSwitchTerminal: switchTerminal,
   onSwitchProject: switchProject,
+  onMoveSession: _showMoveSessionModal,
   onActiveTerminalChange: handleActiveTerminalChange
 });
 

--- a/src/main/ipc/accounts.ipc.js
+++ b/src/main/ipc/accounts.ipc.js
@@ -5,6 +5,7 @@
 
 const { ipcMain, BrowserWindow } = require('electron');
 const AccountManager = require('../services/AccountManager');
+const UsageService = require('../services/UsageService');
 
 function broadcast(channel, payload) {
   for (const win of BrowserWindow.getAllWindows()) {
@@ -41,7 +42,12 @@ function registerAccountsHandlers() {
 
   ipcMain.handle('accounts-switch', async (_event, { id } = {}) => {
     const result = await wrap(() => AccountManager.switchTo(id));
-    if (result.success) await broadcastAccounts();
+    if (result.success) {
+      // The usage figures and the cached token belong to the outgoing account.
+      UsageService.invalidateCredentials();
+      UsageService.refreshUsage().catch(err => console.warn('[accounts.ipc] usage refresh failed:', err.message));
+      await broadcastAccounts();
+    }
     return result;
   });
 

--- a/src/main/services/AccountManager.js
+++ b/src/main/services/AccountManager.js
@@ -13,37 +13,14 @@
 
 const fs = require('fs');
 const path = require('path');
-const os = require('os');
 const crypto = require('crypto');
 const { dataDir } = require('../utils/paths');
-
-// On macOS the Claude CLI keeps its OAuth credentials in the login Keychain
-// rather than in ~/.claude/.credentials.json. Same JSON payload, different
-// container — so the store is picked per platform.
-const KEYCHAIN_SERVICE = 'Claude Code-credentials';
-
-let keytar = null;
-try {
-  keytar = require('keytar');
-} catch (_) {
-  // Native module unavailable (electron-rebuild failed) — file store only.
-}
+// The live store is platform-dependent (Keychain on darwin, file elsewhere);
+// claudeCredentials owns that choice so every reader agrees on it.
+const { readCredentials, writeCredentials } = require('../utils/claudeCredentials');
 
 const accountsDir = path.join(dataDir, 'accounts');
 const indexFile = path.join(accountsDir, 'index.json');
-
-function getCredentialsPath() {
-  const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
-  return path.join(claudeDir, '.credentials.json');
-}
-
-function useKeychain() {
-  return process.platform === 'darwin' && keytar !== null;
-}
-
-function keychainAccount() {
-  return os.userInfo().username;
-}
 
 function ensureDir() {
   // 0700: these files hold OAuth tokens in plaintext.
@@ -67,40 +44,11 @@ function writeIndex(index) {
   fs.renameSync(tmp, indexFile);
 }
 
-function readCredentialsFile() {
-  const credPath = getCredentialsPath();
-  if (!fs.existsSync(credPath)) return null;
-  try {
-    return JSON.parse(fs.readFileSync(credPath, 'utf-8'));
-  } catch {
-    return null;
-  }
-}
-
-function writeCredentialsFile(payload) {
-  const credPath = getCredentialsPath();
-  const claudeDir = path.dirname(credPath);
-  if (!fs.existsSync(claudeDir)) fs.mkdirSync(claudeDir, { recursive: true });
-  const tmp = `${credPath}.tmp`;
-  fs.writeFileSync(tmp, payload, { mode: 0o600 });
-  fs.renameSync(tmp, credPath);
-}
-
 /**
  * Read whatever credentials the Claude CLI is currently using.
- * Keychain first on macOS, with the file as a fallback for setups that opted
- * out of it (e.g. CLAUDE_CONFIG_DIR pointing at a portable config).
  */
 async function readCurrentCredentials() {
-  if (useKeychain()) {
-    try {
-      const raw = await keytar.getPassword(KEYCHAIN_SERVICE, keychainAccount());
-      if (raw) return JSON.parse(raw);
-    } catch (_) {
-      // Keychain access denied or entry unreadable — fall through to the file.
-    }
-  }
-  return readCredentialsFile();
+  return readCredentials();
 }
 
 /**
@@ -135,17 +83,7 @@ async function mergeWithLiveStore(creds) {
  * so the swap takes effect whichever one it picks.
  */
 async function writeCurrentCredentials(creds) {
-  const payload = JSON.stringify(await mergeWithLiveStore(creds), null, 2);
-  let wrote = false;
-  if (useKeychain()) {
-    await keytar.setPassword(KEYCHAIN_SERVICE, keychainAccount(), payload);
-    wrote = true;
-  }
-  // Only touch the file if it already exists (or if it is the only store) —
-  // creating it on macOS would leave a plaintext copy the CLI never asked for.
-  if (!wrote || fs.existsSync(getCredentialsPath())) {
-    writeCredentialsFile(payload);
-  }
+  await writeCredentials(JSON.stringify(await mergeWithLiveStore(creds), null, 2));
 }
 
 function fingerprintCredentials(creds) {

--- a/src/main/services/UsageService.js
+++ b/src/main/services/UsageService.js
@@ -3,10 +3,8 @@
  * Fetches Claude usage data via the OAuth API (primary) or PTY /usage command (fallback).
  */
 
-const path = require('path');
-const fs = require('fs');
-const os = require('os');
 const https = require('https');
+const { readAccessToken } = require('../utils/claudeCredentials');
 
 // Cache
 let usageData = null;
@@ -28,40 +26,48 @@ const OAUTH_BETA_HEADER = 'oauth-2025-04-20';
 
 // ── OAuth API (primary) ──
 
-// Token cache to avoid repeated sync I/O
+// Token cache to avoid hitting the credential store (and, on macOS, the
+// Keychain) on every poll.
 let _tokenCache = null;
 let _tokenCacheTime = 0;
 const TOKEN_CACHE_TTL = 30000; // 30s
 
 /**
- * Read the OAuth access token from ~/.claude/.credentials.json
- * @returns {string|null}
+ * Read the OAuth access token from the CLI's live credential store — the macOS
+ * login Keychain on darwin, ~/.claude/.credentials.json elsewhere. Reading only
+ * the file here is what left the usage panel blank on macOS, where the CLI has
+ * never written one.
+ * @returns {Promise<string|null>}
  */
-function readOAuthToken() {
+async function readOAuthToken() {
   const now = Date.now();
   if (_tokenCache !== null && now - _tokenCacheTime < TOKEN_CACHE_TTL) {
     return _tokenCache;
   }
   try {
-    const configDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
-    const credPath = path.join(configDir, '.credentials.json');
-    if (!fs.existsSync(credPath)) { _tokenCache = null; _tokenCacheTime = now; return null; }
-    const creds = JSON.parse(fs.readFileSync(credPath, 'utf-8'));
-    const token = creds?.claudeAiOauth?.accessToken;
-    if (!token) { _tokenCache = null; _tokenCacheTime = now; return null; }
-    // Check expiry
-    const expiresAt = creds.claudeAiOauth.expiresAt;
-    if (expiresAt && now > expiresAt) {
-      console.log('[Usage] OAuth token expired');
-      _tokenCache = null; _tokenCacheTime = now;
-      return null;
-    }
-    _tokenCache = token; _tokenCacheTime = now;
-    return token;
+    _tokenCache = await readAccessToken();
   } catch (e) {
-    _tokenCache = null; _tokenCacheTime = now;
-    return null;
+    _tokenCache = null;
   }
+  _tokenCacheTime = now;
+  return _tokenCache;
+}
+
+/**
+ * Drop the cached token and usage figures.
+ *
+ * Called after an account switch: the numbers belong to the account that was
+ * active when they were fetched, so serving them for the incoming one would be
+ * a plain lie, and the 30s token cache would keep querying the outgoing account.
+ */
+function invalidateCredentials() {
+  _tokenCache = null;
+  _tokenCacheTime = 0;
+  usageData = null;
+  lastFetch = null;
+  isStale = false;
+  lastError = null;
+  _lastLimitNotifiedReset = null;
 }
 
 /**
@@ -125,7 +131,7 @@ async function fetchUsage() {
 
   try {
     // Try OAuth API first
-    const token = readOAuthToken();
+    const token = await readOAuthToken();
     if (token) {
       try {
         const data = await fetchUsageFromAPI(token);
@@ -142,7 +148,7 @@ async function fetchUsage() {
         console.log('[Usage] API request failed:', apiErr.message);
       }
     } else {
-      lastError = 'No valid Claude OAuth token (missing or expired ~/.claude/.credentials.json)';
+      lastError = 'No valid Claude OAuth token (missing or expired — run /login in a terminal)';
       console.log('[Usage] ' + lastError);
     }
 
@@ -285,6 +291,7 @@ module.exports = {
   getFetchState,
   refreshUsage,
   fetchUsage,
+  invalidateCredentials,
   onWindowShow,
   onUpdate,
   onLimit

--- a/src/main/utils/claudeCredentials.js
+++ b/src/main/utils/claudeCredentials.js
@@ -1,0 +1,114 @@
+/**
+ * Claude credential store
+ *
+ * The Claude CLI keeps its OAuth credentials in a platform-dependent place: the
+ * macOS login Keychain on darwin, ~/.claude/.credentials.json everywhere else.
+ * Same JSON payload, different container.
+ *
+ * Everything that needs the live login reads it through here, so a second reader
+ * cannot quietly go looking in the wrong store — which is exactly how the usage
+ * panel went blank on macOS, where the file it read has never existed.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const KEYCHAIN_SERVICE = 'Claude Code-credentials';
+
+let keytar = null;
+try {
+  keytar = require('keytar');
+} catch (_) {
+  // Native module unavailable (electron-rebuild failed) — file store only.
+}
+
+function getCredentialsPath() {
+  const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
+  return path.join(claudeDir, '.credentials.json');
+}
+
+function useKeychain() {
+  return process.platform === 'darwin' && keytar !== null;
+}
+
+function keychainAccount() {
+  return os.userInfo().username;
+}
+
+function readCredentialsFile() {
+  const credPath = getCredentialsPath();
+  if (!fs.existsSync(credPath)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(credPath, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+function writeCredentialsFile(payload) {
+  const credPath = getCredentialsPath();
+  const claudeDir = path.dirname(credPath);
+  if (!fs.existsSync(claudeDir)) fs.mkdirSync(claudeDir, { recursive: true });
+  const tmp = `${credPath}.tmp`;
+  fs.writeFileSync(tmp, payload, { mode: 0o600 });
+  fs.renameSync(tmp, credPath);
+}
+
+/**
+ * Read whatever credentials the Claude CLI is currently using.
+ * Keychain first on macOS, with the file as a fallback for setups that opted
+ * out of it (e.g. CLAUDE_CONFIG_DIR pointing at a portable config).
+ * @returns {Promise<Object|null>}
+ */
+async function readCredentials() {
+  if (useKeychain()) {
+    try {
+      const raw = await keytar.getPassword(KEYCHAIN_SERVICE, keychainAccount());
+      if (raw) return JSON.parse(raw);
+    } catch (_) {
+      // Keychain access denied or entry unreadable — fall through to the file.
+    }
+  }
+  return readCredentialsFile();
+}
+
+/**
+ * Write credentials to every store the CLI might read on this platform, so a
+ * swap takes effect whichever one it picks.
+ * @param {string} payload - Serialized credentials JSON
+ */
+async function writeCredentials(payload) {
+  let wrote = false;
+  if (useKeychain()) {
+    await keytar.setPassword(KEYCHAIN_SERVICE, keychainAccount(), payload);
+    wrote = true;
+  }
+  // Only touch the file if it already exists (or if it is the only store) —
+  // creating it on macOS would leave a plaintext copy the CLI never asked for.
+  if (!wrote || fs.existsSync(getCredentialsPath())) {
+    writeCredentialsFile(payload);
+  }
+}
+
+/**
+ * The Claude OAuth access token from the live store, or null when it is absent
+ * or expired.
+ * @returns {Promise<string|null>}
+ */
+async function readAccessToken() {
+  const creds = await readCredentials();
+  const oauth = creds?.claudeAiOauth;
+  if (!oauth?.accessToken) return null;
+  if (oauth.expiresAt && Date.now() > oauth.expiresAt) return null;
+  return oauth.accessToken;
+}
+
+module.exports = {
+  KEYCHAIN_SERVICE,
+  getCredentialsPath,
+  useKeychain,
+  readCredentials,
+  writeCredentials,
+  readAccessToken,
+};

--- a/src/renderer/ui/components/TerminalManager.js
+++ b/src/renderer/ui/components/TerminalManager.js
@@ -102,6 +102,7 @@ const SESSION_SVG_DEFS = `<svg style="display:none" xmlns="http://www.w3.org/200
   <symbol id="s-search" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></symbol>
   <symbol id="s-pin" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 17v5"/><path d="M9 11V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v7"/><path d="M5 17h14"/><path d="M7 11l-2 6h14l-2-6"/></symbol>
   <symbol id="s-rename" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.83 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/><path d="m15 5 4 4"/></symbol>
+  <symbol id="s-move" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 20h5a2 2 0 0 0 2-2V6a2 2 0 0 1 2-2h7"/><polyline points="17 1 21 5 17 9"/></symbol>
 </svg>`;
 
 // ── Pure helper functions (module-level, no mutable state) ──
@@ -379,6 +380,7 @@ function buildSessionCardHtml(s, index) {
   const iconId = s.isSkill ? 's-bolt' : 's-chat';
   const pinTitle = s.pinned ? (t('sessions.unpin') || 'Unpin') : (t('sessions.pin') || 'Pin');
   const renameTitle = t('sessions.rename') || 'Rename';
+  const moveTitle = t('sessions.move.title');
 
   return `<div class="session-card${freshClass}${pinnedClass}${renamedClass}${animClass}" data-sid="${s.sessionId}" style="--ci:${index < MAX_ANIMATED ? index : 0}">
 <div class="session-card-icon${skillClass}"><svg width="16" height="16"><use href="#${iconId}"/></svg></div>
@@ -392,8 +394,9 @@ ${s.displaySubtitle ? `<span class="session-card-subtitle">${escapeHtml(truncate
 ${s.gitBranch ? `<span class="session-meta-branch"><svg width="10" height="10"><use href="#s-branch"/></svg>${escapeHtml(s.gitBranch)}</span>` : ''}
 </div>
 <div class="session-card-actions">
-<button class="session-card-rename" data-rename-sid="${s.sessionId}" title="${renameTitle}"><svg width="12" height="12"><use href="#s-rename"/></svg></button>
-<button class="session-card-pin" data-pin-sid="${s.sessionId}" title="${pinTitle}"><svg width="13" height="13"><use href="#s-pin"/></svg></button>
+<button class="session-card-rename" data-rename-sid="${s.sessionId}" title="${escapeHtml(renameTitle)}" aria-label="${escapeHtml(renameTitle)}"><svg width="12" height="12"><use href="#s-rename"/></svg></button>
+<button class="session-card-move" data-move-sid="${s.sessionId}" title="${escapeHtml(moveTitle)}" aria-label="${escapeHtml(moveTitle)}"><svg width="13" height="13"><use href="#s-move"/></svg></button>
+<button class="session-card-pin" data-pin-sid="${s.sessionId}" title="${escapeHtml(pinTitle)}" aria-label="${escapeHtml(pinTitle)}"><svg width="13" height="13"><use href="#s-pin"/></svg></button>
 </div>
 <div class="session-card-arrow"><svg width="12" height="12"><use href="#s-arrow"/></svg></div>
 </div>`;
@@ -508,7 +511,10 @@ class TerminalManager extends BaseComponent {
       onRenderProjects: null,
       onCreateTerminal: null,
       onSwitchTerminal: null,
-      onSwitchProject: null
+      onSwitchProject: null,
+      // (session, fromProject, onDone) => void — the move-to-project modal lives
+      // in the host, which owns the project list and the toasts.
+      onMoveSession: null
     };
 
     // Session pins
@@ -2767,6 +2773,16 @@ class TerminalManager extends BaseComponent {
           const titleEl = card?.querySelector('.session-card-title');
           if (!titleEl) return;
           self._startInlineRename(titleEl, sid, sessionMap.get(sid), () => self._renderSessionsPanel(project, emptyState));
+          return;
+        }
+
+        const moveBtn = e.target.closest('.session-card-move');
+        if (moveBtn) {
+          e.stopPropagation();
+          const session = sessionMap.get(moveBtn.dataset.moveSid);
+          if (session && self._callbacks.onMoveSession) {
+            self._callbacks.onMoveSession(session, project, () => self._renderSessionsPanel(project, emptyState));
+          }
           return;
         }
 

--- a/src/renderer/ui/panels/SettingsPanel.js
+++ b/src/renderer/ui/panels/SettingsPanel.js
@@ -579,6 +579,10 @@ class SettingsPanel extends BasePanel {
     document.getElementById('btn-settings').classList.add('active');
     document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
     document.getElementById('tab-settings').classList.add('active');
+    // Settings is not a nav-tab, so nothing else updates the marker the project
+    // bar keys off — without this it keeps whichever screen we came from and the
+    // bar stays up over a screen that has no project context at all.
+    document.body.dataset.activeTab = 'settings';
     this._ctx?.TimeTrackingDashboard?.cleanup();
     this.renderSettingsTab(initialSubTab);
   }

--- a/styles/projects.css
+++ b/styles/projects.css
@@ -235,11 +235,12 @@ body:not([data-active-tab="dashboard"]) .project-tab--overview {
   box-shadow: inset -2px 0 0 var(--accent);
 }
 
+/* Leads the bar, so it stays put however many projects are open. */
 .project-tab-add {
   width: 26px;
   align-self: center;
   height: 26px;
-  margin: 0 4px;
+  margin: 0 6px 0 0;
   padding: 0;
   border: none;
   background: transparent;
@@ -1453,8 +1454,16 @@ body.compact-projects .project-item:hover {
   flex-shrink: 0;
 }
 
-/* ── Pin Button ── */
-.session-card-pin {
+/* ── Card action buttons (rename, move, pin) ──
+   One rule for the three: they are the same control with a different glyph.
+
+   They stay hidden until the card is hovered, but once shown they are shown
+   properly — at 0.4 opacity over --text-muted they were barely distinguishable
+   from the card background, so the actions read as decoration rather than as
+   buttons you can press. */
+.session-card-pin,
+.session-card-move,
+.session-card-rename {
   width: 28px;
   height: 28px;
   display: flex;
@@ -1465,53 +1474,13 @@ body.compact-projects .project-item:hover {
   border: none;
   cursor: pointer;
   opacity: 0;
-  color: var(--text-muted);
-  padding: 0;
-  border-radius: 6px;
-  transition: background-color 0.15s, color 0.15s, border-color 0.15s, opacity 0.15s;
-}
-
-.session-card-pin svg {
-  width: 13px;
-  height: 13px;
-  max-width: 13px;
-  max-height: 13px;
-}
-
-.session-card:hover .session-card-pin {
-  opacity: 0.4;
-}
-
-.session-card-pin:hover {
-  opacity: 1 !important;
-  color: var(--accent);
-  background: var(--accent-dim);
-}
-
-/* Pinned state */
-.session-card--pinned .session-card-pin {
-  opacity: 1;
-  color: var(--accent);
-}
-
-/* ── Move-to-project button (mirrors the pin button) ── */
-.session-card-move {
-  width: 28px;
-  height: 28px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  background: none;
-  border: none;
-  cursor: pointer;
-  opacity: 0;
-  color: var(--text-muted);
+  color: var(--text-secondary);
   padding: 0;
   border-radius: 6px;
   transition: background-color 0.15s, color 0.15s, opacity 0.15s;
 }
 
+.session-card-pin svg,
 .session-card-move svg {
   width: 13px;
   height: 13px;
@@ -1519,14 +1488,41 @@ body.compact-projects .project-item:hover {
   max-height: 13px;
 }
 
-.session-card:hover .session-card-move {
-  opacity: 0.4;
+.session-card-rename svg {
+  width: 12px;
+  height: 12px;
+  max-width: 12px;
+  max-height: 12px;
 }
 
-.session-card-move:hover {
+.session-card:hover .session-card-pin,
+.session-card:hover .session-card-move,
+.session-card:hover .session-card-rename {
+  opacity: 1;
+  background: var(--bg-hover);
+}
+
+.session-card-pin:hover,
+.session-card-move:hover,
+.session-card-rename:hover {
   opacity: 1 !important;
   color: var(--accent);
   background: var(--accent-dim);
+}
+
+.session-card-pin:focus-visible,
+.session-card-move:focus-visible,
+.session-card-rename:focus-visible {
+  opacity: 1;
+  outline: 1px solid var(--accent);
+  outline-offset: -1px;
+}
+
+/* Pinned state — the only action that stays visible off-hover, because it
+   reports state rather than offering one. */
+.session-card--pinned .session-card-pin {
+  opacity: 1;
+  color: var(--accent);
 }
 
 /* ── Move-to-project modal ── */
@@ -1602,41 +1598,6 @@ body.compact-projects .project-item:hover {
   align-items: center;
   gap: 2px;
   flex-shrink: 0;
-}
-
-/* ── Rename Button ── */
-.session-card-rename {
-  width: 28px;
-  height: 28px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  background: none;
-  border: none;
-  cursor: pointer;
-  opacity: 0;
-  color: var(--text-muted);
-  padding: 0;
-  border-radius: 6px;
-  transition: background-color 0.15s, color 0.15s, border-color 0.15s, opacity 0.15s;
-}
-
-.session-card-rename svg {
-  width: 12px;
-  height: 12px;
-  max-width: 12px;
-  max-height: 12px;
-}
-
-.session-card:hover .session-card-rename {
-  opacity: 0.4;
-}
-
-.session-card-rename:hover {
-  opacity: 1 !important;
-  color: var(--accent);
-  background: var(--accent-dim);
 }
 
 /* Renamed state — subtle indicator on title */

--- a/tests/services/claudeCredentials.test.js
+++ b/tests/services/claudeCredentials.test.js
@@ -1,0 +1,127 @@
+/**
+ * claudeCredentials — the one place that knows where the Claude CLI keeps its
+ * OAuth login.
+ *
+ * The regression these cover: on macOS the CLI stores credentials in the login
+ * Keychain and never writes ~/.claude/.credentials.json, so a reader that only
+ * looks at the file finds nothing and reports "not logged in" for an account
+ * that is perfectly signed in.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const mockKeychain = new Map();
+jest.mock('keytar', () => ({
+  getPassword: jest.fn(async (service, account) => mockKeychain.get(`${service}:${account}`) ?? null),
+  setPassword: jest.fn(async (service, account, secret) => { mockKeychain.set(`${service}:${account}`, secret); }),
+  deletePassword: jest.fn(async (service, account) => mockKeychain.delete(`${service}:${account}`))
+}));
+
+const credentials = require('../../src/main/utils/claudeCredentials');
+
+const CONFIG_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'ct-creds-'));
+const KEY = `${credentials.KEYCHAIN_SERVICE}:${os.userInfo().username}`;
+
+const realPlatform = process.platform;
+const setPlatform = (value) => {
+  Object.defineProperty(process, 'platform', { value, configurable: true });
+};
+
+const oauth = (accessToken, expiresAt = Date.now() + 3600_000) => ({
+  claudeAiOauth: { accessToken, refreshToken: `refresh-${accessToken}`, expiresAt }
+});
+
+beforeAll(() => {
+  process.env.CLAUDE_CONFIG_DIR = CONFIG_DIR;
+});
+
+afterAll(() => {
+  setPlatform(realPlatform);
+  delete process.env.CLAUDE_CONFIG_DIR;
+  fs.rmSync(CONFIG_DIR, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  mockKeychain.clear();
+  fs.rmSync(credentials.getCredentialsPath(), { force: true });
+});
+
+describe('on macOS', () => {
+  beforeEach(() => setPlatform('darwin'));
+
+  test('reads the Keychain when no credentials file exists', async () => {
+    mockKeychain.set(KEY, JSON.stringify(oauth('sk-ant-oat01-keychain')));
+
+    expect(fs.existsSync(credentials.getCredentialsPath())).toBe(false);
+    expect(await credentials.readAccessToken()).toBe('sk-ant-oat01-keychain');
+  });
+
+  test('prefers the Keychain over a stale credentials file', async () => {
+    fs.writeFileSync(credentials.getCredentialsPath(), JSON.stringify(oauth('sk-ant-oat01-file')));
+    mockKeychain.set(KEY, JSON.stringify(oauth('sk-ant-oat01-keychain')));
+
+    expect(await credentials.readAccessToken()).toBe('sk-ant-oat01-keychain');
+  });
+
+  test('falls back to the file when the Keychain entry is absent', async () => {
+    fs.writeFileSync(credentials.getCredentialsPath(), JSON.stringify(oauth('sk-ant-oat01-file')));
+
+    expect(await credentials.readAccessToken()).toBe('sk-ant-oat01-file');
+  });
+
+  test('writes the Keychain, and leaves no plaintext file behind', async () => {
+    await credentials.writeCredentials(JSON.stringify(oauth('sk-ant-oat01-written')));
+
+    expect(JSON.parse(mockKeychain.get(KEY)).claudeAiOauth.accessToken).toBe('sk-ant-oat01-written');
+    expect(fs.existsSync(credentials.getCredentialsPath())).toBe(false);
+  });
+
+  test('keeps an existing credentials file in sync with the Keychain', async () => {
+    fs.writeFileSync(credentials.getCredentialsPath(), JSON.stringify(oauth('sk-ant-oat01-old')));
+
+    await credentials.writeCredentials(JSON.stringify(oauth('sk-ant-oat01-new')));
+
+    const onDisk = JSON.parse(fs.readFileSync(credentials.getCredentialsPath(), 'utf8'));
+    expect(onDisk.claudeAiOauth.accessToken).toBe('sk-ant-oat01-new');
+  });
+});
+
+describe('elsewhere', () => {
+  beforeEach(() => setPlatform('linux'));
+
+  test('reads the credentials file, ignoring any Keychain entry', async () => {
+    mockKeychain.set(KEY, JSON.stringify(oauth('sk-ant-oat01-keychain')));
+    fs.writeFileSync(credentials.getCredentialsPath(), JSON.stringify(oauth('sk-ant-oat01-file')));
+
+    expect(await credentials.readAccessToken()).toBe('sk-ant-oat01-file');
+  });
+
+  test('returns null when nothing is stored', async () => {
+    expect(await credentials.readAccessToken()).toBeNull();
+  });
+});
+
+describe('token validity', () => {
+  beforeEach(() => setPlatform('darwin'));
+
+  test('an expired token is not handed out', async () => {
+    mockKeychain.set(KEY, JSON.stringify(oauth('sk-ant-oat01-expired', Date.now() - 1000)));
+
+    expect(await credentials.readAccessToken()).toBeNull();
+  });
+
+  test('credentials without an OAuth block yield no token', async () => {
+    mockKeychain.set(KEY, JSON.stringify({ mcpOAuth: { some: 'server' } }));
+
+    expect(await credentials.readAccessToken()).toBeNull();
+  });
+
+  test('an unparseable store does not throw', async () => {
+    mockKeychain.set(KEY, 'not json');
+    fs.writeFileSync(credentials.getCredentialsPath(), 'not json either');
+
+    expect(await credentials.readAccessToken()).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #90, fixes #91.

Four unrelated follow-ups to the project tab bar and multi-account work.

### The project bar stayed up over Settings

Settings is not a nav-tab, so nothing updated `body[data-active-tab]` on the way in and the bar kept whichever screen we came from — a project selector over a screen with no project context at all. The marker is now set where `SettingsPanel` already toggles the other classes, so every route in (the button, `Ctrl+,`, a restored `activeTab`) is covered.

### The + moves to the head of the bar

After the tabs it drifted right with every project opened and eventually scrolled out of the strip, which made "open a project" unreachable exactly when you had the most of them. At the head it also lines up with the session row's + one row below.

### Session cards get the move-to-project action

The landing screen you get on a project with no open session is the same list of the same cards as the sessions modal, and it was the one place you could not move a session from. The three card actions were also near-invisible — `opacity: 0.4` over `--text-muted` made them read as decoration — so the rename / move / pin buttons now share one rule that shows them properly on card hover, with the pin still staying lit off-hover because it reports state.

### Usage stopped reporting on macOS

`UsageService` read the OAuth token from `~/.claude/.credentials.json`, but on darwin the CLI keeps it in the login Keychain and never writes that file. `AccountManager` already knew this; `UsageService` did not, so it saw "no token" and served nothing at all — which is why the panel went blank once accounts were in play.

Both now read through `src/main/utils/claudeCredentials`, which owns the per-platform choice, so a second reader cannot quietly go looking in the wrong store again. Switching accounts additionally drops the cached token and figures and refetches: the numbers belong to the account that was active when they were fetched, and the 30s token cache would otherwise keep querying the outgoing one.

Verified against the live store on macOS: the token now resolves and `fetchUsage()` returns real figures where it previously returned `null`.

### Tests

`tests/services/claudeCredentials.test.js` — 10 cases over both platforms: Keychain-with-no-file (the regression), Keychain preferred over a stale file, file fallback, no plaintext file created on darwin, an existing file kept in sync, file-only elsewhere, expired tokens, missing OAuth block, unparseable stores.

Full suite: 75 suites, 2156 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
