### PR TITLE
fix(a11y): raise tool detail contrast, repair replayed subagent cards

### DIFF
--- a/src/renderer/ui/components/ChatView.js
+++ b/src/renderer/ui/components/ChatView.js
@@ -6739,7 +6739,11 @@ class ChatView extends BaseComponent {
             const name = input.name || input.subagent_type || 'agent';
             const desc = input.description || '';
             const el = document.createElement('div');
-            el.className = 'chat-subagent-card completed history';
+            // `done`, not `completed`: the finished state is styled off `.done`
+            // (added at the live path's completion), and no rule ever matched
+            // `.completed` on this component. Replayed subagents were stuck in
+            // the purple running state forever.
+            el.className = 'chat-subagent-card done history';
             el.innerHTML = `
               <div class="chat-subagent-header">
                 <div class="chat-subagent-icon">

--- a/styles/chat.css
+++ b/styles/chat.css
@@ -763,9 +763,10 @@ mark.chat-search-hit.current {
   align-items: center;
   gap: 12px;
   margin: 16px 0 12px;
-  color: var(--text-tertiary);
+  /* Same reason as .history below: opacity 0.6 over --text-tertiary rendered
+     11px text at 3.04:1. --text-muted holds 5.27:1 at its nominal value. */
+  color: var(--text-muted);
   font-size: 11px;
-  opacity: 0.6;
 }
 .chat-history-divider::before,
 .chat-history-divider::after {
@@ -773,7 +774,8 @@ mark.chat-search-hit.current {
   flex: 1;
   height: 1px;
   background: currentColor;
-  opacity: 0.3;
+  /* Decorative rules, not text — dimming them with alpha is fine. */
+  opacity: 0.25;
 }
 .chat-history-divider span {
   white-space: nowrap;
@@ -797,12 +799,29 @@ mark.chat-search-hit.current {
   color: var(--text-secondary);
 }
 
-/* History messages: slightly dimmed to distinguish from live messages */
+/* History messages: dimmed one notch down the text ramp so replayed turns read
+   as past. This used to be `opacity: 0.7` on the container, but that multiplies
+   every nested gray too: secondary text landed at 4.47:1 and muted at 3.14:1,
+   under the AA floor the ramp in base.css exists to hold. Remapping the ramp
+   variables dims the whole subtree in one lever (chat.css reads them in 166
+   places) and keeps every level legible.
+   Ratios vs --bg-primary #0d0d0d: 8.08 / 6.57 / 5.85 / 5.27 */
 .chat-msg.history,
 .chat-tool-card.history,
 .chat-thinking.history {
-  opacity: 0.7;
+  --text-primary: #a7a7a7;
+  --text-secondary: #969696;
+  --text-tertiary: #8d8d8d;
+  --text-muted: #858585;
   animation: none;
+}
+
+/* The accent chrome was riding that container opacity, so without it replayed
+   cards would sit brighter than live ones. Pull it back explicitly instead. */
+.chat-tool-card.history {
+  background: linear-gradient(135deg, rgba(var(--accent-color-rgb, 99, 102, 241), 0.04), rgba(var(--accent-color-rgb, 99, 102, 241), 0.015));
+  border-color: rgba(var(--accent-color-rgb, 99, 102, 241), 0.09);
+  border-left-color: rgba(var(--accent-color-rgb, 99, 102, 241), 0.32);
 }
 
 /* Loading pulse animation for welcome logo */

--- a/styles/chat.css
+++ b/styles/chat.css
@@ -808,6 +808,7 @@ mark.chat-search-hit.current {
    Ratios vs --bg-primary #0d0d0d: 8.08 / 6.57 / 5.85 / 5.27 */
 .chat-msg.history,
 .chat-tool-card.history,
+.chat-subagent-card.history,
 .chat-thinking.history {
   --text-primary: #a7a7a7;
   --text-secondary: #969696;
@@ -822,6 +823,14 @@ mark.chat-search-hit.current {
   background: linear-gradient(135deg, rgba(var(--accent-color-rgb, 99, 102, 241), 0.04), rgba(var(--accent-color-rgb, 99, 102, 241), 0.015));
   border-color: rgba(var(--accent-color-rgb, 99, 102, 241), 0.09);
   border-left-color: rgba(var(--accent-color-rgb, 99, 102, 241), 0.32);
+}
+
+/* Subagent cards state their colours literally rather than through the ramp, so
+   the remap above cannot reach their chrome. Pull it back the same way. */
+.chat-subagent-card.history {
+  background: linear-gradient(135deg, rgba(34, 197, 94, 0.05), rgba(34, 197, 94, 0.025));
+  border-color: rgba(34, 197, 94, 0.14);
+  border-left-color: rgba(34, 197, 94, 0.3);
 }
 
 /* Loading pulse animation for welcome logo */
@@ -1059,14 +1068,18 @@ mark.chat-search-hit.current {
   opacity: 0.7;
 }
 
+/* The argument line next to a tool name (the path on a Read, the pattern on a
+   Grep). It used to be --text-tertiary at `opacity: 0.6`, which composites to
+   about 3.0:1 over the card background — under the 4.5:1 AA needs at 11px, and
+   on live cards too, exactly when this line is worth reading. --text-muted is
+   the ramp's own bottom step and renders at 4.99:1 without an alpha. */
 .chat-tool-detail {
   font-size: 11px;
-  color: var(--text-tertiary);
+  color: var(--text-muted);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   font-family: 'Cascadia Code', 'Fira Code', monospace;
-  opacity: 0.6;
 }
 
 .chat-tool-status {


### PR DESCRIPTION
Closes #93.

> [!IMPORTANT]
> Depends on #88 and carries its commit. GitHub will not let me base a cross-fork PR on a branch that only exists in my fork, so the two commits show up together here. **Merge #88 first** and this diff collapses on its own to just the follow-up commit (`fix(a11y): raise tool detail contrast, repair replayed subagent cards`). Review that one — the other is already under review in #88. Splitting them apart is not really possible: both edit the same CSS block, so independent branches would conflict on merge.

## 1. `.chat-tool-detail` was below AA, including on live cards

```diff
  .chat-tool-detail {
    font-size: 11px;
-   color: var(--text-tertiary);
+   color: var(--text-muted);
    ...
-   opacity: 0.6;
  }
```

`--text-tertiary` at `opacity: 0.6` composites to about **3.0:1** over the tool card background, against the 4.5:1 AA asks at 11px. Worth repeating from the issue: this is not history-only. It applies to cards for tools running *right now*, which is exactly when the argument line (the path on a `Read`, the pattern on a `Grep`) is worth reading.

`--text-muted` is the ramp's own bottom step and renders at **4.99:1** with no alpha. It still reads a clear step below `.chat-tool-name`.

## 2. Replayed subagent cards were tagged with two dead classes

```diff
- el.className = 'chat-subagent-card completed history';
+ el.className = 'chat-subagent-card done history';
```

This turned out worse than #93 described, so it is worth spelling out. The finished state of a subagent card is styled off `.done`, which the live path adds at `ChatView.js:4048` when the subagent returns. **No rule has ever matched `.completed` on this component** — the only `.completed` rules in `chat.css` belong to `.chat-task-card`, a different component.

So replayed subagent cards kept the purple *running* treatment forever, never the green finished one, even though they are finished by definition. Reading back through a session showed every past subagent as still in flight.

## 3. `.history` was inert on subagent cards too

The dimming selector list named messages, tool cards and thinking blocks, but not subagent cards, so they alone escaped it. Added, plus an explicit chrome rule: subagent cards state their colours literally (`rgba(34, 197, 94, …)`) rather than through the ramp, so the variable remap cannot reach their background and borders.

## Testing

`npm run build:renderer` and `npx jest` (73 suites, 2142 tests) both pass.

The subagent change is one class name on the replay path; the rest is CSS. Checked by resuming a session containing a completed subagent, which now renders green, dimmed, and consistent with the tool cards around it.

## One tradeoff worth your call

`--text-muted` is the ramp's floor, and #88 remaps `--text-muted` to that same value inside history containers. So the detail line does not dim any further in replayed cards — it renders the same there as on live ones. It is the only element in the block that behaves that way.

The alternative is to keep `--text-tertiary` and just delete the `opacity` line: that dims correctly in history (5.66:1) and has more headroom live (6.22:1), at the cost of a louder jump from today's rendering. I went with `--text-muted` because it is the gentler visual change and the one I floated in #93, but I have no attachment to it — say the word and I will switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)