### PR TITLE
feat(sidebar): group the nav by scope and make it fit again

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,65 +118,30 @@
     <!-- Sidebar -->
     <div class="sidebar">
       <nav class="nav-tabs" role="tablist" aria-label="Main navigation">
+        <div class="nav-separator"><span data-i18n="ui.separatorProject">Projet</span></div>
         <button class="nav-tab active" data-tab="claude" title="Claude" data-i18n-title="ui.tooltipClaude" role="tab" aria-selected="true">
           <svg viewBox="0 0 24 24" fill="currentColor">
             <path d="M20 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.89 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8h16v10zM6 10h2v2H6zm0 4h8v2H6zm10 0h2v2h-2zm-6-4h8v2h-8z"/>
           </svg>
           <span data-i18n="ui.tabClaude">Claude</span>
         </button>
-        <div class="nav-separator"><span data-i18n="ui.separatorTools">Outils</span></div>
         <button class="nav-tab" data-tab="git" title="Git" data-i18n-title="ui.tooltipGit">
           <svg viewBox="0 0 24 24" fill="currentColor">
             <path d="M2.6 10.59L8.38 4.8l1.69 1.7c-.24.85.15 1.78.93 2.23v5.54c-.6.34-1 .99-1 1.73a2 2 0 0 0 2 2 2 2 0 0 0 2-2c0-.74-.4-1.39-1-1.73V9.41l1.35 1.36c-.02.13-.03.26-.03.4a2 2 0 0 0 2 2 2 2 0 0 0 2-2 2 2 0 0 0-2-2c-.14 0-.27.01-.4.04L13.2 7.07a2 2 0 0 0-1.12-2.51L13.71 2.9 21.41 10.59a2 2 0 0 1 0 2.82L13.41 21.41a2 2 0 0 1-2.82 0L2.59 13.41a2 2 0 0 1 0-2.82z"/>
           </svg>
           <span data-i18n="ui.tabGit">Git</span>
         </button>
-        <button class="nav-tab" data-tab="database" title="Database" data-i18n-title="ui.tooltipDatabase">
+        <button class="nav-tab" data-tab="dashboard" title="Dashboard" data-i18n-title="ui.tooltipDashboard">
           <svg viewBox="0 0 24 24" fill="currentColor">
-            <path d="M12 3C7.58 3 4 4.79 4 7v10c0 2.21 3.58 4 8 4s8-1.79 8-4V7c0-2.21-3.58-4-8-4zm6 14c0 .5-2.13 2-6 2s-6-1.5-6-2v-2.23c1.61.78 3.72 1.23 6 1.23s4.39-.45 6-1.23V17zm0-5c0 .5-2.13 2-6 2s-6-1.5-6-2V9.77C7.61 10.55 9.72 11 12 11s4.39-.45 6-1.23V12zm-6-3c-3.87 0-6-1.5-6-2s2.13-2 6-2 6 1.5 6 2-2.13 2-6 2z"/>
+            <path d="M3 13h8V3H3v10zm0 8h8v-6H3v6zm10 0h8V11h-8v10zm0-18v6h8V3h-8z"/>
           </svg>
-          <span data-i18n="ui.tabDatabase">Database</span>
+          <span data-i18n="ui.tabDashboard">Dashboard</span>
         </button>
-        <button class="nav-tab" data-tab="mcp" title="MCP" data-i18n-title="ui.tooltipMcp">
+        <button class="nav-tab" data-tab="session-replay" title="Session Replay" data-i18n-title="ui.tooltipSessionReplay">
           <svg viewBox="0 0 24 24" fill="currentColor">
-            <path d="M17 16l-4-4V8.82C14.16 8.4 15 7.3 15 6c0-1.66-1.34-3-3-3S9 4.34 9 6c0 1.3.84 2.4 2 2.82V12l-4 4H3v5h5v-3.05l4-4.2 4 4.2V21h5v-5h-4z"/>
+            <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 14.5v-9l6 4.5-6 4.5z"/>
           </svg>
-          <span data-i18n="ui.tabMcp">MCP</span>
-        </button>
-        <div class="nav-separator"><span data-i18n="ui.separatorAI">AI</span></div>
-        <button class="nav-tab" data-tab="plugins" title="Plugins" data-i18n-title="ui.tooltipPlugins" role="tab" aria-selected="false">
-          <svg viewBox="0 0 24 24" fill="currentColor">
-            <path d="M20.5 11H19V7c0-1.1-.9-2-2-2h-4V3.5C13 2.12 11.88 1 10.5 1S8 2.12 8 3.5V5H4c-1.1 0-1.99.9-1.99 2v3.8H3.5c1.49 0 2.7 1.21 2.7 2.7s-1.21 2.7-2.7 2.7H2V20c0 1.1.9 2 2 2h3.8v-1.5c0-1.49 1.21-2.7 2.7-2.7 1.49 0 2.7 1.21 2.7 2.7V22H17c1.1 0 2-.9 2-2v-4h1.5c1.38 0 2.5-1.12 2.5-2.5S21.88 11 20.5 11z"/>
-          </svg>
-          <span data-i18n="ui.tabPlugins">Plugins</span>
-        </button>
-        <button class="nav-tab" data-tab="skills" title="Skills" data-i18n-title="ui.tooltipSkills">
-          <svg viewBox="0 0 24 24" fill="currentColor">
-            <path d="M19.14 12.94c.04-.31.06-.63.06-.94 0-.31-.02-.63-.06-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.04.31-.06.63-.06.94s.02.63.06.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z"/>
-          </svg>
-          <span data-i18n="ui.tabSkills">Skills</span>
-        </button>
-        <button class="nav-tab" data-tab="agents" title="Agents" data-i18n-title="ui.tooltipAgents">
-          <svg viewBox="0 0 24 24" fill="currentColor">
-            <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zM8 17.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5zM9.5 8c0-1.38 1.12-2.5 2.5-2.5s2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5S9.5 9.38 9.5 8zm6.5 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/>
-          </svg>
-          <span data-i18n="ui.tabAgents">Agents</span>
-        </button>
-        <button class="nav-tab" data-tab="workflows" title="Workflows" data-i18n-title="ui.tooltipWorkflows">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <rect x="2" y="3" width="6" height="6" rx="1"/><rect x="16" y="3" width="6" height="6" rx="1"/>
-            <rect x="9" y="15" width="6" height="6" rx="1"/>
-            <path d="M5 9v3a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V9"/><path d="M12 12v3"/>
-          </svg>
-          <span data-i18n="ui.tabWorkflows">Workflows</span>
-        </button>
-        <button class="nav-tab" data-tab="control-tower" title="Control Tower" data-i18n-title="ui.tooltipControlTower">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M12 2L2 7l10 5 10-5-10-5z"/>
-            <path d="M2 17l10 5 10-5"/>
-            <path d="M2 12l10 5 10-5"/>
-          </svg>
-          <span data-i18n="ui.tabControlTower">Control Tower</span>
+          <span data-i18n="ui.tabSessionReplay">Replay</span>
         </button>
         <button class="nav-tab" data-tab="tasks" title="Parallel Tasks" data-i18n-title="ui.tooltipTasks">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -190,31 +155,14 @@
           </svg>
           <span data-i18n="parallel.tabTitle">Tasks</span>
         </button>
-        <div class="nav-separator"><span data-i18n="ui.separatorAnalytics">Analytique</span></div>
-        <button class="nav-tab" data-tab="dashboard" title="Dashboard" data-i18n-title="ui.tooltipDashboard">
-          <svg viewBox="0 0 24 24" fill="currentColor">
-            <path d="M3 13h8V3H3v10zm0 8h8v-6H3v6zm10 0h8V11h-8v10zm0-18v6h8V3h-8z"/>
+        <div class="nav-separator"><span data-i18n="ui.separatorAllProjects">Tous les projets</span></div>
+        <button class="nav-tab" data-tab="control-tower" title="Control Tower" data-i18n-title="ui.tooltipControlTower">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M12 2L2 7l10 5 10-5-10-5z"/>
+            <path d="M2 17l10 5 10-5"/>
+            <path d="M2 12l10 5 10-5"/>
           </svg>
-          <span data-i18n="ui.tabDashboard">Dashboard</span>
-        </button>
-        <button class="nav-tab" data-tab="timetracking" title="Time Tracking" data-i18n-title="ui.tooltipTimeTracking">
-          <svg viewBox="0 0 24 24" fill="currentColor">
-            <path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z"/>
-          </svg>
-          <span data-i18n="ui.tabTimeTracking">Time Tracking</span>
-        </button>
-        <button class="nav-tab" data-tab="session-replay" title="Session Replay" data-i18n-title="ui.tooltipSessionReplay">
-          <svg viewBox="0 0 24 24" fill="currentColor">
-            <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 14.5v-9l6 4.5-6 4.5z"/>
-          </svg>
-          <span data-i18n="ui.tabSessionReplay">Replay</span>
-        </button>
-        <div class="nav-separator nav-separator--bare"></div>
-        <button class="nav-tab" data-tab="memory" title="Memory" data-i18n-title="ui.tooltipMemory">
-          <svg viewBox="0 0 24 24" fill="currentColor">
-            <path d="M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z"/>
-          </svg>
-          <span data-i18n="ui.memory">Memory</span>
+          <span data-i18n="ui.tabControlTower">Control Tower</span>
         </button>
         <button class="nav-tab" data-tab="workspace" title="Workspaces" data-i18n-title="ui.tooltipWorkspace">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -225,6 +173,58 @@
           </svg>
           <span data-i18n="workspace.title">Workspaces</span>
         </button>
+        <button class="nav-tab" data-tab="memory" title="Memory" data-i18n-title="ui.tooltipMemory">
+          <svg viewBox="0 0 24 24" fill="currentColor">
+            <path d="M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z"/>
+          </svg>
+          <span data-i18n="ui.memory">Memory</span>
+        </button>
+        <button class="nav-tab" data-tab="timetracking" title="Time Tracking" data-i18n-title="ui.tooltipTimeTracking">
+          <svg viewBox="0 0 24 24" fill="currentColor">
+            <path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z"/>
+          </svg>
+          <span data-i18n="ui.tabTimeTracking">Time Tracking</span>
+        </button>
+        <button class="nav-tab" data-tab="database" title="Database" data-i18n-title="ui.tooltipDatabase">
+          <svg viewBox="0 0 24 24" fill="currentColor">
+            <path d="M12 3C7.58 3 4 4.79 4 7v10c0 2.21 3.58 4 8 4s8-1.79 8-4V7c0-2.21-3.58-4-8-4zm6 14c0 .5-2.13 2-6 2s-6-1.5-6-2v-2.23c1.61.78 3.72 1.23 6 1.23s4.39-.45 6-1.23V17zm0-5c0 .5-2.13 2-6 2s-6-1.5-6-2V9.77C7.61 10.55 9.72 11 12 11s4.39-.45 6-1.23V12zm-6-3c-3.87 0-6-1.5-6-2s2.13-2 6-2 6 1.5 6 2-2.13 2-6 2z"/>
+          </svg>
+          <span data-i18n="ui.tabDatabase">Database</span>
+        </button>
+        <div class="nav-separator"><span data-i18n="ui.separatorCapabilities">Capacités</span></div>
+        <button class="nav-tab" data-tab="skills" title="Skills" data-i18n-title="ui.tooltipSkills">
+          <svg viewBox="0 0 24 24" fill="currentColor">
+            <path d="M19 9l1.25-2.75L23 5l-2.75-1.25L19 1l-1.25 2.75L15 5l2.75 1.25L19 9zm-7.5.5L9 4 6.5 9.5 1 12l5.5 2.5L9 20l2.5-5.5L17 12l-5.5-2.5zM19 15l-1.25 2.75L15 19l2.75 1.25L19 23l1.25-2.75L23 19l-2.75-1.25L19 15z"/>
+          </svg>
+          <span data-i18n="ui.tabSkills">Skills</span>
+        </button>
+        <button class="nav-tab" data-tab="agents" title="Agents" data-i18n-title="ui.tooltipAgents">
+          <svg viewBox="0 0 24 24" fill="currentColor">
+            <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zM8 17.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5zM9.5 8c0-1.38 1.12-2.5 2.5-2.5s2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5S9.5 9.38 9.5 8zm6.5 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/>
+          </svg>
+          <span data-i18n="ui.tabAgents">Agents</span>
+        </button>
+        <button class="nav-tab" data-tab="plugins" title="Plugins" data-i18n-title="ui.tooltipPlugins" role="tab" aria-selected="false">
+          <svg viewBox="0 0 24 24" fill="currentColor">
+            <path d="M20.5 11H19V7c0-1.1-.9-2-2-2h-4V3.5C13 2.12 11.88 1 10.5 1S8 2.12 8 3.5V5H4c-1.1 0-1.99.9-1.99 2v3.8H3.5c1.49 0 2.7 1.21 2.7 2.7s-1.21 2.7-2.7 2.7H2V20c0 1.1.9 2 2 2h3.8v-1.5c0-1.49 1.21-2.7 2.7-2.7 1.49 0 2.7 1.21 2.7 2.7V22H17c1.1 0 2-.9 2-2v-4h1.5c1.38 0 2.5-1.12 2.5-2.5S21.88 11 20.5 11z"/>
+          </svg>
+          <span data-i18n="ui.tabPlugins">Plugins</span>
+        </button>
+        <button class="nav-tab" data-tab="mcp" title="MCP" data-i18n-title="ui.tooltipMcp">
+          <svg viewBox="0 0 24 24" fill="currentColor">
+            <path d="M17 16l-4-4V8.82C14.16 8.4 15 7.3 15 6c0-1.66-1.34-3-3-3S9 4.34 9 6c0 1.3.84 2.4 2 2.82V12l-4 4H3v5h5v-3.05l4-4.2 4 4.2V21h5v-5h-4z"/>
+          </svg>
+          <span data-i18n="ui.tabMcp">MCP</span>
+        </button>
+        <button class="nav-tab" data-tab="workflows" title="Workflows" data-i18n-title="ui.tooltipWorkflows">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="2" y="3" width="6" height="6" rx="1"/><rect x="16" y="3" width="6" height="6" rx="1"/>
+            <rect x="9" y="15" width="6" height="6" rx="1"/>
+            <path d="M5 9v3a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V9"/><path d="M12 12v3"/>
+          </svg>
+          <span data-i18n="ui.tabWorkflows">Workflows</span>
+        </button>
+        <div class="nav-separator"><span data-i18n="ui.separatorSystem">Système</span></div>
         <button class="nav-tab" data-tab="errorlog" title="Error Log" data-i18n-title="ui.tooltipErrorLog" role="tab" aria-selected="false">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
@@ -239,7 +239,6 @@
           </svg>
           <span data-i18n="connectivity.tabTitle">Connectivity</span>
         </button>
-        <!-- More tabs button (shown only when there are hidden tabs) -->
         <div class="nav-separator nav-separator--bare" id="nav-separator-more" style="display:none"></div>
         <button class="nav-tab more-tabs-btn" id="btn-more-tabs" title="Plus" style="display:none" role="tab" aria-haspopup="true">
           <svg viewBox="0 0 24 24" fill="currentColor" width="18" height="18">

--- a/renderer.js
+++ b/renderer.js
@@ -3515,7 +3515,9 @@ document.querySelectorAll('.nav-tab[data-tab]').forEach(tab => {
 });
 
 // ========== PINNED TABS SYSTEM ==========
-const _ALL_TABS_ORDER = ['claude', 'git', 'database', 'mcp', 'plugins', 'skills', 'agents', 'workflows', 'tasks', 'control-tower', 'dashboard', 'timetracking', 'session-replay', 'memory', 'workspace', 'errorlog', 'connectivity'];
+// Canonical order — must mirror the grouping in index.html, since the groups
+// carry meaning (whether the project tab drives the screen).
+const _ALL_TABS_ORDER = ['claude', 'git', 'dashboard', 'session-replay', 'tasks', 'control-tower', 'workspace', 'memory', 'timetracking', 'database', 'skills', 'agents', 'plugins', 'mcp', 'workflows', 'errorlog', 'connectivity'];
 
 function applyPinnedTabs() {
   const pinned = settingsState.get().pinnedTabs || _ALL_TABS_ORDER;
@@ -3594,17 +3596,61 @@ function _unpinTab(tabId) {
 }
 
 // ── Sidebar drag & drop ──────────────────────────────────────────────
+/**
+ * The separator a tab currently sits under, i.e. its group.
+ * @param {HTMLElement} tab
+ * @returns {HTMLElement|null}
+ */
+// Tabs whose position is not user-modifiable: Claude heads its group.
+const _FIXED_TABS = new Set(['claude']);
+
+function _groupOf(tab) {
+  let el = tab.previousElementSibling;
+  while (el && !el.classList.contains('nav-separator')) el = el.previousElementSibling;
+  return el;
+}
+
+/**
+ * Restore a saved order *within each group*.
+ *
+ * The previous version re-inserted every tab before the trailing "more"
+ * separator, which flattened all the groups the moment a single tab had been
+ * dragged. The groups say whether the project tab drives the screen, so they
+ * have to survive reordering.
+ */
 function _applyTabsOrder() {
   const order = settingsState.get().tabsOrder;
   if (!order || !order.length) return;
   const nav = document.querySelector('.nav-tabs');
-  const moreSep = document.getElementById('nav-separator-more');
-  if (!nav || !moreSep) return;
-  // Re-insert tabs in saved order, before the "more" separator
-  order.slice().reverse().forEach(tabId => {
+  if (!nav) return;
+
+  // Group each saved id by the separator its tab belongs to, then re-insert
+  // bottom-up inside that group only.
+  const byGroup = new Map();
+  for (const tabId of order) {
     const tab = nav.querySelector(`.nav-tab[data-tab="${tabId}"]`);
-    if (tab) nav.insertBefore(tab, moreSep);
-  });
+    if (!tab) continue;
+    if (_FIXED_TABS.has(tabId)) continue;
+    const group = _groupOf(tab);
+    // A tab above the first separator has no group — it stays put.
+    if (!group) continue;
+    if (!byGroup.has(group)) byGroup.set(group, []);
+    byGroup.get(group).push(tab);
+  }
+
+  for (const [group, tabs] of byGroup) {
+    // Anchor after any fixed tab already pinned to the top of this group.
+    let anchor = group;
+    let next = anchor.nextElementSibling;
+    while (next && next.classList.contains('nav-tab') && _FIXED_TABS.has(next.dataset.tab)) {
+      anchor = next;
+      next = anchor.nextElementSibling;
+    }
+    for (const tab of tabs) {
+      anchor.after(tab);
+      anchor = tab;
+    }
+  }
 }
 
 function _saveTabsOrder() {
@@ -3620,6 +3666,10 @@ function _reorderTab(draggedId, targetId, position) {
   const dragged = nav.querySelector(`.nav-tab[data-tab="${draggedId}"]`);
   const target = nav.querySelector(`.nav-tab[data-tab="${targetId}"]`);
   if (!dragged || !target) return;
+  if (_FIXED_TABS.has(draggedId)) return;
+  // Reordering stays inside a group: a tab under "Project" describes a screen
+  // the project tab drives, so moving it elsewhere would make the label lie.
+  if (_groupOf(dragged) !== _groupOf(target)) return;
   if (position === 'after') {
     target.after(dragged);
   } else {
@@ -3638,6 +3688,15 @@ function _initSidebarDragDrop() {
   // Add drag handle on each tab
   nav.querySelectorAll('.nav-tab[data-tab]').forEach(tab => {
     if (tab.id === 'btn-more-tabs') return;
+    if (_FIXED_TABS.has(tab.dataset.tab)) {
+      // No handle, but keep its footprint so the icon stays aligned with the rest.
+      if (!tab.querySelector(".nav-tab-drag-handle")) {
+        const spacer = document.createElement("span");
+        spacer.className = "nav-tab-drag-handle nav-tab-drag-handle--fixed";
+        tab.prepend(spacer);
+      }
+      return;
+    }
     if (tab.querySelector('.nav-tab-drag-handle')) return; // already added
     const handle = document.createElement('span');
     handle.className = 'nav-tab-drag-handle';
@@ -3825,8 +3884,10 @@ function _buildMoreDropdown() {
   dropdown.innerHTML = unpinned.map(tabId => {
     const tab = document.querySelector(`.nav-tab[data-tab="${tabId}"]`);
     if (!tab) return '';
-    const svg = tab.querySelector('svg')?.outerHTML || '';
-    const label = tab.querySelector('span')?.textContent?.trim() || tabId;
+    // Direct children only: _initSidebarDragDrop() prepends a drag-handle span
+    // with its own svg, and querySelector('svg'/'span') was picking that up.
+    const svg = tab.querySelector(':scope > svg')?.outerHTML || '';
+    const label = tab.querySelector(':scope > span:not(.nav-tab-drag-handle)')?.textContent?.trim() || tabId;
     return `
       <button class="nav-tab" data-more-tab="${tabId}" role="menuitem">
         ${svg}

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -1026,8 +1026,6 @@
     "tabClaude": "Claude",
     "moreTabs": "More",
     "hiddenTabsCount": "{count} hidden",
-    "separatorTools": "Tools",
-    "separatorAI": "AI",
     "separatorExtensions": "Extensions",
     "tabPlugins": "Plugins",
     "tabSkills": "Skills",
@@ -1038,7 +1036,6 @@
     "tabDatabase": "Database",
     "tabGit": "Git",
     "separatorCloud": "Cloud",
-    "separatorAnalytics": "Analytics",
     "tabDashboard": "Dashboard",
     "tabTimeTracking": "Time Tracking",
     "tabSessionReplay": "Replay",
@@ -1081,7 +1078,11 @@
     "tooltipWorkspace": "Cross-project knowledge hubs",
     "tooltipConnectivity": "GitHub, remote access and cloud settings",
     "tooltipErrorLog": "Centralized error log with AI triage",
-    "tabErrorLog": "Error Log"
+    "tabErrorLog": "Error Log",
+    "separatorProject": "Project",
+    "separatorAllProjects": "All projects",
+    "separatorCapabilities": "Capabilities",
+    "separatorSystem": "System"
   },
   "memory": {
     "panelDescription": "Configure how Claude behaves in your projects. Global settings apply everywhere, project settings override them.",

--- a/src/renderer/i18n/locales/es.json
+++ b/src/renderer/i18n/locales/es.json
@@ -1023,8 +1023,6 @@
     "tabClaude": "Claude",
     "moreTabs": "Más",
     "hiddenTabsCount": "{count} ocultas",
-    "separatorTools": "Herramientas",
-    "separatorAI": "IA",
     "separatorExtensions": "Extensiones",
     "tabPlugins": "Plugins",
     "tabSkills": "Skills",
@@ -1035,7 +1033,6 @@
     "tabDatabase": "Base de datos",
     "tabGit": "Git",
     "separatorCloud": "Nube",
-    "separatorAnalytics": "Analíticas",
     "tabDashboard": "Panel de control",
     "tabTimeTracking": "Tiempo",
     "tabSessionReplay": "Replay",
@@ -1078,7 +1075,11 @@
     "tooltipWorkspace": "Hubs de conocimiento multi-proyecto",
     "tooltipConnectivity": "GitHub, acceso remoto y ajustes de nube",
     "tooltipErrorLog": "Registro de errores centralizado con triaje IA",
-    "tabErrorLog": "Errores"
+    "tabErrorLog": "Errores",
+    "separatorProject": "Proyecto",
+    "separatorAllProjects": "Todos los proyectos",
+    "separatorCapabilities": "Capacidades",
+    "separatorSystem": "Sistema"
   },
   "memory": {
     "panelDescription": "Configura como Claude se comporta en tus proyectos. Los ajustes globales aplican en todos lados, los de proyecto los reemplazan.",

--- a/src/renderer/i18n/locales/fr.json
+++ b/src/renderer/i18n/locales/fr.json
@@ -1121,8 +1121,6 @@
     "tabClaude": "Claude",
     "moreTabs": "Plus",
     "hiddenTabsCount": "{count} masqué(s)",
-    "separatorTools": "Outils",
-    "separatorAI": "AI",
     "separatorExtensions": "Extensions",
     "tabPlugins": "Plugins",
     "tabSkills": "Skills",
@@ -1133,7 +1131,6 @@
     "tabDatabase": "Base de données",
     "tabGit": "Git",
     "separatorCloud": "Cloud",
-    "separatorAnalytics": "Analytique",
     "tabDashboard": "Dashboard",
     "tabTimeTracking": "Suivi du temps",
     "tabSessionReplay": "Replay",
@@ -1176,7 +1173,11 @@
     "tooltipWorkspace": "Hubs de connaissances multi-projets",
     "tooltipConnectivity": "GitHub, accès distant et paramètres cloud",
     "tooltipErrorLog": "Journal d'erreurs centralisé avec triage IA",
-    "tabErrorLog": "Erreurs"
+    "tabErrorLog": "Erreurs",
+    "separatorProject": "Projet",
+    "separatorAllProjects": "Tous les projets",
+    "separatorCapabilities": "Capacités",
+    "separatorSystem": "Système"
   },
   "memory": {
     "panelDescription": "Configurez le comportement de Claude dans vos projets. Les reglages globaux s'appliquent partout, les reglages projet les remplacent.",

--- a/src/renderer/i18n/locales/id.json
+++ b/src/renderer/i18n/locales/id.json
@@ -1026,8 +1026,6 @@
     "tabClaude": "Claude",
     "moreTabs": "Lainnya",
     "hiddenTabsCount": "{count} tersembunyi",
-    "separatorTools": "Tool",
-    "separatorAI": "AI",
     "separatorExtensions": "Ekstensi",
     "tabPlugins": "Plugin",
     "tabSkills": "Skills",
@@ -1038,7 +1036,6 @@
     "tabDatabase": "Basis Data",
     "tabGit": "Git",
     "separatorCloud": "Cloud",
-    "separatorAnalytics": "Analitik",
     "tabDashboard": "Dasbor",
     "tabTimeTracking": "Pelacakan Waktu",
     "tabSessionReplay": "Replay",
@@ -1081,7 +1078,11 @@
     "tooltipWorkspace": "Pusat pengetahuan lintas proyek",
     "tooltipConnectivity": "Pengaturan GitHub, akses jarak jauh, dan cloud",
     "tooltipErrorLog": "Log kesalahan terpusat dengan triase AI",
-    "tabErrorLog": "Log Kesalahan"
+    "tabErrorLog": "Log Kesalahan",
+    "separatorProject": "Proyek",
+    "separatorAllProjects": "Semua proyek",
+    "separatorCapabilities": "Kemampuan",
+    "separatorSystem": "Sistem"
   },
   "memory": {
     "panelDescription": "Atur bagaimana Claude berperilaku dalam proyek Anda. Pengaturan global berlaku di mana saja, pengaturan proyek akan menimpanya.",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -1026,8 +1026,6 @@
     "tabClaude": "Claude",
     "moreTabs": "更多",
     "hiddenTabsCount": "{count}隐藏",
-    "separatorTools": "工具",
-    "separatorAI": "人工智能",
     "separatorExtensions": "扩展",
     "tabPlugins": "插件",
     "tabSkills": "技能",
@@ -1038,7 +1036,6 @@
     "tabDatabase": "数据库",
     "tabGit": "Git",
     "separatorCloud": "云",
-    "separatorAnalytics": "分析",
     "tabDashboard": "仪表板",
     "tabTimeTracking": "时间追踪",
     "tabSessionReplay": "重播",
@@ -1081,7 +1078,11 @@
     "tooltipWorkspace": "跨项目知识中心",
     "tooltipConnectivity": "GitHub、远程访问和云设置",
     "tooltipErrorLog": "通过 AI 分类进行集中式错误日志",
-    "tabErrorLog": "错误日志"
+    "tabErrorLog": "错误日志",
+    "separatorProject": "项目",
+    "separatorAllProjects": "所有项目",
+    "separatorCapabilities": "能力",
+    "separatorSystem": "系统"
   },
   "memory": {
     "panelDescription": "配置 Claude 在您的项目中的行为方式。全局设置适用于所有地方，项目设置会覆盖它们。",

--- a/src/renderer/state/settings.state.js
+++ b/src/renderer/state/settings.state.js
@@ -68,7 +68,9 @@ const defaultSettings = {
   agentColors: {}, // Custom colors per tool/agent name: { 'Grep': '#ff0000', 'my-agent': '#00ff00' }
   enableFollowupSuggestions: true, // Show AI-generated follow-up suggestion chips after Claude responds (uses Haiku)
   enhancePrompts: false, // Opt-in: reformulate prompts via Haiku for better prompt engineering before sending
-  pinnedTabs: ['claude', 'git', 'database', 'mcp', 'plugins', 'skills', 'agents', 'workflows', 'tasks', 'control-tower', 'dashboard', 'timetracking', 'session-replay', 'memory', 'connectivity'], // Pinned sidebar tabs (rest go to More menu)
+  // Every tab is pinned by default: the grouped sidebar fits without overflow,
+  // so the More menu is now opt-in rather than the default state.
+  pinnedTabs: ['claude', 'git', 'dashboard', 'session-replay', 'tasks', 'control-tower', 'workspace', 'memory', 'timetracking', 'database', 'skills', 'agents', 'plugins', 'mcp', 'workflows', 'errorlog', 'connectivity'],
   activeTab: 'claude', // Last active sidebar tab (restored on restart)
   openProjectIds: [], // Projects with a tab in the project bar, in tab order (restored on restart)
   tabsOrder: null, // null = canonical order, otherwise array of all tabIds in custom order
@@ -141,6 +143,14 @@ function _migrateSettings(saved) {
   }
   if (saved.activeTab === 'cloud-panel') {
     saved.activeTab = 'connectivity';
+  }
+
+  // Workspaces and Error Log were never in the default pinned set, so nobody
+  // could have deliberately unpinned them. The grouped sidebar has room now.
+  if (Array.isArray(saved.pinnedTabs)) {
+    for (const id of ['workspace', 'errorlog']) {
+      if (!saved.pinnedTabs.includes(id)) saved.pinnedTabs.push(id);
+    }
   }
 }
 

--- a/styles/layout.css
+++ b/styles/layout.css
@@ -567,7 +567,7 @@ body.platform-darwin .titlebar-drag {
 }
 
 .nav-separator {
-  padding: 10px 14px 4px;
+  padding: 6px 14px 2px;
   font-size: 10px;
   font-weight: 600;
   text-transform: uppercase;
@@ -577,7 +577,7 @@ body.platform-darwin .titlebar-drag {
 }
 
 .nav-separator--bare {
-  padding: 8px 14px 0;
+  padding: 5px 14px 0;
   border-top: 1px solid var(--border-color);
   margin-top: 4px;
 }
@@ -586,7 +586,7 @@ body.platform-darwin .titlebar-drag {
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 8px 14px;
+  padding: 7px 14px 7px 8px;
   border: none;
   background: transparent;
   color: var(--text-secondary);
@@ -598,15 +598,15 @@ body.platform-darwin .titlebar-drag {
   text-align: left;
 }
 
-.nav-tab svg {
+.nav-tab > svg {
   width: 18px;
   height: 18px;
   flex-shrink: 0;
   opacity: 0.7;
 }
 
-.nav-tab:hover svg,
-.nav-tab.active svg {
+.nav-tab:hover > svg,
+.nav-tab.active > svg {
   opacity: 1;
 }
 
@@ -632,7 +632,7 @@ body.platform-darwin .titlebar-drag {
   border-radius: 0 3px 3px 0;
 }
 
-.sidebar.collapsed .nav-tab.active::before {
+.sidebar.collapsed .nav-tabs .nav-tab.active::before {
   left: 0;
   right: 0;
   top: auto;
@@ -682,7 +682,9 @@ body.platform-darwin .titlebar-drag {
   min-width: 56px;
 }
 
-.sidebar.collapsed .nav-tab span {
+/* Scoped to the rail: the More dropdown is a sibling of .nav-tabs, and these
+   rules used to blank out its labels whenever the sidebar was collapsed. */
+.sidebar.collapsed .nav-tabs .nav-tab span {
   display: none;
 }
 
@@ -709,14 +711,14 @@ body.platform-darwin .titlebar-drag {
   padding: 0;
 }
 
-.sidebar.collapsed .nav-tab {
+.sidebar.collapsed .nav-tabs .nav-tab {
   justify-content: center;
   padding: 10px;
   position: relative;
 }
 
 /* Tooltip on hover when sidebar is collapsed */
-.sidebar.collapsed .nav-tab[data-tooltip]::after,
+.sidebar.collapsed .nav-tabs .nav-tab[data-tooltip]::after,
 .sidebar.collapsed .settings-btn[data-tooltip]::after,
 .sidebar.collapsed .notification-toggle[data-tooltip]::after {
   content: attr(data-tooltip);
@@ -738,14 +740,22 @@ body.platform-darwin .titlebar-drag {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
 }
 
-.sidebar.collapsed .nav-tab[data-tooltip]:hover::after,
+.sidebar.collapsed .nav-tabs .nav-tab[data-tooltip]:hover::after,
 .sidebar.collapsed .settings-btn[data-tooltip]:hover::after,
 .sidebar.collapsed .notification-toggle[data-tooltip]:hover::after {
   opacity: 1;
 }
 
+/* 56px cannot hold the footer row — stack it back up when collapsed. */
 .sidebar.collapsed .sidebar-footer {
   padding: 8px;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.sidebar.collapsed .sidebar-footer .version {
+  margin-left: 0;
+  padding-right: 0;
 }
 
 .sidebar.collapsed .notification-toggle span,
@@ -779,6 +789,13 @@ body.platform-darwin .titlebar-drag {
   flex-shrink: 0;
 }
 
+/* Fixed tabs reserve the handle box without offering the affordance. */
+.nav-tab-drag-handle--fixed {
+  width: 12px;
+  height: 18px;
+  pointer-events: none;
+}
+
 .nav-tab:hover .nav-tab-drag-handle {
   opacity: 0.5;
 }
@@ -788,7 +805,7 @@ body.platform-darwin .titlebar-drag {
   color: var(--accent);
 }
 
-.sidebar.collapsed .nav-tab-drag-handle {
+.sidebar.collapsed .nav-tabs .nav-tab-drag-handle {
   display: none;
 }
 
@@ -885,11 +902,32 @@ body.platform-darwin .titlebar-drag {
 
 .sidebar-footer {
   margin-top: auto;
-  padding: 12px 16px;
+  padding: 6px 10px;
   border-top: 1px solid var(--border-color);
   display: flex;
-  flex-direction: column;
-  gap: 8px;
+  flex-direction: row;
+  align-items: center;
+  gap: 4px;
+}
+
+/* Icon-only in the footer row; the label lives in the tooltip. */
+.sidebar-footer .notification-toggle span,
+.sidebar-footer .settings-btn span {
+  display: none;
+}
+
+.sidebar-footer .notification-toggle,
+.sidebar-footer .settings-btn {
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.sidebar-footer .version {
+  margin-left: auto;
+  padding-right: 2px;
 }
 
 .notification-toggle {
@@ -1098,8 +1136,10 @@ body.platform-darwin .titlebar-drag {
     --projects-panel-width: 400px;
   }
 
+  /* A wide screen is not a tall one: take the extra room horizontally only.
+     The old 14px vertical padding added 238px to a nav that already overflowed. */
   .nav-tab {
-    padding: 14px 18px;
+    padding: 8px 18px 8px 10px;
   }
 
   .panel-header {


### PR DESCRIPTION
## The problem

The sidebar needed **1075px**. The app's default window gives it 864px.

| | |
|---|---:|
| 17 rows × 46px | 782 px |
| Footer (4 stacked elements) | 166 px |
| Separators | 87 px |
| **Total** | **1075 px** |

So the *pinned tabs* setting was never really a feature — it was a workaround asking you to decide, by hand, which seven entries to hide. Workspaces and Error Log were not even in the default set: they shipped hidden.

Most of that height carried no information. A `@media (min-width: 1920px)` rule inflated rows to `padding: 14px 18px` — **28px of padding around an 18px icon**, and a wide screen was getting the tallest rows in the app. A wide screen is not a tall one; taking the extra room horizontally instead gives back 238px. The footer stacked three full-width rows for two toggles and a version string; on a single icon row it drops from 166px to 43px.

**737px, no destination removed, no overflow.** Every tab is pinned by default now, and a migration adds Workspaces and Error Log to saved settings — nobody could have deliberately unpinned what was never shown.

![Sidebar](https://raw.githubusercontent.com/bleleve/claude-terminal/assets/project-tab-navigation/shots/06-sidebar-grouped.png)

## The taxonomy was the other half

`AI` held six entries — a third of the menu — and mixed *installing capabilities* with *running agents*. `Tools` mixed a git workflow, a data browser and an MCP capability. The last group had no label at all and collected whatever was left over.

Groups now answer one question: **does the project tab drive this screen?**

| Group | Screens |
|---|---|
| **Project** | Claude, Git, Dashboard, Replay, Tasks |
| **All projects** | Control Tower, Workspaces, Memory, Time Tracking, Database |
| **Capabilities** | Skills, Agents, Plugins, MCP, Workflows |
| **System** | Error Log, Connectivity |

That is exactly the rule #86 introduced for the project bar, and which is now on `main`. It was invisible — you discovered it by navigating. The menu now states it.

## Groups have to survive customisation

`_applyTabsOrder()` re-inserted every tab before the trailing separator, which **flattened all four groups the moment one tab had been dragged**. Harmless when groups were decorative; not when they carry meaning.

Reordering is now scoped to a group, a saved order is replayed inside each group, and Claude's position is fixed. Verified against a custom order saved before the change, deliberately scrambled across groups: every tab lands in its right group with the relative order preserved.

## Three bugs found on the way

All three are visible in the screenshots above and below.

- **The More dropdown showed drag-handle glyphs instead of icons**, and fell back to tab ids for labels. `_buildMoreDropdown()` ran `querySelector('svg'|'span')` on a tab that `_initSidebarDragDrop()` had prepended a handle to, so it copied the handle. Direct children only now.
- **Its labels vanished entirely when the sidebar was collapsed.** The dropdown is a sibling of `.nav-tabs` *inside* `.sidebar`, so `.sidebar.collapsed .nav-tab span { display: none }` applied to it. Those rules are scoped to the rail.
- **Skills used the exact same gear as Settings.**

![Collapsed rail](https://raw.githubusercontent.com/bleleve/claude-terminal/assets/project-tab-navigation/shots/07-sidebar-collapsed.png)

One more, found while aligning icons: `.nav-tab svg { width: 18px }` also matched the drag handle's SVG, overriding its own 12px and widening the gutter by 6px on every row. Scoped to `> svg`.

## Testing

- `npm test` — 2142 tests, all passing
- `node scripts/check-i18n.js` — 5 locales at 100%
- Driven through CDP: group membership, height, collapsed rail, More dropdown in both states, custom-order migration, icon alignment across all rows.

Not covered: the drag gesture end to end — Chromium ignores synthetic `DragEvent`s, `dragstart` never fires. The grouping predicate the guard uses was verified directly on 7 tab pairs (same group → allowed, different groups → refused), but the mouse gesture itself needs a human.

Screenshots use throwaway projects in an isolated `HOME`; no real data.
