### PR TITLE
fix(usage): build the limit bars from the API instead of a hardcoded Sonnet

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,33 +20,12 @@
     </div>
     <!-- Usage Display -->
     <div class="titlebar-usage" id="titlebar-usage" data-i18n-title="common.refresh">
-      <div class="usage-item" data-type="session">
-        <div class="usage-header">
-          <span class="usage-label" data-i18n="ui.session">Session</span>
-          <span class="usage-value"><span class="usage-percent" id="usage-percent-session">--</span><span class="usage-reset" id="usage-reset-session"></span></span>
-        </div>
-        <div class="usage-bar-container">
-          <div class="usage-bar" id="usage-bar-session" style="width: 0%"></div>
-        </div>
-      </div>
-      <div class="usage-item" data-type="weekly">
-        <div class="usage-header">
-          <span class="usage-label" data-i18n="ui.weekly">Weekly</span>
-          <span class="usage-value"><span class="usage-percent" id="usage-percent-weekly">--</span><span class="usage-reset" id="usage-reset-weekly"></span></span>
-        </div>
-        <div class="usage-bar-container">
-          <div class="usage-bar" id="usage-bar-weekly" style="width: 0%"></div>
-        </div>
-      </div>
-      <div class="usage-item" data-type="sonnet">
-        <div class="usage-header">
-          <span class="usage-label" data-i18n="ui.sonnet">Sonnet</span>
-          <span class="usage-value"><span class="usage-percent" id="usage-percent-sonnet">--</span><span class="usage-reset" id="usage-reset-sonnet"></span></span>
-        </div>
-        <div class="usage-bar-container">
-          <div class="usage-bar" id="usage-bar-sonnet" style="width: 0%"></div>
-        </div>
-      </div>
+      <!--
+        The plan-limit bars are built by the renderer, not written here: which
+        buckets exist is the API's call, so the markup follows the response
+        instead of hardcoding one bar per limit the API happened to expose the
+        day it was written. Bars are inserted before the "extra" item below.
+      -->
       <div class="usage-item" data-type="extra" id="usage-item-extra" style="display: none;">
         <div class="usage-header">
           <span class="usage-label" data-i18n="ui.extra">Extra</span>

--- a/renderer.js
+++ b/renderer.js
@@ -6033,32 +6033,117 @@ api.app.getVersion().then(version => {
 }).catch(() => {});
 
 // ========== USAGE MONITOR ==========
-let usageResetTargets = { session: null, weekly: null, sonnet: null };
+// Which limit buckets exist is the API's call (see UsageService.readBuckets), so
+// the bars are built from whatever it returns rather than declared in the HTML.
+// The two plan-wide windows are the only ones assumed to always be there, and
+// only as the placeholder shown before the first response lands.
+const PLACEHOLDER_USAGE_BUCKETS = [
+  { id: 'session', type: 'session', label: null, labelKey: 'ui.session', utilization: null, resetsAt: null },
+  { id: 'weekly',  type: 'weekly',  label: null, labelKey: 'ui.weekly',  utilization: null, resetsAt: null }
+];
+
+/** bucket id -> its rendered nodes */
+const usageBucketEls = new Map();
+/** bucket id -> reset Date, for the once-a-minute countdown */
+const usageResetTargets = new Map();
 let usageResetInterval = null;
 
 const usageElements = {
   container: document.getElementById('titlebar-usage'),
-  session: {
-    bar: document.getElementById('usage-bar-session'),
-    percent: document.getElementById('usage-percent-session'),
-    reset: document.getElementById('usage-reset-session')
-  },
-  weekly: {
-    bar: document.getElementById('usage-bar-weekly'),
-    percent: document.getElementById('usage-percent-weekly'),
-    reset: document.getElementById('usage-reset-weekly')
-  },
-  sonnet: {
-    bar: document.getElementById('usage-bar-sonnet'),
-    percent: document.getElementById('usage-percent-sonnet'),
-    reset: document.getElementById('usage-reset-sonnet')
-  },
   extra: {
     item: document.getElementById('usage-item-extra'),
     bar: document.getElementById('usage-bar-extra'),
     percent: document.getElementById('usage-percent-extra')
   }
 };
+
+/**
+ * Build the nodes for one usage bucket.
+ *
+ * A scoped bucket's name is whatever the API called the model, so it is set as
+ * text and never as markup. Plan-wide buckets keep their data-i18n attribute so
+ * a language switch still retranslates them in place.
+ *
+ * @param {Object} bucket
+ * @returns {{item: Element, label: Element, bar: Element, percent: Element, reset: Element}}
+ */
+function createUsageBucketEl(bucket) {
+  const item = document.createElement('div');
+  item.className = 'usage-item';
+  item.dataset.type = bucket.type;
+
+  const header = document.createElement('div');
+  header.className = 'usage-header';
+
+  const label = document.createElement('span');
+  label.className = 'usage-label';
+  if (bucket.labelKey) label.dataset.i18n = bucket.labelKey;
+
+  const value = document.createElement('span');
+  value.className = 'usage-value';
+  const percent = document.createElement('span');
+  percent.className = 'usage-percent';
+  percent.textContent = '--';
+  const reset = document.createElement('span');
+  reset.className = 'usage-reset';
+  value.append(percent, reset);
+
+  header.append(label, value);
+
+  const barContainer = document.createElement('div');
+  barContainer.className = 'usage-bar-container';
+  const bar = document.createElement('div');
+  bar.className = 'usage-bar';
+  bar.style.width = '0%';
+  barContainer.appendChild(bar);
+
+  item.append(header, barContainer);
+  return { item, label, bar, percent, reset };
+}
+
+/**
+ * Reconcile the rendered bars against a bucket list, keyed by bucket id, so a
+ * limit the API stops sending takes its bar with it instead of freezing on its
+ * last value.
+ *
+ * @param {Array<Object>} buckets
+ */
+function renderUsageBuckets(buckets) {
+  const { container, extra } = usageElements;
+  if (!container) return;
+
+  const seen = new Set();
+
+  for (const bucket of buckets) {
+    seen.add(bucket.id);
+    let els = usageBucketEls.get(bucket.id);
+    if (!els) {
+      els = createUsageBucketEl(bucket);
+      usageBucketEls.set(bucket.id, els);
+    }
+    // Re-inserting an existing node moves it, so walking the list in order also
+    // reorders the bars when the API sends its limits in a different order.
+    // Always before the extra-usage item, which is not a plan limit.
+    container.insertBefore(els.item, extra.item || null);
+
+    els.label.textContent = bucket.labelKey ? t(bucket.labelKey) : bucket.label;
+    updateUsageBar(els, bucket.utilization);
+
+    const resetsAt = bucket.resetsAt ? new Date(bucket.resetsAt) : null;
+    if (resetsAt && !isNaN(resetsAt.getTime())) {
+      usageResetTargets.set(bucket.id, resetsAt);
+    } else {
+      usageResetTargets.delete(bucket.id);
+    }
+  }
+
+  for (const [id, els] of usageBucketEls) {
+    if (seen.has(id)) continue;
+    els.item.remove();
+    usageBucketEls.delete(id);
+    usageResetTargets.delete(id);
+  }
+}
 
 /**
  * Update a single usage bar
@@ -6129,31 +6214,20 @@ function updateUsageDisplay(usageData) {
 
   usageElements.container.classList.remove('loading');
 
-  if (!usageData || !usageData.data) {
-    updateUsageBar(usageElements.session, null);
-    updateUsageBar(usageElements.weekly, null);
-    updateUsageBar(usageElements.sonnet, null);
-    updateResetEl(usageElements.session.reset, null);
-    updateResetEl(usageElements.weekly.reset, null);
-    updateResetEl(usageElements.sonnet.reset, null);
+  const buckets = usageData?.data?.buckets;
+  if (!Array.isArray(buckets)) {
+    // No usable payload: keep the plan-wide bars on screen, blanked, rather
+    // than collapsing the titlebar to nothing.
+    renderUsageBuckets(PLACEHOLDER_USAGE_BUCKETS);
     if (usageElements.extra.item) usageElements.extra.item.style.display = 'none';
     return;
   }
 
-  const data = usageData.data;
-
-  // Update all three usage bars
-  updateUsageBar(usageElements.session, data.session);
-  updateUsageBar(usageElements.weekly, data.weekly);
-  updateUsageBar(usageElements.sonnet, data.sonnet);
+  renderUsageBuckets(buckets);
 
   // Extra usage (paid tokens beyond plan) — show only when non-zero
-  updateExtraUsage(data.extraUsage);
+  updateExtraUsage(usageData.data.extraUsage);
 
-  // Set reset targets for each category
-  usageResetTargets.session = data.sessionReset ? new Date(data.sessionReset) : null;
-  usageResetTargets.weekly = data.weeklyReset ? new Date(data.weeklyReset) : null;
-  usageResetTargets.sonnet = data.sonnetReset ? new Date(data.sonnetReset) : null;
   startResetCountdown();
 }
 
@@ -6165,9 +6239,9 @@ function startResetCountdown() {
 }
 
 function updateAllResets() {
-  updateResetEl(usageElements.session.reset, usageResetTargets.session);
-  updateResetEl(usageElements.weekly.reset, usageResetTargets.weekly);
-  updateResetEl(usageElements.sonnet.reset, usageResetTargets.sonnet);
+  for (const [id, els] of usageBucketEls) {
+    updateResetEl(els.reset, usageResetTargets.get(id) || null);
+  }
 }
 
 function updateResetEl(el, target) {
@@ -6213,21 +6287,20 @@ async function refreshUsageDisplay() {
         : '';
     } else {
       usageElements.container.classList.remove('loading', 'stale');
-      updateUsageBar(usageElements.session, null);
-      updateUsageBar(usageElements.weekly, null);
-      updateUsageBar(usageElements.sonnet, null);
+      renderUsageBuckets(PLACEHOLDER_USAGE_BUCKETS);
     }
   } catch (error) {
     usageElements.container.classList.remove('loading');
-    updateUsageBar(usageElements.session, null);
-    updateUsageBar(usageElements.weekly, null);
-    updateUsageBar(usageElements.sonnet, null);
+    renderUsageBuckets(PLACEHOLDER_USAGE_BUCKETS);
     console.error('Usage refresh error:', error);
   }
 }
 
 // Initialize usage monitor
 if (usageElements.container) {
+  // Bars the API has not described yet, so the titlebar is not empty on boot.
+  renderUsageBuckets(PLACEHOLDER_USAGE_BUCKETS);
+
   // Click to refresh
   usageElements.container.addEventListener('click', () => {
     refreshUsageDisplay();

--- a/src/main/services/UsageService.js
+++ b/src/main/services/UsageService.js
@@ -65,6 +65,91 @@ function readOAuthToken() {
 }
 
 /**
+ * Fallback for a response with no `limits` array — the shape the API served
+ * before it described its own buckets. Only the two plan-wide windows can be
+ * recovered this way: a scoped limit is unreadable without `limits`, because
+ * the root key holding its number is a codename rather than a stable name.
+ *
+ * @param {Object} json - Raw API response
+ * @returns {Array<Object>} Bucket list, possibly empty
+ */
+function legacyBuckets(json) {
+  const out = [];
+  if (typeof json?.five_hour?.utilization === 'number') {
+    out.push({
+      id: 'session', type: 'session', label: null, labelKey: 'ui.session',
+      utilization: json.five_hour.utilization, resetsAt: json.five_hour.resets_at ?? null
+    });
+  }
+  if (typeof json?.seven_day?.utilization === 'number') {
+    out.push({
+      id: 'weekly', type: 'weekly', label: null, labelKey: 'ui.weekly',
+      utilization: json.seven_day.utilization, resetsAt: json.seven_day.resets_at ?? null
+    });
+  }
+  return out;
+}
+
+/**
+ * The usage buckets the titlebar renders, read from the API's `limits` array.
+ *
+ * The response used to carry one fixed key per bucket — `five_hour`,
+ * `seven_day`, `seven_day_sonnet`. The per-model key has been null since the
+ * scoped weekly limit moved off Sonnet, and the root key that now carries that
+ * number is a rotating codename (`nimbus_quill` at the time of writing), so
+ * neither one is readable. `limits` is the part of the response that survives a
+ * model rename: the server states which limits exist and names the model each
+ * scoped one applies to, so the label is data instead of a string we have to
+ * ship a release to change.
+ *
+ * Which buckets come back is the server's call, not ours — a plan may expose
+ * one scoped limit, several, or none. Only the two plan-wide windows are
+ * assumed to be always present, and even those go through the same list.
+ *
+ * `labelKey` is set for the plan-wide buckets, whose names are ours to
+ * translate; `label` for scoped ones, whose name only the server knows.
+ *
+ * @param {Object} json - Raw API response
+ * @returns {Array<{id: string, type: string, label: string|null, labelKey: string|null,
+ *                  utilization: number, resetsAt: string|null}>}
+ */
+function readBuckets(json) {
+  if (!Array.isArray(json?.limits)) return legacyBuckets(json);
+
+  const buckets = [];
+  for (const limit of json.limits) {
+    if (!limit || typeof limit.percent !== 'number') continue;
+    const resetsAt = limit.resets_at ?? null;
+
+    if (limit.kind === 'session') {
+      buckets.push({
+        id: 'session', type: 'session', label: null, labelKey: 'ui.session',
+        utilization: limit.percent, resetsAt
+      });
+    } else if (limit.kind === 'weekly_all') {
+      buckets.push({
+        id: 'weekly', type: 'weekly', label: null, labelKey: 'ui.weekly',
+        utilization: limit.percent, resetsAt
+      });
+    } else {
+      // Every other kind is scoped to something. We can only render one the
+      // server named, so an unlabelled bucket is dropped rather than shown as
+      // an anonymous bar.
+      const label = limit.scope?.model?.display_name;
+      if (!label) continue;
+      buckets.push({
+        id: `scoped:${label}`, type: 'scoped', label, labelKey: null,
+        utilization: limit.percent, resetsAt
+      });
+    }
+  }
+
+  // An empty `limits` (or one we could make nothing of) is likelier to be a
+  // shape we don't understand yet than a plan with no limits at all.
+  return buckets.length ? buckets : legacyBuckets(json);
+}
+
+/**
  * Fetch usage data from the OAuth API
  * @returns {Promise<Object>} Parsed usage data in standard format
  */
@@ -91,13 +176,7 @@ function fetchUsageFromAPI(token) {
           const json = JSON.parse(body);
           resolve({
             timestamp: new Date().toISOString(),
-            session: json.five_hour?.utilization ?? null,
-            weekly: json.seven_day?.utilization ?? null,
-            sonnet: json.seven_day_sonnet?.utilization ?? null,
-            opus: json.seven_day_opus?.utilization ?? null,
-            sessionReset: json.five_hour?.resets_at ?? null,
-            weeklyReset: json.seven_day?.resets_at ?? null,
-            sonnetReset: json.seven_day_sonnet?.resets_at ?? null,
+            buckets: readBuckets(json),
             extraUsage: json.extra_usage ?? null,
             _source: 'api'
           });
@@ -250,8 +329,8 @@ function onUpdate(cb) {
 
 /**
  * Register a callback fired when a usage threshold is crossed.
- * Invoked at most once per reset window per scope (session / weekly).
- * @param {Function} cb - cb({ scope, utilization, resetsAt })
+ * Invoked at most once per reset window per bucket.
+ * @param {Function} cb - cb({ scope, label, utilization, resetsAt })
  */
 function onLimit(cb) {
   _onLimitCallback = cb;
@@ -260,25 +339,29 @@ function onLimit(cb) {
 const LIMIT_THRESHOLD = 0.95; // 95%
 
 function _maybeNotifyLimit(data) {
-  if (!_onLimitCallback || !data) return;
-  // Pick the most-pressured bucket
-  const candidates = [
-    { scope: 'session', utilization: data.session, resetsAt: data.sessionReset },
-    { scope: 'weekly',  utilization: data.weekly,  resetsAt: data.weeklyReset  },
-    { scope: 'sonnet',  utilization: data.sonnet,  resetsAt: data.sonnetReset  },
-  ].filter(c => typeof c.utilization === 'number' && c.utilization >= LIMIT_THRESHOLD);
+  if (!_onLimitCallback || !Array.isArray(data?.buckets)) return;
+  // Pick the most-pressured bucket, whichever ones the API sent
+  const candidates = data.buckets
+    .filter(b => typeof b.utilization === 'number' && b.utilization >= LIMIT_THRESHOLD)
+    .sort((a, b) => b.utilization - a.utilization);
   if (!candidates.length) return;
-  // Most utilized first
-  candidates.sort((a, b) => b.utilization - a.utilization);
   const top = candidates[0];
   // De-dupe per reset window
-  const key = `${top.scope}:${top.resetsAt || ''}`;
+  const key = `${top.id}:${top.resetsAt || ''}`;
   if (key === _lastLimitNotifiedReset) return;
   _lastLimitNotifiedReset = key;
-  try { _onLimitCallback(top); } catch (e) { console.error('[Usage] onLimit cb threw:', e.message); }
+  try {
+    _onLimitCallback({
+      scope: top.id,
+      label: top.label,
+      utilization: top.utilization,
+      resetsAt: top.resetsAt
+    });
+  } catch (e) { console.error('[Usage] onLimit cb threw:', e.message); }
 }
 
 module.exports = {
+  readBuckets,
   startPeriodicFetch,
   stopPeriodicFetch,
   getUsageData,

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -1054,7 +1054,6 @@
     "stashes": "Stashes",
     "minimize": "Minimize",
     "maximize": "Maximize",
-    "sonnet": "Sonnet",
     "skillsMarketplace": "Marketplace",
     "sidebarCustomize": "Customize sidebar",
     "sidebarDragHint": "Drag to reorder - Right-click a tab to hide it quickly",

--- a/src/renderer/i18n/locales/es.json
+++ b/src/renderer/i18n/locales/es.json
@@ -1051,7 +1051,6 @@
     "stashes": "Stashes",
     "minimize": "Minimizar",
     "maximize": "Maximizar",
-    "sonnet": "Sonnet",
     "skillsMarketplace": "Marketplace",
     "sidebarCustomize": "Personalizar barra lateral",
     "sidebarDragHint": "Arrastra para reordenar - Clic derecho en una pestaña para ocultarla rápidamente",

--- a/src/renderer/i18n/locales/fr.json
+++ b/src/renderer/i18n/locales/fr.json
@@ -1149,7 +1149,6 @@
     "stashes": "Remisages",
     "minimize": "Réduire",
     "maximize": "Agrandir",
-    "sonnet": "Sonnet",
     "skillsMarketplace": "Marketplace",
     "sidebarCustomize": "Personnaliser la barre latérale",
     "sidebarDragHint": "Glisse pour réordonner - Clic droit sur un onglet pour le masquer rapidement",

--- a/src/renderer/i18n/locales/id.json
+++ b/src/renderer/i18n/locales/id.json
@@ -1054,7 +1054,6 @@
     "stashes": "Stash",
     "minimize": "Kecilkan",
     "maximize": "Perbesar",
-    "sonnet": "Sonnet",
     "skillsMarketplace": "Marketplace",
     "sidebarCustomize": "Kustomisasi bilah samping",
     "sidebarDragHint": "Seret untuk mengatur urutan - Klik kanan pada tab untuk menyembunyikannya dengan cepat",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -1054,7 +1054,6 @@
     "stashes": "藏品",
     "minimize": "最小化",
     "maximize": "最大化",
-    "sonnet": "十四行诗",
     "skillsMarketplace": "市场",
     "sidebarCustomize": "自定义侧边栏",
     "sidebarDragHint": "拖动重新排序 - 右键单击选项卡可快速隐藏它",

--- a/styles/layout.css
+++ b/styles/layout.css
@@ -188,7 +188,8 @@ body.platform-darwin .titlebar-drag {
   color: #a78bfa;
 }
 
-.usage-item[data-type="sonnet"] .usage-percent {
+/* Any per-model limit the API scopes, whichever model that is today. */
+.usage-item[data-type="scoped"] .usage-percent {
   color: #f9a8d4;
 }
 
@@ -228,7 +229,7 @@ body.platform-darwin .titlebar-drag {
   background: linear-gradient(90deg, #7c3aed, #a78bfa);
 }
 
-.usage-item[data-type="sonnet"] .usage-bar {
+.usage-item[data-type="scoped"] .usage-bar {
   background: linear-gradient(90deg, #db2777, #f9a8d4);
 }
 

--- a/tests/services/UsageService.test.js
+++ b/tests/services/UsageService.test.js
@@ -1,0 +1,104 @@
+/**
+ * Guards the usage bucket parsing.
+ *
+ * The titlebar used to read one fixed key per limit — `five_hour`, `seven_day`,
+ * `seven_day_sonnet`. The per-model key went null when the scoped weekly limit
+ * moved off Sonnet, and nothing caught it: the bar simply showed "Sonnet --%"
+ * against an empty gauge for as long as it took someone to notice. These tests
+ * pin the shape we read now, so the next model rename is a data change rather
+ * than a silent blank bar.
+ */
+
+const { readBuckets } = require('../../src/main/services/UsageService');
+
+/** A response captured from /api/oauth/usage, trimmed to the fields we read. */
+const LIVE_RESPONSE = {
+  five_hour: { utilization: 16.0, resets_at: '2026-09-03T11:50:00Z' },
+  seven_day: { utilization: 6.0, resets_at: '2026-09-08T00:00:00Z' },
+  seven_day_opus: null,
+  seven_day_sonnet: null,
+  nimbus_quill: { utilization: 0.0, resets_at: null },
+  limits: [
+    {
+      kind: 'session', group: 'session', percent: 16, severity: 'normal',
+      resets_at: '2026-09-03T11:50:00Z', scope: null, is_active: true
+    },
+    {
+      kind: 'weekly_all', group: 'weekly', percent: 6, severity: 'normal',
+      resets_at: '2026-09-08T00:00:00Z', scope: null, is_active: false
+    },
+    {
+      kind: 'weekly_scoped', group: 'weekly', percent: 0, severity: 'normal',
+      resets_at: null, scope: { model: { id: null, display_name: 'Fable' } }, is_active: false
+    }
+  ]
+};
+
+describe('readBuckets', () => {
+  test('reads the three buckets a live response describes', () => {
+    expect(readBuckets(LIVE_RESPONSE)).toEqual([
+      { id: 'session', type: 'session', label: null, labelKey: 'ui.session', utilization: 16, resetsAt: '2026-09-03T11:50:00Z' },
+      { id: 'weekly', type: 'weekly', label: null, labelKey: 'ui.weekly', utilization: 6, resetsAt: '2026-09-08T00:00:00Z' },
+      { id: 'scoped:Fable', type: 'scoped', label: 'Fable', labelKey: null, utilization: 0, resetsAt: null }
+    ]);
+  });
+
+  test('takes the scoped label from the API, not from a hardcoded model name', () => {
+    const renamed = {
+      ...LIVE_RESPONSE,
+      limits: [{ kind: 'weekly_scoped', percent: 42, resets_at: null, scope: { model: { display_name: 'Mythos' } } }]
+    };
+    expect(readBuckets(renamed)).toEqual([
+      { id: 'scoped:Mythos', type: 'scoped', label: 'Mythos', labelKey: null, utilization: 42, resetsAt: null }
+    ]);
+  });
+
+  test('renders every scoped limit when a plan exposes more than one', () => {
+    const twoModels = {
+      ...LIVE_RESPONSE,
+      limits: [
+        { kind: 'weekly_scoped', percent: 10, resets_at: null, scope: { model: { display_name: 'Fable' } } },
+        { kind: 'weekly_scoped', percent: 20, resets_at: null, scope: { model: { display_name: 'Opus' } } }
+      ]
+    };
+    expect(readBuckets(twoModels).map(b => b.label)).toEqual(['Fable', 'Opus']);
+  });
+
+  test('keeps only the plan-wide buckets when a plan has no scoped limit', () => {
+    const noScope = { ...LIVE_RESPONSE, limits: LIVE_RESPONSE.limits.slice(0, 2) };
+    expect(readBuckets(noScope).map(b => b.id)).toEqual(['session', 'weekly']);
+  });
+
+  test('drops a scoped limit the server did not name rather than showing a blank bar', () => {
+    const unnamed = {
+      ...LIVE_RESPONSE,
+      limits: [...LIVE_RESPONSE.limits.slice(0, 2), { kind: 'weekly_scoped', percent: 5, scope: null }]
+    };
+    expect(readBuckets(unnamed).map(b => b.id)).toEqual(['session', 'weekly']);
+  });
+
+  test('ignores a limit with no percent instead of rendering NaN', () => {
+    const broken = { limits: [{ kind: 'session', resets_at: null, scope: null }] , five_hour: null, seven_day: null };
+    expect(readBuckets(broken)).toEqual([]);
+  });
+
+  test('falls back to the legacy keys when the response has no limits array', () => {
+    const legacy = {
+      five_hour: { utilization: 30, resets_at: '2026-09-03T11:50:00Z' },
+      seven_day: { utilization: 12, resets_at: '2026-09-08T00:00:00Z' }
+    };
+    expect(readBuckets(legacy).map(b => ({ id: b.id, utilization: b.utilization })))
+      .toEqual([{ id: 'session', utilization: 30 }, { id: 'weekly', utilization: 12 }]);
+  });
+
+  test('falls back rather than blanking the bar when limits is present but unusable', () => {
+    const empty = { ...LIVE_RESPONSE, limits: [] };
+    expect(readBuckets(empty).map(b => b.id)).toEqual(['session', 'weekly']);
+  });
+
+  test('survives an empty or malformed response', () => {
+    expect(readBuckets({})).toEqual([]);
+    expect(readBuckets(null)).toEqual([]);
+    expect(readBuckets({ limits: null })).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #100.

## The bug

The third bar in the titlebar reads `seven_day_sonnet` from `/api/oauth/usage`. That key is `null`, and has been since the weekly per-model limit moved off Sonnet, so the bar renders **`Sonnet --%` over an empty gauge on every account**. `seven_day_opus` is parsed at the same spot and never displayed; it is null too.

Captured from a live Max account:

```json
{
  "five_hour":        { "utilization": 16.0, "resets_at": "..." },
  "seven_day":        { "utilization": 6.0,  "resets_at": "..." },
  "seven_day_opus":   null,
  "seven_day_sonnet": null,
  "nimbus_quill":     { "utilization": 0.0 },
  "limits": [
    { "kind": "session",       "percent": 16, "scope": null },
    { "kind": "weekly_all",    "percent": 6,  "scope": null },
    { "kind": "weekly_scoped", "percent": 0,
      "scope": { "model": { "display_name": "Fable" } } }
  ]
}
```

## Why not just read a `seven_day_fable` key

There isn't one. The scoped figure now sits under `nimbus_quill` — a codename, not something to write into a release. Swapping one hardcoded model name for another would put us back here at the next rename, with the same silent failure mode: a bar that shows `--` and no error anywhere.

`limits` is the part of the response worth reading. The server states which limits exist and **names the model each scoped one applies to**, so the label becomes data instead of a string that needs a release to change.

## The change

- `UsageService.readBuckets()` turns `limits` into an ordered bucket list. Plan-wide windows carry an i18n key; scoped ones carry the server's `display_name`.
- The bars are no longer declared in `index.html`. The renderer reconciles the DOM against the bucket list, keyed by bucket id: a limit that appears gets a bar, one that stops being sent loses its bar rather than freezing on its last value, and a plan exposing two scoped models gets two bars.
- Session and Weekly keep their `data-i18n` attribute, so a language switch still retranslates them in place. A scoped label is set as text, never as markup.
- `ui.sonnet` is dropped from all five locales.
- A response with no `limits` array falls back to the legacy `five_hour` / `seven_day` keys.

## Testing

- `tests/services/UsageService.test.js` — 11 cases pinning the parsing: the live payload, a renamed model, several scoped limits, a plan with none, an unnamed scoped limit, the legacy fallback, malformed input.
- Full suite: 74 suites / 2151 tests pass. `npm run build:renderer` clean.

## Out of scope, but noted

`LIMIT_THRESHOLD` is `0.95` while the API reports utilisation on a 0-100 scale, so the "limit reached" notification fires at just under **1%** of a window. It predates this change; happy to send it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
