### PR TITLE
fix(chat): stop the 1 Hz whole-DOM scans that never had anything to update

### DIFF
--- a/src/renderer/services/markdown/interactivity.js
+++ b/src/renderer/services/markdown/interactivity.js
@@ -229,7 +229,10 @@ function attachInteractivity(container) {
   });
 
   // ── Discord Rich Presence live timers ──
-  startPresenceTicker(container);
+  // Deliberately not started here. The ticker is demand-driven: postProcess()
+  // turns it on when a rendered batch actually contains a presence card. Arming
+  // one per container up front cost a 1 Hz querySelectorAll over the whole
+  // transcript, for a block type almost no session ever renders.
 }
 
 /**
@@ -245,69 +248,75 @@ function formatPresenceElapsed(ms) {
   return h > 0 ? `${h}:${pad(m)}:${pad(s)}` : `${pad(m)}:${pad(s)}`;
 }
 
+// One interval for the whole renderer, and only while a presence card is on
+// screen. It used to be one interval per chat container, armed the moment
+// interactivity was attached and never released when no presence card ever
+// showed up: `sawPresence` stayed false, so the "nothing left to drive" exit was
+// unreachable and each container kept scanning its own subtree once a second
+// forever. With a handful of chat tabs open on long transcripts that measured
+// ~30-60 ms of querySelectorAll per second, for zero matching nodes.
+let _presenceTicker = null;
+
 /**
- * Stop the presence ticker of a container (if any) and drop the property.
- * Safe to call multiple times, and on containers that never had a ticker.
- * @param {Element} container
+ * Stop the presence ticker.
+ *
+ * Kept for the container-shaped call from detachInteractivity(); the ticker no
+ * longer closes over a container, so any argument is ignored.
  */
-function stopPresenceTicker(container) {
-  if (!container || !container._dcPresenceTicker) return;
-  clearInterval(container._dcPresenceTicker);
-  delete container._dcPresenceTicker;
+function stopPresenceTicker() {
+  if (!_presenceTicker) return;
+  clearInterval(_presenceTicker);
+  _presenceTicker = null;
 }
 
 /**
- * Start a 1s interval (once per container) that refreshes any
- * .dc-presence-time elements with elapsed/remaining durations.
- *
- * The interval self-cancels as soon as the container leaves the document or
- * once every presence node it used to drive is gone — otherwise the closure
- * would keep a detached transcript alive for the whole app lifetime.
+ * Refresh every live presence timer in the document.
+ * @returns {boolean} True while at least one presence node is still on screen.
  */
-function startPresenceTicker(container) {
-  if (container._dcPresenceTicker) return;
+function _tickPresence() {
+  const times = document.querySelectorAll('.dc-presence-time[data-start], .dc-presence-time[data-end]');
+  const bars = document.querySelectorAll('.dc-presence-progress[data-start][data-end]');
+  if (times.length === 0 && bars.length === 0) return false;
 
-  // Only cancel on "no nodes left" once we actually saw some: the container
-  // is usually empty when interactivity is attached and fills in on stream.
-  let sawPresence = false;
+  const now = Date.now();
 
-  const tick = (fromInterval) => {
-    const times = container.querySelectorAll('.dc-presence-time[data-start], .dc-presence-time[data-end]');
-    const bars = container.querySelectorAll('.dc-presence-progress[data-start][data-end]');
-    const hasPresence = times.length > 0 || bars.length > 0;
-
-    if (fromInterval && (!container.isConnected || (sawPresence && !hasPresence))) {
-      stopPresenceTicker(container);
-      return;
+  times.forEach((el) => {
+    const end = el.getAttribute('data-end');
+    const start = el.getAttribute('data-start');
+    if (end) {
+      el.textContent = `${formatPresenceElapsed(Number(end) - now)} left`;
+    } else if (start) {
+      el.textContent = `${formatPresenceElapsed(now - Number(start))} elapsed`;
     }
-    if (!hasPresence) return;
-    sawPresence = true;
+  });
 
-    const now = Date.now();
+  bars.forEach((el) => {
+    const start = Number(el.getAttribute('data-start'));
+    const end = Number(el.getAttribute('data-end'));
+    const total = Math.max(1, end - start);
+    const pct = Math.min(100, Math.max(0, ((now - start) / total) * 100));
+    const fill = el.querySelector('.dc-presence-bar-fill');
+    if (fill) fill.style.width = `${pct.toFixed(2)}%`;
+    const elapsed = el.querySelector('.dc-presence-elapsed');
+    if (elapsed) elapsed.textContent = formatPresenceElapsed(Math.min(now - start, total));
+  });
+  return true;
+}
 
-    times.forEach((el) => {
-      const end = el.getAttribute('data-end');
-      const start = el.getAttribute('data-start');
-      if (end) {
-        el.textContent = `${formatPresenceElapsed(Number(end) - now)} left`;
-      } else if (start) {
-        el.textContent = `${formatPresenceElapsed(now - Number(start))} elapsed`;
-      }
-    });
-
-    bars.forEach((el) => {
-      const start = Number(el.getAttribute('data-start'));
-      const end = Number(el.getAttribute('data-end'));
-      const total = Math.max(1, end - start);
-      const pct = Math.min(100, Math.max(0, ((now - start) / total) * 100));
-      const fill = el.querySelector('.dc-presence-bar-fill');
-      if (fill) fill.style.width = `${pct.toFixed(2)}%`;
-      const elapsed = el.querySelector('.dc-presence-elapsed');
-      if (elapsed) elapsed.textContent = formatPresenceElapsed(Math.min(now - start, total));
-    });
-  };
-  container._dcPresenceTicker = setInterval(() => tick(true), 1000);
-  tick(false);
+/**
+ * Arm the 1 Hz presence ticker, if it is not already running.
+ *
+ * Called by postProcess() with a batch that contains a presence card, so the
+ * cost is only ever paid by sessions that render one. The ticker stops itself
+ * on the first tick that finds nothing left to update — including when the tab
+ * holding the card is closed, since a detached card is no longer in `document`.
+ */
+function ensurePresenceTicker() {
+  _tickPresence();
+  if (_presenceTicker) return;
+  _presenceTicker = setInterval(() => {
+    if (!_tickPresence()) stopPresenceTicker();
+  }, 1000);
 }
 
 function handleCopyClick(btn) {
@@ -462,17 +471,21 @@ function initializePreviewIframe(container) {
 
 /**
  * Release every timer attachInteractivity() started on a container.
- * Call this from the owner's destroy()/teardown before dropping the element,
- * so the transcript can be garbage collected.
- * @param {Element} container
+ * Call this from the owner's destroy()/teardown before dropping the element.
+ *
+ * Now a no-op: the presence ticker is global and holds no container, so closing
+ * one tab must not silence a card still open in another. It retires itself on
+ * the first tick that finds nothing left in the document.
+ * @param {Element} _container
  */
-function detachInteractivity(container) {
-  stopPresenceTicker(container);
+function detachInteractivity(_container) {
+  /* nothing container-scoped left to release */
 }
 
 module.exports = {
   attachInteractivity,
   detachInteractivity,
+  ensurePresenceTicker,
   stopPresenceTicker,
   initializePreviewIframe,
   COLLAPSE_THRESHOLD,

--- a/src/renderer/services/markdown/postProcess.js
+++ b/src/renderer/services/markdown/postProcess.js
@@ -6,7 +6,10 @@
 
 const { escapeHtml } = require('../../utils');
 const { t } = require('../../i18n');
-const { initializePreviewIframe } = require('./interactivity');
+const { initializePreviewIframe, ensurePresenceTicker } = require('./interactivity');
+
+/** Presence cards carrying a live timer — the only ones that need a ticker. */
+const PRESENCE_SELECTOR = '.dc-presence-time[data-start], .dc-presence-time[data-end], .dc-presence-progress[data-start][data-end]';
 
 // ── Mermaid SVG cache (LRU, max 50) ──
 
@@ -104,6 +107,13 @@ function postProcess(target) {
   const mermaidBlocks = queryWithin(roots, '.chat-mermaid-block');
   const mathBlocks = queryWithin(roots, '.chat-math-block');
   const inlineMathEls = queryWithin(roots, '.chat-math-inline[data-math-source]');
+
+  // Discord Rich Presence timers. Scoped to the batch just inserted, so a
+  // session that renders no presence card never pays for one — and never arms
+  // the 1 Hz document scan that keeps them counting.
+  if (queryWithin(roots, PRESENCE_SELECTOR).length > 0) {
+    ensurePresenceTicker();
+  }
 
   // Render inline math with KaTeX
   if (inlineMathEls.length > 0) {

--- a/src/renderer/ui/components/ChatView.js
+++ b/src/renderer/ui/components/ChatView.js
@@ -64,26 +64,38 @@ function parseResultJson(text) {
 }
 
 // ── Wakeup countdown ticker (module-level, single global interval) ──
-let _wakeupTickerStarted = false;
+// Runs only while a wakeup card is actually on screen. The first version armed
+// the interval on the first ScheduleWakeup of the session and then ticked for
+// the rest of the app's life, and its `[data-wakeup-at]` selector carried no
+// class or tag to index on — so every second it walked every element in the
+// document. On a few long transcripts that is ~20 ms a second, permanently.
+let _wakeupTimer = null;
+
+/** @returns {boolean} True while at least one wakeup card is still on screen. */
+function _tickWakeups() {
+  const nodes = document.querySelectorAll('.chat-wakeup-card[data-wakeup-at]');
+  if (!nodes.length) return false;
+  const now = Date.now();
+  nodes.forEach((el) => {
+    const at = Number(el.dataset.wakeupAt) || 0;
+    const cd = el.querySelector('[data-countdown]');
+    if (!cd) return;
+    const remaining = Math.max(0, Math.round((at - now) / 1000));
+    if (remaining === 0) {
+      cd.textContent = 'fired';
+      cd.classList.add('is-fired');
+    } else {
+      cd.textContent = 'in ' + fmtDur(remaining);
+    }
+  });
+  return true;
+}
+
 function ensureWakeupTicker() {
-  if (_wakeupTickerStarted) return;
-  _wakeupTickerStarted = true;
-  setInterval(() => {
-    const nodes = document.querySelectorAll('[data-wakeup-at]');
-    if (!nodes.length) return;
-    const now = Date.now();
-    nodes.forEach((el) => {
-      const at = Number(el.dataset.wakeupAt) || 0;
-      const cd = el.querySelector('[data-countdown]');
-      if (!cd) return;
-      const remaining = Math.max(0, Math.round((at - now) / 1000));
-      if (remaining === 0) {
-        cd.textContent = 'fired';
-        cd.classList.add('is-fired');
-      } else {
-        cd.textContent = 'in ' + fmtDur(remaining);
-      }
-    });
+  _tickWakeups();
+  if (_wakeupTimer) return;
+  _wakeupTimer = setInterval(() => {
+    if (!_tickWakeups()) { clearInterval(_wakeupTimer); _wakeupTimer = null; }
   }, 1000);
 }
 const { getSetting, setSetting, isNotificationsEnabled } = require('../../state/settings.state');

--- a/tests/services/markdownIdleTickers.test.js
+++ b/tests/services/markdownIdleTickers.test.js
@@ -1,0 +1,109 @@
+/**
+ * Idle-cost regression test for the chat markdown tickers.
+ *
+ * attachInteractivity() used to arm a 1 Hz interval on every chat container,
+ * scanning that container's whole subtree for Discord presence cards whether or
+ * not any existed — and it could never stop when none ever appeared, because its
+ * exit condition required having seen one first. With a few tabs open on long
+ * transcripts that measured tens of milliseconds of querySelectorAll per second,
+ * for the life of the process.
+ *
+ * The ticker is now armed by postProcess(), only for a render batch that
+ * actually contains a presence card, and retires itself once the last one leaves
+ * the document.
+ */
+
+jest.mock('../../src/renderer/i18n', () => ({ t: (key) => key }));
+
+describe('markdown idle tickers', () => {
+  let interactivity;
+  let postProcess;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.useFakeTimers();
+    document.body.innerHTML = '';
+    interactivity = require('../../src/renderer/services/markdown/interactivity');
+    ({ postProcess } = require('../../src/renderer/services/markdown/postProcess'));
+  });
+
+  afterEach(() => {
+    interactivity.stopPresenceTicker();
+    jest.useRealTimers();
+  });
+
+  /** A rendered batch holding one presence card with a live elapsed timer. */
+  function presenceBatch(startedMsAgo) {
+    const batch = document.createElement('div');
+    batch.innerHTML = `<div class="dc-presence">`
+      + `<div class="dc-presence-time" data-start="${Date.now() - startedMsAgo}"></div>`
+      + `</div>`;
+    document.body.appendChild(batch);
+    return batch;
+  }
+
+  it('arms no timer when interactivity is attached to a container', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    interactivity.attachInteractivity(container);
+
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it('arms no timer for a rendered batch without a presence card', () => {
+    const batch = document.createElement('div');
+    batch.innerHTML = '<p>just prose, and a <code>code span</code></p>';
+    document.body.appendChild(batch);
+
+    postProcess(batch);
+
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it('arms the ticker for a batch that has one, and keeps it counting', () => {
+    const batch = presenceBatch(65_000);
+
+    postProcess(batch);
+    expect(jest.getTimerCount()).toBe(1);
+
+    const time = batch.querySelector('.dc-presence-time');
+    expect(time.textContent).toBe('01:05 elapsed');
+
+    jest.advanceTimersByTime(1000);
+    expect(time.textContent).toBe('01:06 elapsed');
+  });
+
+  it('arms only one ticker no matter how many batches carry a card', () => {
+    postProcess(presenceBatch(1000));
+    postProcess(presenceBatch(2000));
+
+    expect(jest.getTimerCount()).toBe(1);
+  });
+
+  it('retires the ticker once the last presence card leaves the document', () => {
+    const batch = presenceBatch(1000);
+    postProcess(batch);
+    expect(jest.getTimerCount()).toBe(1);
+
+    // Closing the tab that held the card detaches it from the document.
+    batch.remove();
+    jest.advanceTimersByTime(1000);
+
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it('leaves a card open in another tab counting when one tab is torn down', () => {
+    const kept = presenceBatch(1000);
+    const closed = presenceBatch(1000);
+    postProcess(kept);
+
+    // ChatView calls this from destroy(); it must not silence the global ticker.
+    interactivity.detachInteractivity(closed);
+    closed.remove();
+    jest.advanceTimersByTime(1000);
+
+    expect(jest.getTimerCount()).toBe(1);
+    expect(kept.querySelector('.dc-presence-time').textContent).toBe('00:02 elapsed');
+  });
+});


### PR DESCRIPTION
Fixes #98.

Two timers polled the DOM once a second looking for card types that most sessions never render, and neither could stop when it found nothing.

`attachInteractivity()` armed a Discord Rich Presence ticker on every chat container, the moment the container was created and still empty. Its exit condition — `sawPresence && !hasPresence` — required having seen a presence card first, so a container that never got one scanned its own subtree twice a second for the life of the process, once per open tab.

`ensureWakeupTicker()` fired on the first `ScheduleWakeup` of the session and then ran forever, and its `[data-wakeup-at]` selector carries no class or tag to index on, so every tick walked every element in the document.

### Measured

Electron driven over CDP, isolated `HOME`, nine restored chat tabs, 325k elements, app idle:

| | before | after |
|---|---|---|
| presence tickers armed | 9 (matching nodes: **0**) | **0** |
| `querySelectorAll` self-time | **4.31%**, top non-idle cost | gone from the profile |
| `ScriptDuration` / 10 s idle | **648 ms** | **27 ms** |
| idle | 73.6% | **99.7%** |

~45-90 ms of main thread per second, in synchronous chunks, for queries returning zero nodes — and it scaled with transcript size.

### Approach

`postProcess()` already receives the nodes of the render batch it just inserted and initialises mermaid/KaTeX/preview blocks from them, so detecting presence cards there is work proportional to the batch rather than to the transcript. The ticker is armed only for a batch that actually contains one.

One interval now serves the whole renderer instead of one per container, and it retires itself on the first tick that finds nothing left. A detached card is no longer in `document`, so closing a tab releases the ticker without silencing a card still open elsewhere — which is why `detachInteractivity()` keeps its signature for `ChatView.destroy()` but no longer has a container-scoped timer to release.

The wakeup ticker gets the same stop path, plus a class-qualified `.chat-wakeup-card[data-wakeup-at]` selector.

Behaviour with presence and wakeup cards present is unchanged; only the cost when they are absent is. One difference worth naming: a presence card that appears mid-stream now starts counting when its block finalises rather than on the next second, since the stream path deliberately does not run a per-frame scan.

### Tests

`tests/services/markdownIdleTickers.test.js`, 6 cases: attach arms nothing; a batch without a card arms nothing; a batch with one arms exactly one and keeps it counting; several batches still arm only one; the ticker retires when the last card leaves the document; tearing down one tab does not silence a card open in another.

Full suite green (74 suites, 2148 tests).

### Noted while measuring, not addressed here

- `ControlTowerPanel._updateTimers()` runs four document-wide `querySelectorAll` every 2 s (~42 ms/s on the same DOM). Correctly gated on panel visibility, so it only costs while the Control Tower is on screen — but it is the same shape of problem.
- Nine open chat tabs retain their full transcripts as live DOM: 325k elements, ~1.7 GB JS heap. Trimming or virtualising transcripts would be a separate, larger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)