### PR TITLE
feat(navigation): let the user pick between the project tab bar and the projects sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -434,6 +434,9 @@
               <button class="btn-icon" id="btn-new-project" data-i18n-title="common.new" aria-label="New project">
                 <svg viewBox="0 0 24 24" fill="currentColor"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/></svg>
               </button>
+              <button class="btn-icon" id="btn-toggle-projects" data-i18n-title="ui.hideProjects" title="Hide projects" aria-label="Toggle projects panel">
+                <svg viewBox="0 0 24 24" fill="currentColor"><path d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"/></svg>
+              </button>
               <button class="btn-icon" id="btn-close-projects-popover" data-i18n-title="common.close" title="Close" aria-label="Close">
                 <svg viewBox="0 0 12 12"><path d="M1 1l10 10M11 1L1 11" stroke="currentColor" stroke-width="1.5" fill="none"/></svg>
               </button>
@@ -445,12 +448,21 @@
             <button class="projects-search-clear" id="projects-search-clear" style="display:none" aria-label="Clear">&times;</button>
           </div>
           <div class="projects-list" id="projects-list" role="list" aria-label="Projects"></div>
+          <!-- Drag handle for the docked column; inert while this is a popover -->
+          <div class="panel-resizer" id="projects-panel-resizer"></div>
         </div>
       </div>
 
       <!-- Claude Tab -->
       <div class="tab-content active" id="tab-claude" role="tabpanel" aria-label="Claude">
         <div class="claude-layout" id="claude-layout">
+          <!-- Sidebar navigation: thin strip that brings the projects panel back
+               once it has been collapsed. Hidden in tab-bar mode. -->
+          <button class="btn-show-projects" id="btn-show-projects" data-i18n-title="ui.showProjects" title="Show projects" aria-label="Show projects">
+            <svg viewBox="0 0 24 24" fill="currentColor"><path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/></svg>
+          </button>
+          <!-- In sidebar mode the projects host is moved in here and docked as a
+               column; in tab-bar mode it stays a popover above the content. -->
           <!-- File Explorer Panel -->
           <div class="file-explorer-panel" id="file-explorer-panel" style="display: none;">
             <div class="panel-header">
@@ -486,6 +498,10 @@
 
           <!-- Terminals Panel -->
           <div class="terminals-panel">
+            <!-- Sidebar navigation: the tools row (project name, git actions, CI
+                 pill, quick actions) is moved in here instead of sitting in the
+                 project bar. Empty and collapsed in tab-bar mode. -->
+            <div class="terminals-header" id="terminals-header"></div>
             <!-- Session tabs row: session actions sit to the left of the tabs -->
             <div class="terminals-tabs-row">
               <div class="session-actions">
@@ -634,6 +650,13 @@
       <div class="tab-content" id="tab-git">
         <div class="git-tab-layout">
           <div class="git-tab-sidebar">
+            <!-- Sidebar navigation only: this screen's own project list -->
+            <div class="git-sidebar-section git-sidebar-projects">
+              <div class="git-sidebar-header">
+                <h3 data-i18n="projects.title">Projets</h3>
+              </div>
+              <div class="git-projects-list" id="git-projects-list"></div>
+            </div>
             <div class="git-sidebar-section git-sidebar-quick-actions">
               <div class="git-sidebar-header">
                 <h3 data-i18n="ui.quickActions">Quick Actions</h3>
@@ -725,6 +748,13 @@
       <!-- Dashboard Tab -->
       <div class="tab-content" id="tab-dashboard">
         <div class="dashboard-layout">
+          <!-- Sidebar navigation only: this screen's own project list -->
+          <div class="dashboard-sidebar">
+            <div class="dashboard-sidebar-header">
+              <h3 data-i18n="projects.title">Projets</h3>
+            </div>
+            <div class="dashboard-projects-list" id="dashboard-projects-list"></div>
+          </div>
           <div class="dashboard-main">
             <div class="dashboard-content" id="dashboard-content">
               <div class="dashboard-empty">

--- a/renderer.js
+++ b/renderer.js
@@ -2931,6 +2931,14 @@ function setNavigationMode(mode) {
 // Changing it from Settings goes through the same path as the first-launch card
 document.addEventListener('navigation-mode-change', (e) => setNavigationMode(e.detail));
 
+// Replay and Tasks carry their own project dropdown in sidebar mode, where there
+// is no bar to pick from. They select through this rather than holding a second
+// notion of the active project.
+document.addEventListener('project-select-by-path', (e) => {
+  const index = projectsState.get().projects.findIndex(p => p.path === e.detail);
+  if (index >= 0) selectProjectFromBar(index);
+});
+
 function isProjectsPopoverOpen() {
   const popover = document.getElementById('projects-popover');
   return !!popover && popover.style.display !== 'none';

--- a/renderer.js
+++ b/renderer.js
@@ -9,6 +9,7 @@ const api = window.electron_api;
 const { path, fs, process: nodeProcess, __dirname } = window.electron_nodeModules;
 const { fileExists, fsp, ensureDirs } = require('./src/renderer/utils/fs-async');
 const { matchesSessionQuery } = require('./src/renderer/utils/sessionSearch');
+const { applyNavigationMode, isSidebarNavigation } = require('./src/renderer/ui/navigationMode');
 
 document.body.classList.add(`platform-${nodeProcess.platform}`);
 
@@ -311,6 +312,8 @@ const { loadSessionData, clearProjectSessions, saveTerminalSessions } = require(
     document.body.classList.add('reduce-motion');
   }
   applyNavigationMode(settingsState.get().navigationMode);
+  // Asked once, after the rest is on screen so the previews sit over the real app
+  setTimeout(promptNavigationModeChoice, 1200);
   // Restore notification bell state from persisted settings
   document.getElementById('btn-notifications').classList.toggle('active', isNotificationsEnabled());
 
@@ -2858,50 +2861,75 @@ ProjectBar.initProjectBar({
 // per-project action, on demand instead of in permanent screen space.
 
 /**
- * Navigation mode: the project tab bar, or the same projects panel docked as a
- * permanent left column. A body class drives the layout and both modes share one
- * ProjectList, so there is no second implementation to keep in step.
- * @param {'tabs'|'sidebar'|null} mode - null until the user has been asked
+ * Ask once, on the first launch after the two navigations started shipping
+ * together. `navigationMode` stays null until answered, and the answer is what
+ * makes it stop asking — no separate "already seen" flag to fall out of sync.
  */
-function applyNavigationMode(mode) {
-  const sidebar = mode === 'sidebar';
-  document.body.classList.toggle('nav-sidebar', sidebar);
-  document.body.classList.toggle('nav-tabs', !sidebar);
+function promptNavigationModeChoice(attempt = 0) {
+  if (settingsState.get().navigationMode) return;
 
-  // Two nodes are shared by both navigations rather than duplicated, because
-  // duplicating them would mean two #projects-list hosts and two tool rows
-  // drifting apart. They are moved to where each navigation expects them.
-  const popover = document.getElementById('projects-popover');
-  const layout = document.getElementById('claude-layout');
-  const content = document.querySelector('.content');
-  const tools = document.getElementById('project-bar-tools');
-  const header = document.getElementById('terminals-header');
-  const bar = document.getElementById('project-bar');
-
-  if (sidebar) {
-    // Docked column, to the left of the file explorer, as it was before the bar
-    if (popover && layout && popover.parentElement !== layout) {
-      layout.insertBefore(popover, layout.querySelector('#file-explorer-panel'));
-    }
-    if (tools && header && tools.parentElement !== header) header.appendChild(tools);
-    if (popover) popover.style.display = 'flex';
-  } else {
-    if (popover && content && popover.parentElement !== content) {
-      content.insertBefore(popover, content.querySelector('.tab-content'));
-    }
-    if (tools && bar && tools.parentElement !== bar) bar.appendChild(tools);
-    // Back to a popover: closed until the + button opens it
-    if (popover) {
-      popover.style.display = 'none';
-      popover.classList.remove('collapsed');
-    }
+  // The overlay is shared with the other first-launch modal (telemetry consent)
+  // and the last one to open wins, so wait for it instead of being replaced by
+  // it. Bounded, so a modal the user leaves open does not retry forever.
+  const overlay = document.getElementById('modal-overlay');
+  if (overlay?.classList.contains('active')) {
+    if (attempt < 30) setTimeout(() => promptNavigationModeChoice(attempt + 1), 2000);
+    return;
   }
+
+  // Miniatures of each layout, drawn in CSS rather than shipped as images so
+  // they follow the accent colour and cannot go stale against the real UI.
+  const previews = {
+    tabs: `<span class="nav-mini nav-mini--tabs">
+      <span class="nav-mini-nav"></span>
+      <span class="nav-mini-body"><span class="nav-mini-tabs"><i></i><i></i><i></i></span><span class="nav-mini-screen"></span></span>
+    </span>`,
+    sidebar: `<span class="nav-mini nav-mini--sidebar">
+      <span class="nav-mini-nav"></span>
+      <span class="nav-mini-col"><i></i><i></i><i></i></span>
+      <span class="nav-mini-screen"></span>
+    </span>`,
+  };
+  const card = (mode) => `
+    <button class="nav-choice" data-nav-mode="${mode}">
+      <span class="nav-choice-preview">${previews[mode]}</span>
+      <span class="nav-choice-title">${escapeHtml(t(`navigationMode.${mode}Title`))}</span>
+      <span class="nav-choice-desc">${escapeHtml(t(`navigationMode.${mode}Desc`))}</span>
+      <span class="nav-choice-cta">${escapeHtml(t('navigationMode.choose'))}</span>
+    </button>`;
+
+  showModal(t('navigationMode.title'), `
+    <div class="nav-choice-modal">
+      <p class="nav-choice-intro">${escapeHtml(t('navigationMode.intro'))}</p>
+      <div class="nav-choice-grid">${card('tabs')}${card('sidebar')}</div>
+    </div>
+  `);
+
+  document.querySelector('.nav-choice-grid')?.addEventListener('click', (e) => {
+    const btn = e.target.closest('.nav-choice');
+    if (!btn) return;
+    setNavigationMode(btn.dataset.navMode);
+    closeModal();
+  });
 }
 
-/** In sidebar mode the panel is permanent, so it is never "open" or "closed". */
-function isProjectsPanelDocked() {
-  return document.body.classList.contains('nav-sidebar');
+/**
+ * Persist a navigation mode and mount it without a restart.
+ * @param {'tabs'|'sidebar'} mode
+ */
+function setNavigationMode(mode) {
+  settingsState.setProp('navigationMode', mode);
+  saveSettingsImmediate();
+  applyNavigationMode(mode);
+  // The project-scoped screens are laid out differently in each mode, so
+  // repaint whichever one is on screen.
+  const projectIndex = projectsState.get().selectedProjectFilter;
+  TerminalManager.filterByProject(projectIndex);
+  applyProjectContext(projectIndex);
 }
+
+// Changing it from Settings goes through the same path as the first-launch card
+document.addEventListener('navigation-mode-change', (e) => setNavigationMode(e.detail));
 
 function isProjectsPopoverOpen() {
   const popover = document.getElementById('projects-popover');
@@ -2931,7 +2959,7 @@ function openProjectsPopover(anchor) {
 }
 
 function closeProjectsPopover() {
-  if (isProjectsPanelDocked()) return;
+  if (isSidebarNavigation()) return;
   const popover = document.getElementById('projects-popover');
   if (!popover || popover.style.display === 'none') return;
   popover.style.display = 'none';
@@ -2939,7 +2967,7 @@ function closeProjectsPopover() {
 }
 
 function toggleProjectsPopover(anchor) {
-  if (isProjectsPanelDocked()) return;
+  if (isSidebarNavigation()) return;
   if (isProjectsPopoverOpen()) closeProjectsPopover();
   else openProjectsPopover(anchor);
 }

--- a/renderer.js
+++ b/renderer.js
@@ -310,6 +310,7 @@ const { loadSessionData, clearProjectSessions, saveTerminalSessions } = require(
   if (settingsState.get().reduceMotion) {
     document.body.classList.add('reduce-motion');
   }
+  applyNavigationMode(settingsState.get().navigationMode);
   // Restore notification bell state from persisted settings
   document.getElementById('btn-notifications').classList.toggle('active', isNotificationsEnabled());
 
@@ -2856,6 +2857,52 @@ ProjectBar.initProjectBar({
 // Hosts the full ProjectList: search, folders, drag & drop and every
 // per-project action, on demand instead of in permanent screen space.
 
+/**
+ * Navigation mode: the project tab bar, or the same projects panel docked as a
+ * permanent left column. A body class drives the layout and both modes share one
+ * ProjectList, so there is no second implementation to keep in step.
+ * @param {'tabs'|'sidebar'|null} mode - null until the user has been asked
+ */
+function applyNavigationMode(mode) {
+  const sidebar = mode === 'sidebar';
+  document.body.classList.toggle('nav-sidebar', sidebar);
+  document.body.classList.toggle('nav-tabs', !sidebar);
+
+  // Two nodes are shared by both navigations rather than duplicated, because
+  // duplicating them would mean two #projects-list hosts and two tool rows
+  // drifting apart. They are moved to where each navigation expects them.
+  const popover = document.getElementById('projects-popover');
+  const layout = document.getElementById('claude-layout');
+  const content = document.querySelector('.content');
+  const tools = document.getElementById('project-bar-tools');
+  const header = document.getElementById('terminals-header');
+  const bar = document.getElementById('project-bar');
+
+  if (sidebar) {
+    // Docked column, to the left of the file explorer, as it was before the bar
+    if (popover && layout && popover.parentElement !== layout) {
+      layout.insertBefore(popover, layout.querySelector('#file-explorer-panel'));
+    }
+    if (tools && header && tools.parentElement !== header) header.appendChild(tools);
+    if (popover) popover.style.display = 'flex';
+  } else {
+    if (popover && content && popover.parentElement !== content) {
+      content.insertBefore(popover, content.querySelector('.tab-content'));
+    }
+    if (tools && bar && tools.parentElement !== bar) bar.appendChild(tools);
+    // Back to a popover: closed until the + button opens it
+    if (popover) {
+      popover.style.display = 'none';
+      popover.classList.remove('collapsed');
+    }
+  }
+}
+
+/** In sidebar mode the panel is permanent, so it is never "open" or "closed". */
+function isProjectsPanelDocked() {
+  return document.body.classList.contains('nav-sidebar');
+}
+
 function isProjectsPopoverOpen() {
   const popover = document.getElementById('projects-popover');
   return !!popover && popover.style.display !== 'none';
@@ -2864,7 +2911,9 @@ function isProjectsPopoverOpen() {
 function openProjectsPopover(anchor) {
   const popover = document.getElementById('projects-popover');
   if (!popover) return;
-  popover.style.display = 'block';
+  // flex, matching .projects-popover in the stylesheet, so the panel inside
+  // stretches to the popover instead of collapsing to its content height
+  popover.style.display = 'flex';
   document.getElementById('btn-open-project')?.setAttribute('aria-expanded', 'true');
 
   // Anchor under the + button, clamped to the viewport.
@@ -2882,6 +2931,7 @@ function openProjectsPopover(anchor) {
 }
 
 function closeProjectsPopover() {
+  if (isProjectsPanelDocked()) return;
   const popover = document.getElementById('projects-popover');
   if (!popover || popover.style.display === 'none') return;
   popover.style.display = 'none';
@@ -2889,6 +2939,7 @@ function closeProjectsPopover() {
 }
 
 function toggleProjectsPopover(anchor) {
+  if (isProjectsPanelDocked()) return;
   if (isProjectsPopoverOpen()) closeProjectsPopover();
   else openProjectsPopover(anchor);
 }
@@ -3406,7 +3457,7 @@ const _TAB_LIFECYCLE = {
     deactivate: () => ControlTowerPanel.cleanup()
   },
   dashboard: {
-    activate: () => renderDashboardForScope(),
+    activate: () => { populateDashboardProjects(); renderDashboardForScope(); },
     // 30s GitHub Actions poll started by the dashboard cards; it used to keep
     // hitting the API from a tab nobody was looking at.
     deactivate: () => DashboardService.stopWorkflowPolling()
@@ -4171,6 +4222,147 @@ document.getElementById('modal-overlay').onclick = (e) => { if (e.target.id === 
  * Overview tab in front of them shows all projects. There is deliberately no
  * second project selector on the screen itself.
  */
+function populateDashboardProjects() {
+  // Sidebar navigation only: in tab-bar mode the bar and its Overview tab are
+  // the selector, and this list is not on screen.
+  if (!document.body.classList.contains('nav-sidebar')) return;
+  const list = document.getElementById('dashboard-projects-list');
+  if (!list) return;
+  const state = projectsState.get();
+  const { projects, folders, rootOrder } = state;
+
+  if (projects.length === 0) {
+    list.innerHTML = `<div class="dashboard-projects-empty">Aucun projet</div>`;
+    return;
+  }
+
+  // Overview item
+  const overviewHtml = `
+    <div class="dashboard-project-item overview-item ${localState.dashboardScope === 'overview' ? 'active' : ''}" data-index="-1">
+      <div class="dashboard-project-icon">
+        <svg viewBox="0 0 24 24" fill="currentColor"><path d="M3 13h8V3H3v10zm0 8h8v-6H3v6zm10 0h8V11h-8v10zm0-18v6h8V3h-8z"/></svg>
+      </div>
+      <div class="dashboard-project-info">
+        <div class="dashboard-project-name">${t('dashboard.overview')}</div>
+      </div>
+    </div>
+  `;
+
+  function renderFolderItem(folder, depth) {
+    const projectCount = countProjectsRecursive(folder.id);
+    const isCollapsed = folder.collapsed;
+    const indent = depth * 16;
+
+    const colorIndicator = folder.color
+      ? `<span class="dash-folder-color" style="background: ${folder.color}"></span>`
+      : '';
+
+    const folderIcon = folder.icon
+      ? `<span class="dash-folder-emoji">${folder.icon}</span>`
+      : `<svg viewBox="0 0 24 24" fill="currentColor"><path d="M20 6h-8l-2-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2z"/></svg>`;
+
+    let childrenHtml = '';
+    const children = folder.children || [];
+    for (const childId of children) {
+      const childFolder = folders.find(f => f.id === childId);
+      if (childFolder) {
+        childrenHtml += renderFolderItem(childFolder, depth + 1);
+      } else {
+        const childProject = projects.find(p => p.id === childId);
+        if (childProject && childProject.folderId === folder.id) {
+          childrenHtml += renderProjectItem(childProject, depth + 1);
+        }
+      }
+    }
+
+    return `
+      <div class="dash-folder-item" data-folder-id="${folder.id}">
+        <div class="dash-folder-header" style="padding-left: ${indent + 8}px">
+          <span class="dash-folder-chevron ${isCollapsed ? 'collapsed' : ''}">
+            <svg viewBox="0 0 24 24" fill="currentColor"><path d="M7 10l5 5 5-5z"/></svg>
+          </span>
+          ${colorIndicator}
+          <span class="dash-folder-icon">${folderIcon}</span>
+          <span class="dash-folder-name">${escapeHtml(folder.name)}</span>
+          <span class="dash-folder-count">${projectCount}</span>
+        </div>
+        <div class="dash-folder-children ${isCollapsed ? 'collapsed' : ''}">
+          ${childrenHtml}
+        </div>
+      </div>
+    `;
+  }
+
+  function renderProjectItem(project, depth) {
+    const index = getProjectIndex(project.id);
+    const isActive = localState.dashboardScope !== 'overview' && projectsState.get().selectedProjectFilter === index;
+    const indent = depth * 16;
+
+    const colorIndicator = project.color
+      ? `<span class="dash-folder-color" style="background: ${project.color}"></span>`
+      : '';
+
+    const dashTypeHandler = registry.get(project.type);
+    const dashTypeIcon = dashTypeHandler.getDashboardIcon ? dashTypeHandler.getDashboardIcon(project) : null;
+    const iconHtml = project.icon
+      ? `<span class="dashboard-project-emoji">${project.icon}</span>`
+      : (dashTypeIcon || '<svg viewBox="0 0 24 24" fill="currentColor"><path d="M20 6h-8l-2-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2z"/></svg>');
+
+    return `
+      <div class="dashboard-project-item ${isActive ? 'active' : ''}" data-index="${index}" style="padding-left: ${indent}px">
+        <div class="dashboard-project-icon">${colorIndicator}${iconHtml}</div>
+        <div class="dashboard-project-info">
+          <div class="dashboard-project-name">${escapeHtml(project.name)}</div>
+          <div class="dashboard-project-path">${escapeHtml(project.path)}</div>
+        </div>
+      </div>
+    `;
+  }
+
+  let itemsHtml = '';
+  for (const itemId of (rootOrder || [])) {
+    const folder = folders.find(f => f.id === itemId);
+    if (folder) {
+      itemsHtml += renderFolderItem(folder, 0);
+    } else {
+      const project = projects.find(p => p.id === itemId);
+      if (project) {
+        itemsHtml += renderProjectItem(project, 0);
+      }
+    }
+  }
+
+  list.innerHTML = overviewHtml + itemsHtml;
+
+  // Click handlers for projects
+  list.querySelectorAll('.dashboard-project-item').forEach(item => {
+    item.onclick = () => {
+      const index = parseInt(item.dataset.index);
+      if (index === -1) {
+        localState.dashboardScope = 'overview';
+        populateDashboardProjects();
+        renderDashboardForScope();
+      } else {
+        // Same switch the project bar performs, so both navigations agree
+        localState.dashboardScope = 'project';
+        selectProjectFromBar(index);
+        populateDashboardProjects();
+      }
+    };
+  });
+
+  // Click handlers for folder headers (toggle collapse)
+  list.querySelectorAll('.dash-folder-header').forEach(header => {
+    header.onclick = (e) => {
+      e.stopPropagation();
+      const folderItem = header.closest('.dash-folder-item');
+      const folderId = folderItem.dataset.folderId;
+      toggleFolderCollapse(folderId);
+      populateDashboardProjects();
+    };
+  });
+}
+
 function renderDashboardForScope() {
   const projectIndex = projectsState.get().selectedProjectFilter;
   const project = projectsState.get().projects[projectIndex] || null;
@@ -6575,3 +6767,78 @@ window.addEventListener('beforeunload', () => {
   DashboardService.cleanup();
 });
 
+
+// ========== PROJECTS PANEL RESIZER (sidebar navigation) ==========
+// The host is the same node the tab-bar mode uses as a popover; docked, it is
+// the column, so width and collapse apply to it rather than to the inner panel.
+(function initProjectsPanelResizer() {
+  const resizer = document.getElementById('projects-panel-resizer');
+  const panel = document.getElementById('projects-popover');
+  const btnToggle = document.getElementById('btn-toggle-projects');
+  if (!resizer || !panel) return;
+
+  function updateToggleVisibility(width) {
+    if (btnToggle) btnToggle.style.display = width < 210 ? 'none' : '';
+  }
+
+  let startX, startWidth;
+
+  resizer.addEventListener('mousedown', (e) => {
+    if (!document.body.classList.contains('nav-sidebar')) return;
+    e.preventDefault();
+    startX = e.clientX;
+    startWidth = panel.offsetWidth;
+    resizer.classList.add('active');
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+
+    const onMouseMove = (ev) => {
+      const newWidth = Math.min(600, Math.max(170, startWidth + (ev.clientX - startX)));
+      panel.style.width = newWidth + 'px';
+      updateToggleVisibility(newWidth);
+    };
+
+    const onMouseUp = () => {
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+      resizer.classList.remove('active');
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+      updateToggleVisibility(panel.offsetWidth);
+      settingsState.setProp('projectsPanelWidth', panel.offsetWidth);
+      saveSettingsImmediate();
+    };
+
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+  });
+
+  const savedWidth = settingsState.get().projectsPanelWidth;
+  if (savedWidth) panel.style.width = savedWidth + 'px';
+})();
+
+// ========== PROJECTS PANEL TOGGLE (sidebar navigation) ==========
+(function initProjectsPanelToggle() {
+  const panel = document.getElementById('projects-popover');
+  const layout = document.getElementById('claude-layout');
+  const btnToggle = document.getElementById('btn-toggle-projects');
+  const btnShow = document.getElementById('btn-show-projects');
+  if (!panel || !layout || !btnToggle || !btnShow) return;
+
+  if (localStorage.getItem('projects-panel-hidden') === 'true') {
+    panel.classList.add('collapsed');
+    layout.classList.add('projects-hidden');
+  }
+
+  btnToggle.onclick = () => {
+    panel.classList.add('collapsed');
+    layout.classList.add('projects-hidden');
+    localStorage.setItem('projects-panel-hidden', 'true');
+  };
+
+  btnShow.onclick = () => {
+    panel.classList.remove('collapsed');
+    layout.classList.remove('projects-hidden');
+    localStorage.setItem('projects-panel-hidden', 'false');
+  };
+})();

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -3936,5 +3936,18 @@
       "watchMultiHint": "Pick one or more projects. \"Any project\" also covers ones you add later.",
       "watchMultiPickHint": "Watched per repository, so pick at least one project."
     }
+  },
+  "navigationMode": {
+    "title": "Choose your navigation",
+    "intro": "Claude Terminal can lay out your projects two ways. You can switch at any time in Settings.",
+    "tabsTitle": "Project tabs",
+    "tabsDesc": "One tab per open project across the top, browser-style. Leaves the most room for the screen you are working in.",
+    "sidebarTitle": "Projects sidebar",
+    "sidebarDesc": "A permanent projects column on the left, as before. Search, folders and every project stay in view.",
+    "choose": "Use this one",
+    "settingsLabel": "Navigation",
+    "settingsHint": "How you switch between projects",
+    "optionTabs": "Project tabs",
+    "optionSidebar": "Projects sidebar"
   }
 }

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -1403,7 +1403,9 @@
     "paramSubject": "Subject",
     "paramActiveForm": "Active form",
     "paramStatus": "Status",
-    "labelSession": "Session"
+    "labelSession": "Session",
+    "labelProject": "Project",
+    "selectProject": "Select a project..."
   },
   "timetracking": {
     "title": "Time Tracking",

--- a/src/renderer/i18n/locales/es.json
+++ b/src/renderer/i18n/locales/es.json
@@ -3936,5 +3936,18 @@
       "watchMultiHint": "Elige uno o varios proyectos. «Cualquier proyecto» cubre también los que añadas después.",
       "watchMultiPickHint": "Se vigila por repositorio, así que elige al menos un proyecto."
     }
+  },
+  "navigationMode": {
+    "title": "Elige tu navegación",
+    "intro": "Claude Terminal puede organizar tus proyectos de dos formas. Puedes cambiarlo cuando quieras en Ajustes.",
+    "tabsTitle": "Pestañas de proyecto",
+    "tabsDesc": "Una pestaña por proyecto abierto en la parte superior, como un navegador. Deja el máximo espacio a la pantalla en la que trabajas.",
+    "sidebarTitle": "Columna de proyectos",
+    "sidebarDesc": "Una columna de proyectos permanente a la izquierda, como antes. Búsqueda, carpetas y todos los proyectos siempre a la vista.",
+    "choose": "Usar esta",
+    "settingsLabel": "Navegación",
+    "settingsHint": "Cómo cambias de proyecto",
+    "optionTabs": "Pestañas de proyecto",
+    "optionSidebar": "Columna de proyectos"
   }
 }

--- a/src/renderer/i18n/locales/es.json
+++ b/src/renderer/i18n/locales/es.json
@@ -1400,7 +1400,9 @@
     "paramSubject": "Asunto",
     "paramActiveForm": "Forma activa",
     "paramStatus": "Estado",
-    "labelSession": "Sesión"
+    "labelSession": "Sesión",
+    "labelProject": "Proyecto",
+    "selectProject": "Selecciona un proyecto..."
   },
   "timetracking": {
     "title": "Seguimiento de tiempo",

--- a/src/renderer/i18n/locales/fr.json
+++ b/src/renderer/i18n/locales/fr.json
@@ -3936,5 +3936,18 @@
       "watchMultiHint": "Choisissez un ou plusieurs projets. « N'importe quel projet » couvre aussi ceux ajoutés plus tard.",
       "watchMultiPickHint": "Surveillé par dépôt : choisissez au moins un projet."
     }
+  },
+  "navigationMode": {
+    "title": "Choisis ta navigation",
+    "intro": "Claude Terminal peut disposer tes projets de deux façons. Tu pourras changer à tout moment dans les Réglages.",
+    "tabsTitle": "Onglets de projet",
+    "tabsDesc": "Un onglet par projet ouvert en haut, comme un navigateur. Laisse le plus de place à l'écran sur lequel tu travailles.",
+    "sidebarTitle": "Colonne projets",
+    "sidebarDesc": "Une colonne projets permanente à gauche, comme avant. Recherche, dossiers et tous les projets restent visibles.",
+    "choose": "Utiliser celle-ci",
+    "settingsLabel": "Navigation",
+    "settingsHint": "Comment tu passes d'un projet à l'autre",
+    "optionTabs": "Onglets de projet",
+    "optionSidebar": "Colonne projets"
   }
 }

--- a/src/renderer/i18n/locales/fr.json
+++ b/src/renderer/i18n/locales/fr.json
@@ -1403,7 +1403,9 @@
     "paramSubject": "Sujet",
     "paramActiveForm": "Forme active",
     "paramStatus": "Statut",
-    "labelSession": "Session"
+    "labelSession": "Session",
+    "labelProject": "Projet",
+    "selectProject": "Sélectionner un projet..."
   },
   "timetracking": {
     "title": "Suivi du temps",

--- a/src/renderer/i18n/locales/id.json
+++ b/src/renderer/i18n/locales/id.json
@@ -3936,5 +3936,18 @@
       "watchMultiHint": "Pilih satu atau beberapa proyek. \"Proyek apa pun\" juga mencakup proyek yang Anda tambahkan nanti.",
       "watchMultiPickHint": "Dipantau per repositori, jadi pilih setidaknya satu proyek."
     }
+  },
+  "navigationMode": {
+    "title": "Pilih navigasi Anda",
+    "intro": "Claude Terminal dapat menata proyek Anda dengan dua cara. Anda bisa mengubahnya kapan saja di Pengaturan.",
+    "tabsTitle": "Tab proyek",
+    "tabsDesc": "Satu tab per proyek yang terbuka di bagian atas, seperti peramban. Menyisakan ruang paling banyak untuk layar yang sedang Anda pakai.",
+    "sidebarTitle": "Kolom proyek",
+    "sidebarDesc": "Kolom proyek permanen di sebelah kiri, seperti sebelumnya. Pencarian, folder, dan semua proyek tetap terlihat.",
+    "choose": "Gunakan ini",
+    "settingsLabel": "Navigasi",
+    "settingsHint": "Cara Anda berpindah antar proyek",
+    "optionTabs": "Tab proyek",
+    "optionSidebar": "Kolom proyek"
   }
 }

--- a/src/renderer/i18n/locales/id.json
+++ b/src/renderer/i18n/locales/id.json
@@ -1403,7 +1403,9 @@
     "paramSubject": "Subjek",
     "paramActiveForm": "Bentuk aktif",
     "paramStatus": "Status",
-    "labelSession": "Sesi"
+    "labelSession": "Sesi",
+    "labelProject": "Proyek",
+    "selectProject": "Pilih proyek..."
   },
   "timetracking": {
     "title": "Pelacakan Waktu",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -3936,5 +3936,18 @@
       "watchMultiHint": "选择一个或多个项目。 “任何项目”还包括您以后添加的项目。",
       "watchMultiPickHint": "按仓库进行监视，因此请至少选择一个项目。"
     }
+  },
+  "navigationMode": {
+    "title": "选择你的导航方式",
+    "intro": "Claude Terminal 可以用两种方式排布项目。你随时可以在设置中切换。",
+    "tabsTitle": "项目标签页",
+    "tabsDesc": "顶部每个打开的项目一个标签页，就像浏览器一样。为你正在使用的界面留出最多空间。",
+    "sidebarTitle": "项目侧栏",
+    "sidebarDesc": "左侧常驻的项目栏，和以前一样。搜索、文件夹和所有项目始终可见。",
+    "choose": "使用这个",
+    "settingsLabel": "导航",
+    "settingsHint": "你在项目之间切换的方式",
+    "optionTabs": "项目标签页",
+    "optionSidebar": "项目侧栏"
   }
 }

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -1403,7 +1403,9 @@
     "paramSubject": "主题",
     "paramActiveForm": "主动形式",
     "paramStatus": "状态",
-    "labelSession": "会话"
+    "labelSession": "会话",
+    "labelProject": "项目",
+    "selectProject": "选择一个项目..."
   },
   "timetracking": {
     "title": "时间追踪",

--- a/src/renderer/services/GitTabService.js
+++ b/src/renderer/services/GitTabService.js
@@ -361,7 +361,130 @@ function renderGitTab() {
   renderSubTabContent();
 }
 
+/* Sidebar navigation only: this screen keeps its own project list there.
+   In tab-bar mode the container is absent and this returns immediately. */
+function countFolderProjects(folder, folders, projects) {
+  let count = 0;
+  for (const childId of (folder.children || [])) {
+    const childFolder = folders.find(f => f.id === childId);
+    if (childFolder) count += countFolderProjects(childFolder, folders, projects);
+    else if (projects.find(p => p.id === childId)) count++;
+  }
+  return count;
+}
+
+function renderProjectsList() {
+  // Sidebar navigation only: in tab-bar mode the project bar is the selector
+  // and this list is not on screen, so there is nothing to paint.
+  if (!document.body.classList.contains('nav-sidebar')) return;
+  const list = document.getElementById('git-projects-list');
+  if (!list) return;
+
+  const state = projectsState.get();
+  const { projects, folders, rootOrder } = state;
+
+  if (!projects || projects.length === 0) {
+    list.innerHTML = `<div class="git-sidebar-empty">${t('projects.noProjects')}</div>`;
+    return;
+  }
+
+  function renderFolderItem(folder, depth) {
+    const indent = depth * 16;
+    const projectCount = countFolderProjects(folder, folders, projects);
+    const isCollapsed = folder.collapsed;
+
+    const folderIcon = folder.icon
+      ? `<span class="git-folder-emoji">${folder.icon}</span>`
+      : `<svg viewBox="0 0 24 24" fill="currentColor"><path d="M20 6h-8l-2-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2z"/></svg>`;
+
+    const colorDot = folder.color
+      ? `<span class="git-folder-color" style="background:${folder.color}"></span>`
+      : '';
+
+    let childrenHtml = '';
+    for (const childId of (folder.children || [])) {
+      const childFolder = folders.find(f => f.id === childId);
+      if (childFolder) {
+        childrenHtml += renderFolderItem(childFolder, depth + 1);
+      } else {
+        const childProject = projects.find(p => p.id === childId);
+        if (childProject) childrenHtml += renderProjectItem(childProject, depth + 1);
+      }
+    }
+
+    return `<div class="git-folder-item" data-folder-id="${escapeAttr(folder.id)}">
+      <div class="git-folder-header" style="padding-left:${8 + indent}px">
+        <span class="git-folder-chevron ${isCollapsed ? 'collapsed' : ''}">
+          <svg viewBox="0 0 24 24" fill="currentColor"><path d="M7 10l5 5 5-5z"/></svg>
+        </span>
+        ${colorDot}
+        <span class="git-folder-icon">${folderIcon}</span>
+        <span class="git-folder-name">${escapeHtml(folder.name)}</span>
+        <span class="git-folder-count">${projectCount}</span>
+      </div>
+      <div class="git-folder-children ${isCollapsed ? 'collapsed' : ''}">
+        ${childrenHtml}
+      </div>
+    </div>`;
+  }
+
+  function renderProjectItem(project, depth) {
+    const indent = depth * 16;
+    const isActive = selectedProjectId === project.id;
+
+    const iconHtml = project.icon
+      ? `<span class="git-project-emoji">${project.icon}</span>`
+      : `<svg viewBox="0 0 24 24" fill="currentColor"><path d="M20 6h-8l-2-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2z"/></svg>`;
+
+    const colorDot = project.color
+      ? `<span class="git-folder-color" style="background:${project.color}"></span>`
+      : '';
+
+    const pathParts = project.path ? project.path.replace(/\\/g, '/').split('/') : [];
+    const shortPath = pathParts.length > 2 ? '.../' + pathParts.slice(-2).join('/') : project.path || '';
+
+    return `<div class="git-project-item ${isActive ? 'active' : ''}" data-project-id="${escapeAttr(project.id)}" style="padding-left:${indent}px">
+      <div class="git-project-icon">${colorDot}${iconHtml}</div>
+      <div class="git-project-info">
+        <div class="git-project-name">${escapeHtml(project.name)}</div>
+        <div class="git-project-path">${escapeHtml(shortPath)}</div>
+      </div>
+    </div>`;
+  }
+
+  let html = '';
+  for (const itemId of (rootOrder || [])) {
+    const folder = folders.find(f => f.id === itemId);
+    if (folder) {
+      html += renderFolderItem(folder, 0);
+    } else {
+      const project = projects.find(p => p.id === itemId);
+      if (project) html += renderProjectItem(project, 0);
+    }
+  }
+
+  list.innerHTML = html;
+
+  // Delegated click handler for project list
+  list.onclick = (e) => {
+    const header = e.target.closest('.git-folder-header');
+    if (header) {
+      e.stopPropagation();
+      const chevron = header.querySelector('.git-folder-chevron');
+      const children = header.nextElementSibling;
+      if (chevron && children) {
+        chevron.classList.toggle('collapsed');
+        children.classList.toggle('collapsed');
+      }
+      return;
+    }
+    const item = e.target.closest('.git-project-item[data-project-id]');
+    if (item) selectProjectById(item.dataset.projectId);
+  };
+}
+
 function renderSidebar() {
+  renderProjectsList();
   renderQuickActions();
   renderBranches();
   renderTags();

--- a/src/renderer/state/settings.state.js
+++ b/src/renderer/state/settings.state.js
@@ -71,6 +71,7 @@ const defaultSettings = {
   pinnedTabs: ['claude', 'git', 'database', 'mcp', 'plugins', 'skills', 'agents', 'workflows', 'tasks', 'control-tower', 'dashboard', 'timetracking', 'session-replay', 'memory', 'connectivity'], // Pinned sidebar tabs (rest go to More menu)
   activeTab: 'claude', // Last active sidebar tab (restored on restart)
   openProjectIds: [], // Projects with a tab in the project bar, in tab order (restored on restart)
+  navigationMode: null, // 'tabs' | 'sidebar' | null = never chosen, ask once on next launch
   tabsOrder: null, // null = canonical order, otherwise array of all tabIds in custom order
   parallelMaxAgents: 3, // Default number of parallel agents for Parallel Task Manager (1-10)
   maxTurns: null, // null = no limit (SDK/CLI default), or a cap on API round-trips for the whole tab

--- a/src/renderer/ui/navigationMode.js
+++ b/src/renderer/ui/navigationMode.js
@@ -1,0 +1,80 @@
+/**
+ * Navigation mode
+ *
+ * Two navigations ship together and only one is mounted at a time: the project
+ * tab bar, or the projects sidebar it replaced. Which one is a body class.
+ *
+ * Two nodes are shared rather than duplicated — the projects host and the tools
+ * row — because a second `#projects-list` or a second tool row would be two
+ * implementations drifting apart. They are moved to where each navigation
+ * expects them, which is what most of this module does.
+ */
+
+const MODES = ['tabs', 'sidebar'];
+
+/** @returns {boolean} true when `mode` is a navigation the app can mount */
+function isNavigationMode(mode) {
+  return MODES.includes(mode);
+}
+
+/**
+ * The mode to mount for a stored setting. Anything unset or unrecognised falls
+ * back to the tab bar, which is what a fresh install gets.
+ * @param {string|null|undefined} stored
+ * @returns {'tabs'|'sidebar'}
+ */
+function resolveNavigationMode(stored) {
+  return stored === 'sidebar' ? 'sidebar' : 'tabs';
+}
+
+/**
+ * Apply a mode to the DOM: the body class, and the two shared nodes.
+ * Safe to call before those nodes exist (first paint) and repeatedly.
+ * @param {'tabs'|'sidebar'|null} mode
+ * @param {Document} [doc]
+ */
+function applyNavigationMode(mode, doc = typeof document !== 'undefined' ? document : null) {
+  if (!doc) return;
+  const sidebar = resolveNavigationMode(mode) === 'sidebar';
+  doc.body.classList.toggle('nav-sidebar', sidebar);
+  doc.body.classList.toggle('nav-tabs', !sidebar);
+
+  const popover = doc.getElementById('projects-popover');
+  const layout = doc.getElementById('claude-layout');
+  const content = doc.querySelector('.content');
+  const tools = doc.getElementById('project-bar-tools');
+  const header = doc.getElementById('terminals-header');
+  const bar = doc.getElementById('project-bar');
+
+  if (sidebar) {
+    // Docked column, left of the file explorer, as it was before the tab bar
+    if (popover && layout && popover.parentElement !== layout) {
+      layout.insertBefore(popover, layout.querySelector('#file-explorer-panel'));
+    }
+    if (tools && header && tools.parentElement !== header) header.appendChild(tools);
+    if (popover) popover.style.display = 'flex';
+  } else {
+    if (popover && content && popover.parentElement !== content) {
+      content.insertBefore(popover, content.querySelector('.tab-content'));
+    }
+    if (tools && bar && tools.parentElement !== bar) bar.appendChild(tools);
+    // Back to a popover: closed until the + button opens it
+    if (popover) {
+      popover.style.display = 'none';
+      popover.classList.remove('collapsed');
+    }
+  }
+}
+
+/** True when the docked sidebar is the mounted navigation. */
+function isSidebarNavigation(doc = typeof document !== 'undefined' ? document : null) {
+  return !!doc && doc.body.classList.contains('nav-sidebar');
+}
+
+module.exports = {
+  MODES,
+  isNavigationMode,
+  resolveNavigationMode,
+  applyNavigationMode,
+  isSidebarNavigation,
+};

--- a/src/renderer/ui/panels/SessionReplayPanel.js
+++ b/src/renderer/ui/panels/SessionReplayPanel.js
@@ -1422,6 +1422,13 @@ function buildHtml() {
           </div>
         </div>
         <div class="sr-controls">
+          <!-- Sidebar navigation only: with no project bar to pick from, this
+               screen carries its own selector again. It drives the same active
+               project the bar does, not a second one. -->
+          <div class="sr-control-group sr-control-group--project">
+            <label class="sr-control-label">${t('sessionReplay.labelProject')}</label>
+            <div class="sr-cs-container" id="sr-project-select-wrap"></div>
+          </div>
           <div class="sr-control-group sr-control-group--branch" id="sr-branch-select-wrap" style="display:none">
             <label class="sr-control-label">${t('sessions.filterBranch')}</label>
             <div class="sr-cs-container"></div>
@@ -1469,6 +1476,26 @@ function init(containerEl, opts = {}) {
 
   const deleteBtn = container.querySelector('#sr-delete-btn');
   const exportBtn = container.querySelector('#sr-export-btn');
+
+  // Sidebar navigation only: the project selector this screen used to own.
+  // Picking here goes through the app's single project switch, so the panel
+  // still reads the active project from _activeProjectPath() either way.
+  const projWidget = makeCustomSelect(t('sessionReplay.selectProject'));
+  container.querySelector('#sr-project-select-wrap').appendChild(projWidget.el);
+  if (projectsState) {
+    const state = projectsState.get();
+    const projects = state.projects || [];
+    projWidget.setOptions(
+      `<option value="">${t('sessionReplay.selectProject')}</option>` +
+      projects.map(p => `<option value="${escapeHtml(p.path)}">${escapeHtml(p.name || p.path)}</option>`).join('')
+    );
+    projWidget.value = _activeProjectPath();
+    projWidget.addEventListener('change', () => {
+      const picked = projWidget.value;
+      if (!picked || picked === _activeProjectPath()) return;
+      document.dispatchEvent(new CustomEvent('project-select-by-path', { detail: picked }));
+    });
+  }
 
   // Create and inject custom select widgets
   const branchWidget = makeCustomSelect(t('sessions.allBranches'));

--- a/src/renderer/ui/panels/SettingsPanel.js
+++ b/src/renderer/ui/panels/SettingsPanel.js
@@ -706,6 +706,16 @@ class SettingsPanel extends BasePanel {
               </div>
               <div class="settings-toggle-row">
                 <div class="settings-toggle-label">
+                  <div>${t('navigationMode.settingsLabel')}</div>
+                  <div class="settings-toggle-desc">${t('navigationMode.settingsHint')}</div>
+                </div>
+                <select id="navigation-mode-select" class="settings-select">
+                  <option value="tabs" ${settings.navigationMode !== 'sidebar' ? 'selected' : ''}>${t('navigationMode.optionTabs')}</option>
+                  <option value="sidebar" ${settings.navigationMode === 'sidebar' ? 'selected' : ''}>${t('navigationMode.optionSidebar')}</option>
+                </select>
+              </div>
+              <div class="settings-toggle-row">
+                <div class="settings-toggle-label">
                   <div>${t('settings.compactProjects')}</div>
                   <div class="settings-toggle-desc">${t('settings.compactProjectsDesc')}</div>
                 </div>
@@ -1909,6 +1919,14 @@ class SettingsPanel extends BasePanel {
           showProject: newDiscordRpcShowProject,
         });
       } catch (_) { /* discordRpc bridge unavailable */ }
+
+      // Swapping navigation relocates DOM and repaints the project-scoped
+      // screens, so it goes back through the renderer rather than being applied
+      // here — same path the first-launch card takes.
+      const navSelect = document.getElementById('navigation-mode-select');
+      if (navSelect && navSelect.value !== settings.navigationMode) {
+        document.dispatchEvent(new CustomEvent('navigation-mode-change', { detail: navSelect.value }));
+      }
 
       document.body.classList.toggle('compact-projects', newCompactProjects);
       document.body.classList.toggle('reduce-motion', newReduceMotion);

--- a/styles/dashboard.css
+++ b/styles/dashboard.css
@@ -12,6 +12,119 @@
   overflow: hidden;
 }
 
+.dashboard-sidebar {
+  width: 280px;
+  min-width: 200px;
+  flex-shrink: 0;
+  background: var(--bg-secondary);
+  border-right: 1px solid var(--border-color);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+@media (max-width: 1100px) {
+  .dashboard-sidebar {
+    width: 220px;
+    min-width: 180px;
+  }
+}
+
+.dashboard-sidebar-header {
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.dashboard-sidebar-header h3 {
+  font-size: var(--font-base);
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.dashboard-projects-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+}
+
+.dashboard-projects-empty {
+  padding: 20px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.dashboard-project-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px;
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease, opacity 0.15s ease;
+  margin-bottom: 4px;
+}
+
+.dashboard-project-item:hover {
+  background: var(--bg-hover);
+}
+
+.dashboard-project-item.active {
+  background: var(--accent);
+}
+
+.dashboard-project-item.active .dashboard-project-name {
+  color: white;
+}
+
+.dashboard-project-item.active .dashboard-project-path {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.dashboard-project-item.active .dashboard-project-icon {
+  color: white;
+}
+
+.dashboard-project-icon {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent);
+  flex-shrink: 0;
+}
+
+.dashboard-project-icon svg {
+  width: 20px;
+  height: 20px;
+}
+
+.dashboard-project-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.dashboard-project-name {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.dashboard-project-path {
+  font-size: 11px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 2px;
+}
+
 .dashboard-main {
   flex: 1;
   overflow: hidden;
@@ -1462,7 +1575,111 @@
   margin-left: auto;
 }
 
+/* ===== Dashboard Sidebar Folders ===== */
+
+.dash-folder-item {
+  margin-bottom: 2px;
+}
+
+.dash-folder-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background 0.15s;
+  user-select: none;
+}
+
+.dash-folder-header:hover {
+  background: var(--bg-hover);
+}
+
+.dash-folder-chevron {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.15s;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.dash-folder-chevron svg {
+  width: 16px;
+  height: 16px;
+}
+
+.dash-folder-chevron.collapsed {
+  transform: rotate(-90deg);
+}
+
+.dash-folder-color {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.dash-folder-icon {
+  display: flex;
+  align-items: center;
+  color: var(--accent);
+  flex-shrink: 0;
+}
+
+.dash-folder-icon svg {
+  width: 16px;
+  height: 16px;
+}
+
+.dash-folder-emoji {
+  font-size: 14px;
+  line-height: 1;
+}
+
+.dash-folder-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.dash-folder-count {
+  font-size: 11px;
+  color: var(--text-muted);
+  background: var(--bg-hover);
+  padding: 1px 6px;
+  border-radius: 8px;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.dash-folder-children {
+  margin-left: 8px;
+  border-left: 1px solid var(--border-color);
+  padding-left: 4px;
+}
+
+.dash-folder-children.collapsed {
+  display: none;
+}
+
+.dashboard-project-emoji {
+  font-size: 16px;
+  line-height: 1;
+}
+
 /* ===== Overview Dashboard ===== */
+
+/* Overview item separator in sidebar */
+.dashboard-project-item.overview-item {
+  border-bottom: 1px solid var(--border-color);
+  margin-bottom: 8px;
+  padding-bottom: 12px;
+}
 
 /* Overview container with folder sections */
 .overview-container {

--- a/styles/git.css
+++ b/styles/git.css
@@ -985,7 +985,10 @@
   flex-shrink: 0;
 }
 
-/* Project bar tools are the positioning context for the changes/branch dropdowns */
+/* Terminals header relative for dropdown positioning */
+/* Both hosts exist: the terminals header in sidebar mode, the project bar
+   tools in tab mode. Whichever is on screen anchors the dropdowns. */
+.terminals-header,
 .project-bar-tools {
   position: relative;
 }
@@ -1025,6 +1028,7 @@
   border-bottom: 1px solid rgba(255, 255, 255, 0.04);
 }
 
+.git-sidebar-section.git-sidebar-projects,
 .git-sidebar-section.git-sidebar-quick-actions {
   flex-shrink: 0;
 }
@@ -1092,6 +1096,209 @@
   font-size: var(--font-2xs);
   color: var(--text-muted);
   opacity: 0.6;
+}
+
+/* Projects list in sidebar */
+.git-projects-list {
+  max-height: 280px;
+  overflow-y: auto;
+  padding: 2px 6px 6px;
+}
+
+.git-projects-list::-webkit-scrollbar { width: 4px; }
+.git-projects-list::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.08); border-radius: 2px; }
+.git-projects-list::-webkit-scrollbar-thumb:hover { background: rgba(255,255,255,0.15); }
+
+/* Folder items */
+.git-folder-item {
+  margin-bottom: 1px;
+}
+
+.git-folder-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.12s;
+}
+
+.git-folder-header:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.git-folder-chevron {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.15s;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.git-folder-chevron svg {
+  width: 14px;
+  height: 14px;
+}
+
+.git-folder-chevron.collapsed {
+  transform: rotate(-90deg);
+}
+
+.git-folder-color {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.git-folder-icon {
+  display: flex;
+  align-items: center;
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+
+.git-folder-icon svg {
+  width: 15px;
+  height: 15px;
+}
+
+.git-folder-emoji {
+  font-size: 13px;
+  line-height: 1;
+}
+
+.git-folder-name {
+  font-size: var(--font-xs);
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.git-folder-count {
+  font-size: 9px;
+  color: var(--text-muted);
+  background: rgba(255, 255, 255, 0.05);
+  padding: 0 5px;
+  border-radius: 6px;
+  margin-left: auto;
+  line-height: 1.5;
+}
+
+.git-folder-children {
+  margin-left: 10px;
+  border-left: 1px solid rgba(255, 255, 255, 0.04);
+  padding-left: 2px;
+}
+
+.git-folder-children.collapsed {
+  display: none;
+}
+
+/* Project items */
+.git-project-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 10px;
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: background-color 0.12s ease, color 0.12s ease, border-color 0.12s ease, opacity 0.12s ease;
+  border-radius: 6px;
+  margin-bottom: 1px;
+  position: relative;
+}
+
+.git-project-item:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.git-project-item.active {
+  background: rgba(217, 119, 6, 0.1);
+}
+
+.git-project-item.active::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 4px;
+  bottom: 4px;
+  width: 2px;
+  background: var(--accent);
+  border-radius: 1px;
+}
+
+.git-project-item.active .git-project-name {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.git-project-item.active .git-project-path {
+  color: var(--text-secondary);
+}
+
+.git-project-item.active .git-project-icon {
+  color: var(--accent);
+}
+
+.git-project-icon {
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-secondary);
+  flex-shrink: 0;
+  position: relative;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 6px;
+}
+
+.git-project-icon svg {
+  width: 16px;
+  height: 16px;
+}
+
+.git-project-icon .git-folder-color {
+  position: absolute;
+  top: -1px;
+  right: -1px;
+  width: 6px;
+  height: 6px;
+}
+
+.git-project-emoji {
+  font-size: 16px;
+  line-height: 1;
+}
+
+.git-project-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.git-project-name {
+  font-size: var(--font-sm);
+  font-weight: 500;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.3;
+}
+
+.git-project-path {
+  font-size: 10px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 1px;
+  opacity: 0.7;
 }
 
 /* Quick actions */

--- a/styles/layout.css
+++ b/styles/layout.css
@@ -971,6 +971,8 @@ body.platform-darwin .titlebar-drag {
   background: var(--bg-primary);
   display: flex;
   flex-direction: column;
+  /* Positioning context for the docked projects panel in sidebar mode */
+  position: relative;
 }
 
 /* ============================================

--- a/styles/projects.css
+++ b/styles/projects.css
@@ -321,31 +321,49 @@ body:not([data-active-tab="claude"]) .project-bar-tools {
   font-size: var(--font-base);
 }
 
-/* Claude Layout */
-.claude-layout {
-  display: flex;
-  flex: 1;
-  overflow: hidden;
-  position: relative;
+/* ── Sidebar navigation mode ──────────────────────────────────────────────
+   The pre-tab-bar navigation, shipped in full alongside the tab bar. The
+   projects host is moved into .claude-layout and stops being a popover: it
+   becomes the docked column it was, with its resizer and collapse toggle.
+   Only one navigation is mounted at a time, so the two never overlap. ── */
+
+.claude-layout > .projects-popover {
+  position: static;
+  width: var(--projects-panel-width);
+  min-width: 170px;
+  max-width: 450px;
+  flex-shrink: 0;
+  max-height: none;
+  border: none;
+  border-right: 1px solid var(--border-color);
+  border-radius: 0;
+  box-shadow: none;
+  overflow: visible;
+  z-index: 10;
+  transition: width 0.2s ease, min-width 0.2s ease, opacity 0.2s ease;
 }
 
-/* Lives inside .projects-popover — sized by it, not by the layout. */
-.projects-panel {
-  flex: 1;
+.claude-layout > .projects-popover.collapsed {
+  width: 0 !important;
   min-width: 0;
-  background: var(--bg-secondary);
-  display: flex;
-  flex-direction: column;
+  max-width: 0;
+  border-right: none;
   overflow: hidden;
-  position: relative;
+  opacity: 0;
+  pointer-events: none;
 }
 
-.projects-popover .panel-header {
-  padding: 10px 12px;
+/* The tab strip and its + button are the other navigation. The tools row
+   stays: it is the terminals header the sidebar layout also uses. */
+body.nav-sidebar .project-tabs,
+body.nav-sidebar .project-tab-add,
+body.nav-sidebar #btn-close-projects-popover {
+  display: none;
 }
 
-.projects-popover .panel-header h2 {
-  font-size: var(--font-base);
+body.nav-tabs .btn-show-projects,
+body.nav-tabs #btn-toggle-projects {
+  display: none !important;
 }
 
 .sessions-panel {
@@ -4176,4 +4194,75 @@ body.compact-projects .project-item:hover {
 .qa-env-var-row input:focus {
   border-color: var(--accent);
   outline: none;
+}
+
+/* Toggle button icon rotation */
+#btn-toggle-projects svg {
+  transition: transform 0.2s ease;
+}
+
+/* Thin strip to re-open projects panel */
+.btn-show-projects {
+  position: absolute;
+  top: 53px;
+  left: 0;
+  width: 20px;
+  height: calc(100% - 53px);
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  align-items: center;
+  justify-content: center;
+  z-index: 15;
+  transition: background-color 0.15s, color 0.15s, border-color 0.15s, opacity 0.15s;
+  display: none;
+  padding: 0;
+}
+
+.btn-show-projects:hover {
+  background: var(--bg-tertiary);
+  color: var(--accent-color);
+}
+
+.btn-show-projects svg {
+  width: 14px;
+  height: 14px;
+}
+
+.claude-layout.projects-hidden .btn-show-projects {
+  display: flex;
+}
+
+.btn-more-actions {
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.15s, color 0.15s, border-color 0.15s, opacity 0.15s;
+  background: transparent;
+  color: var(--text-muted);
+}
+
+.btn-more-actions svg {
+  width: 16px;
+  height: 16px;
+}
+
+.btn-more-actions:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+
+/* Those two screens carry their own project list in sidebar mode only */
+body.nav-tabs .git-sidebar-projects,
+body.nav-tabs .dashboard-sidebar,
+body.nav-tabs #terminals-header {
+  display: none !important;
 }

--- a/styles/projects.css
+++ b/styles/projects.css
@@ -353,10 +353,9 @@ body:not([data-active-tab="claude"]) .project-bar-tools {
   pointer-events: none;
 }
 
-/* The tab strip and its + button are the other navigation. The tools row
-   stays: it is the terminals header the sidebar layout also uses. */
-body.nav-sidebar .project-tabs,
-body.nav-sidebar .project-tab-add,
+/* The whole bar is the other navigation. Its tools row is moved into the
+   terminals header first, so nothing is left in it to show. */
+body.nav-sidebar #project-bar,
 body.nav-sidebar #btn-close-projects-popover {
   display: none;
 }

--- a/styles/projects.css
+++ b/styles/projects.css
@@ -4265,3 +4265,136 @@ body.nav-tabs .dashboard-sidebar,
 body.nav-tabs #terminals-header {
   display: none !important;
 }
+
+/* ── First-launch navigation chooser ──────────────────────────────────────
+   The two layouts side by side, each drawn as a CSS miniature so it follows
+   the accent colour and cannot go stale against the real UI. ── */
+
+.nav-choice-intro {
+  margin: 0 0 16px;
+  color: var(--text-secondary);
+  font-size: var(--font-sm);
+}
+
+.nav-choice-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.nav-choice {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 14px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.15s, background-color 0.15s;
+}
+
+.nav-choice:hover {
+  border-color: var(--accent);
+  background: var(--bg-hover);
+}
+
+.nav-choice-title {
+  font-size: var(--font-base);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.nav-choice-desc {
+  font-size: var(--font-xs);
+  color: var(--text-secondary);
+  line-height: 1.45;
+}
+
+.nav-choice-cta {
+  margin-top: 2px;
+  font-size: var(--font-2xs);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+/* ── Layout miniatures ── */
+
+/* Inline by default, so it would shrink-wrap the miniature instead of giving
+   it the card's width */
+.nav-choice-preview {
+  display: block;
+  width: 100%;
+  align-self: stretch;
+}
+
+.nav-mini {
+  display: flex;
+  width: 100%;
+  height: 96px;
+  gap: 3px;
+  padding: 4px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+}
+
+.nav-mini-nav {
+  width: 14px;
+  flex-shrink: 0;
+  background: var(--bg-secondary);
+  border-radius: 2px;
+}
+
+.nav-mini-col {
+  width: 26px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 3px;
+  background: var(--bg-secondary);
+  border-radius: 2px;
+}
+
+.nav-mini-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.nav-mini-tabs {
+  display: flex;
+  gap: 3px;
+  height: 10px;
+  flex-shrink: 0;
+}
+
+.nav-mini-tabs i {
+  flex: 1;
+  background: var(--bg-secondary);
+  border-radius: 2px;
+}
+
+.nav-mini-tabs i:first-child,
+.nav-mini-col i:first-child {
+  background: var(--accent-dim);
+  box-shadow: inset 0 0 0 1px var(--accent);
+}
+
+.nav-mini-col i {
+  height: 8px;
+  background: var(--bg-tertiary);
+  border-radius: 2px;
+}
+
+.nav-mini-screen {
+  flex: 1;
+  background: var(--bg-secondary);
+  border-radius: 2px;
+}

--- a/styles/session-replay.css
+++ b/styles/session-replay.css
@@ -1602,3 +1602,9 @@
   letter-spacing: 0.3px;
   flex-shrink: 0;
 }
+
+/* Sidebar navigation only: with a project bar on screen this selector would be
+   a second way to pick the same thing. */
+body.nav-tabs .sr-control-group--project {
+  display: none;
+}

--- a/styles/terminal.css
+++ b/styles/terminal.css
@@ -2355,3 +2355,112 @@ mark.md-search-hit.md-search-current {
 body.hide-tab-mode-toggle .tab-mode-toggle {
   display: none !important;
 }
+
+/* ── Sidebar navigation mode ──────────────────────────────────────────────
+   The pre-tab-bar terminals header and its filter row. Both navigations ship
+   in full and only one is mounted at a time, so these live alongside the
+   project bar rules rather than replacing them. ── */
+
+.terminals-header {
+  display: flex;
+  align-items: center;
+  background: var(--bg-secondary);
+  min-height: 0;
+  position: relative;
+}
+
+.terminals-header:has(.terminals-filter[style*="flex"]) {
+  min-height: 36px;
+  padding: 4px 0;
+}
+
+.filter-project {
+  color: var(--accent);
+  font-weight: 600;
+  background: var(--accent-dim);
+  padding: 4px 12px;
+  border-radius: var(--radius-sm);
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex-shrink: 1;
+}
+
+.filter-clear {
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.15s, color 0.15s, border-color 0.15s, opacity 0.15s;
+  margin-left: 4px;
+}
+
+.filter-clear svg {
+  width: 10px;
+  height: 10px;
+}
+
+.filter-clear:hover {
+  background: var(--accent);
+  color: white;
+}
+
+.filter-resume-session-btn {
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.15s, color 0.15s, border-color 0.15s, opacity 0.15s;
+  flex-shrink: 0;
+}
+
+.filter-resume-session-btn:hover {
+  background: var(--accent-dim);
+  color: var(--accent);
+}
+
+.filter-resume-session-btn svg {
+  width: 14px;
+  height: 14px;
+}
+
+.filter-new-terminal-btn {
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.15s, color 0.15s, border-color 0.15s, opacity 0.15s;
+  flex-shrink: 0;
+}
+
+.filter-new-terminal-btn:hover {
+  background: var(--accent-dim);
+  color: var(--accent);
+}
+
+.filter-new-terminal-btn svg {
+  width: 14px;
+  height: 14px;
+}

--- a/tests/state/projectTabs.state.test.js
+++ b/tests/state/projectTabs.state.test.js
@@ -1,0 +1,215 @@
+// Open project tabs.
+//
+// The tab list is addressed by project id while the active project is an index
+// into `projects`, so the interesting cases are the ones where those two views
+// have to agree: closing the active tab, reordering by drag, and restoring a
+// list saved by a previous run.
+
+const {
+  projectsState,
+  restoreOpenProjectIds,
+  isProjectOpen,
+  getOpenProjects,
+  openProjectTab,
+  closeProjectTab,
+  moveProjectTab,
+  setSelectedProjectFilter,
+} = require('../../src/renderer/state/projects.state');
+
+const PROJECTS = [
+  { id: 'p1', name: 'one', path: '/tmp/one' },
+  { id: 'p2', name: 'two', path: '/tmp/two' },
+  { id: 'p3', name: 'three', path: '/tmp/three' },
+  { id: 'p4', name: 'four', path: '/tmp/four' },
+];
+
+function reset(override = {}) {
+  projectsState.set({
+    projects: PROJECTS.map(p => ({ ...p })),
+    folders: [],
+    rootOrder: PROJECTS.map(p => p.id),
+    selectedProjectFilter: null,
+    openedProjectId: null,
+    openProjectIds: [],
+    ...override,
+  });
+}
+
+const openIds = () => projectsState.get().openProjectIds;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  reset();
+  window.electron_nodeModules.fs.existsSync.mockReturnValue(false);
+  window.electron_nodeModules.fs.readFileSync.mockReturnValue('{}');
+  window.electron_nodeModules.fs.writeFileSync.mockImplementation(() => {});
+  window.electron_nodeModules.fs.renameSync.mockImplementation(() => {});
+});
+
+describe('openProjectTab', () => {
+  test('gives the project a tab and makes it active', () => {
+    openProjectTab('p2');
+
+    expect(openIds()).toEqual(['p2']);
+    expect(isProjectOpen('p2')).toBe(true);
+    expect(projectsState.get().selectedProjectFilter).toBe(1);
+  });
+
+  test('opening the same project twice does not duplicate the tab', () => {
+    openProjectTab('p2');
+    openProjectTab('p2');
+
+    expect(openIds()).toEqual(['p2']);
+  });
+
+  test('activate:false gives a tab without stealing focus', () => {
+    openProjectTab('p1');
+    openProjectTab('p3', { activate: false });
+
+    expect(openIds()).toEqual(['p1', 'p3']);
+    expect(projectsState.get().selectedProjectFilter).toBe(0);
+  });
+
+  test('an unknown id opens nothing', () => {
+    openProjectTab('nope');
+
+    expect(openIds()).toEqual([]);
+  });
+});
+
+describe('setSelectedProjectFilter', () => {
+  test('selecting a project also gives it a tab', () => {
+    setSelectedProjectFilter(2);
+
+    expect(openIds()).toEqual(['p3']);
+    expect(projectsState.get().selectedProjectFilter).toBe(2);
+  });
+
+  test('clearing the filter opens nothing', () => {
+    setSelectedProjectFilter(null);
+
+    expect(openIds()).toEqual([]);
+    expect(projectsState.get().selectedProjectFilter).toBe(null);
+  });
+});
+
+describe('closeProjectTab', () => {
+  test('closing an inactive tab leaves the active project alone', () => {
+    reset({ openProjectIds: ['p1', 'p2', 'p3'], selectedProjectFilter: 0 });
+
+    expect(closeProjectTab('p3')).toBe(null);
+    expect(openIds()).toEqual(['p1', 'p2']);
+    expect(projectsState.get().selectedProjectFilter).toBe(0);
+  });
+
+  test('closing the active tab moves focus to its right', () => {
+    reset({ openProjectIds: ['p1', 'p2', 'p3'], selectedProjectFilter: 1 });
+
+    // p2 closes, so the tab the eye is already on is p3
+    expect(closeProjectTab('p2')).toBe(2);
+    expect(openIds()).toEqual(['p1', 'p3']);
+    expect(projectsState.get().selectedProjectFilter).toBe(2);
+  });
+
+  test('closing the last tab falls back to its left', () => {
+    reset({ openProjectIds: ['p1', 'p2'], selectedProjectFilter: 1 });
+
+    expect(closeProjectTab('p2')).toBe(0);
+    expect(projectsState.get().selectedProjectFilter).toBe(0);
+  });
+
+  test('closing the only tab leaves nothing active', () => {
+    reset({ openProjectIds: ['p2'], selectedProjectFilter: 1 });
+
+    expect(closeProjectTab('p2')).toBe(null);
+    expect(openIds()).toEqual([]);
+    expect(projectsState.get().selectedProjectFilter).toBe(null);
+  });
+
+  test('closing a project with no tab is a no-op', () => {
+    reset({ openProjectIds: ['p1'], selectedProjectFilter: 0 });
+
+    expect(closeProjectTab('p4')).toBe(null);
+    expect(openIds()).toEqual(['p1']);
+  });
+});
+
+describe('moveProjectTab', () => {
+  test('moves a tab to a later position', () => {
+    reset({ openProjectIds: ['p1', 'p2', 'p3'] });
+
+    moveProjectTab('p1', 2);
+
+    expect(openIds()).toEqual(['p2', 'p3', 'p1']);
+  });
+
+  test('moves a tab to an earlier position', () => {
+    reset({ openProjectIds: ['p1', 'p2', 'p3'] });
+
+    moveProjectTab('p3', 0);
+
+    expect(openIds()).toEqual(['p3', 'p1', 'p2']);
+  });
+
+  test('a target past the end lands at the end rather than dropping the tab', () => {
+    reset({ openProjectIds: ['p1', 'p2', 'p3'] });
+
+    moveProjectTab('p1', 99);
+
+    expect(openIds()).toEqual(['p2', 'p3', 'p1']);
+  });
+
+  test('a negative target lands at the front', () => {
+    reset({ openProjectIds: ['p1', 'p2', 'p3'] });
+
+    moveProjectTab('p3', -5);
+
+    expect(openIds()).toEqual(['p3', 'p1', 'p2']);
+  });
+
+  test('moving a project that has no tab changes nothing', () => {
+    reset({ openProjectIds: ['p1', 'p2'] });
+
+    moveProjectTab('p4', 0);
+
+    expect(openIds()).toEqual(['p1', 'p2']);
+  });
+});
+
+describe('restoreOpenProjectIds', () => {
+  test('restores the saved order', () => {
+    restoreOpenProjectIds(['p3', 'p1']);
+
+    expect(openIds()).toEqual(['p3', 'p1']);
+    expect(getOpenProjects().map(p => p.name)).toEqual(['three', 'one']);
+  });
+
+  test('drops ids of projects that no longer exist', () => {
+    restoreOpenProjectIds(['p1', 'deleted-since', 'p2']);
+
+    expect(openIds()).toEqual(['p1', 'p2']);
+  });
+
+  test('ignores anything that is not a list', () => {
+    reset({ openProjectIds: ['p1'] });
+
+    restoreOpenProjectIds(undefined);
+    restoreOpenProjectIds('p2');
+
+    expect(openIds()).toEqual(['p1']);
+  });
+});
+
+describe('getOpenProjects', () => {
+  test('returns the projects in tab order, not in project order', () => {
+    reset({ openProjectIds: ['p4', 'p1'] });
+
+    expect(getOpenProjects().map(p => p.id)).toEqual(['p4', 'p1']);
+  });
+
+  test('skips ids with no matching project instead of returning holes', () => {
+    reset({ openProjectIds: ['p1', 'ghost', 'p2'] });
+
+    expect(getOpenProjects().map(p => p.id)).toEqual(['p1', 'p2']);
+  });
+});

--- a/tests/ui/navigationMode.test.js
+++ b/tests/ui/navigationMode.test.js
@@ -1,0 +1,126 @@
+// Navigation mode: two navigations ship together and only one is mounted.
+//
+// The two shared nodes are moved rather than duplicated, so what this really
+// guards is that each mode leaves them where its layout expects them, and that
+// switching back and forth is reversible.
+
+const {
+  MODES,
+  isNavigationMode,
+  resolveNavigationMode,
+  applyNavigationMode,
+  isSidebarNavigation,
+} = require('../../src/renderer/ui/navigationMode');
+
+/** The parts of index.html the mode actually moves things between. */
+function buildDom() {
+  document.body.className = '';
+  document.body.innerHTML = `
+    <div class="content">
+      <div class="project-bar" id="project-bar">
+        <div class="project-tabs" id="project-tabs"></div>
+        <div class="project-bar-tools" id="project-bar-tools"></div>
+      </div>
+      <div class="projects-popover" id="projects-popover" style="display:none">
+        <div class="projects-panel"><div id="projects-list"></div></div>
+      </div>
+      <div class="tab-content" id="tab-claude">
+        <div class="claude-layout" id="claude-layout">
+          <div class="file-explorer-panel" id="file-explorer-panel"></div>
+          <div class="terminals-panel">
+            <div class="terminals-header" id="terminals-header"></div>
+          </div>
+        </div>
+      </div>
+    </div>`;
+}
+
+const parentIdOf = (id) => document.getElementById(id)?.parentElement?.id || null;
+
+beforeEach(buildDom);
+
+describe('resolveNavigationMode', () => {
+  test('only the two shipped navigations are modes', () => {
+    expect(MODES).toEqual(['tabs', 'sidebar']);
+    expect(isNavigationMode('tabs')).toBe(true);
+    expect(isNavigationMode('sidebar')).toBe(true);
+    expect(isNavigationMode('drawer')).toBe(false);
+  });
+
+  test('an unset or unknown setting falls back to the tab bar', () => {
+    // null is what a install that has never been asked carries
+    expect(resolveNavigationMode(null)).toBe('tabs');
+    expect(resolveNavigationMode(undefined)).toBe('tabs');
+    expect(resolveNavigationMode('drawer')).toBe('tabs');
+    expect(resolveNavigationMode('sidebar')).toBe('sidebar');
+  });
+});
+
+describe('applyNavigationMode', () => {
+  test('sidebar docks the projects host and moves the tools into the header', () => {
+    applyNavigationMode('sidebar');
+
+    expect(isSidebarNavigation()).toBe(true);
+    expect(document.body.classList.contains('nav-sidebar')).toBe(true);
+    expect(document.body.classList.contains('nav-tabs')).toBe(false);
+    expect(parentIdOf('projects-popover')).toBe('claude-layout');
+    expect(parentIdOf('project-bar-tools')).toBe('terminals-header');
+    // Permanent column, so it must not stay hidden by the popover's display
+    expect(document.getElementById('projects-popover').style.display).toBe('flex');
+  });
+
+  test('the docked column sits before the file explorer, as it did', () => {
+    applyNavigationMode('sidebar');
+
+    const children = [...document.getElementById('claude-layout').children].map(c => c.id);
+    expect(children.indexOf('projects-popover')).toBeLessThan(children.indexOf('file-explorer-panel'));
+  });
+
+  test('tabs puts both nodes back and closes the popover', () => {
+    applyNavigationMode('sidebar');
+    applyNavigationMode('tabs');
+
+    expect(isSidebarNavigation()).toBe(false);
+    expect(document.body.classList.contains('nav-tabs')).toBe(true);
+    expect(parentIdOf('projects-popover')).toBe(null); // back to .content, which has no id
+    expect(document.getElementById('projects-popover').parentElement.className).toBe('content');
+    expect(parentIdOf('project-bar-tools')).toBe('project-bar');
+    expect(document.getElementById('projects-popover').style.display).toBe('none');
+  });
+
+  test('a collapsed column does not come back collapsed as a popover', () => {
+    applyNavigationMode('sidebar');
+    document.getElementById('projects-popover').classList.add('collapsed');
+
+    applyNavigationMode('tabs');
+
+    expect(document.getElementById('projects-popover').classList.contains('collapsed')).toBe(false);
+  });
+
+  test('switching back and forth is stable', () => {
+    for (let i = 0; i < 3; i++) {
+      applyNavigationMode('sidebar');
+      applyNavigationMode('tabs');
+    }
+    applyNavigationMode('sidebar');
+
+    expect(parentIdOf('projects-popover')).toBe('claude-layout');
+    expect(parentIdOf('project-bar-tools')).toBe('terminals-header');
+    expect(document.querySelectorAll('#projects-popover').length).toBe(1);
+    expect(document.querySelectorAll('#project-bar-tools').length).toBe(1);
+  });
+
+  test('applying the same mode twice changes nothing', () => {
+    applyNavigationMode('sidebar');
+    const before = document.body.innerHTML;
+    applyNavigationMode('sidebar');
+
+    expect(document.body.innerHTML).toBe(before);
+  });
+
+  test('survives a DOM that has none of those nodes yet', () => {
+    document.body.innerHTML = '';
+    expect(() => applyNavigationMode('sidebar')).not.toThrow();
+    expect(document.body.classList.contains('nav-sidebar')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Why

#86 replaced the project sidebars with a tab bar. That is a change to how the app is navigated, and not everyone wants it. Both navigations now ship and the user picks.

## The choice

`navigationMode` is `null` until answered. A card is shown once, on the first launch that has no answer, with a CSS miniature of each layout. The answer *is* the setting, so there is no separate "already asked" flag to fall out of sync, and it can be changed later from Settings — which goes through the same path rather than a second one.

The chooser waits for the shared modal overlay instead of racing the telemetry consent for it. Whichever opened last used to win and the loser simply disappeared.

## Sidebar mode

What the tab bar replaced, back in full: the Claude projects column with its resizer and collapse strip, the Git screen's own project list, the Dashboard's project sidebar, and Replay's project dropdown.

Two nodes are moved rather than duplicated — the projects host and the tools row — because a second `#projects-list` or a second tool row would be two implementations drifting apart. `src/renderer/ui/navigationMode.js` owns that relocation and is covered on its own.

The restored selectors drive `selectedProjectFilter` rather than reviving the parallel selection models they used to carry, so both navigations always agree on the current project. That is the one deliberate difference from the pre-#86 code.

## Verified by driving the app

Run against an isolated `HOME` with throwaway projects, over CDP:

- Both modes swept across all five project-scoped screens (Claude, Git, Dashboard, Replay, Tasks): the right navigation present, the other absent, no screen blank, no console errors
- Setting never answered stays `null`; nothing writes it on its own
- Clicking a card flips `nav-tabs` to `nav-sidebar` live, relocates both nodes and persists the answer
- Changing it from Settings takes the same path

## Tests

30 new, 2172 total, 75 suites. `navigationMode.js` gets the cases that actually break: is the switch reversible, does a single `#projects-list` survive repeated flips, does a collapsed column come back collapsed as a popover. The tab-state helpers #86 shipped without coverage are covered too — focus after closing the active tab, the drag-reorder index maths, restoring a saved list whose projects were deleted since.

The i18n usage test caught `sessionReplay.labelProject` / `selectProject` the moment the Replay control came back; #86 had dropped them as orphans.

## Also

Removes a 28-line block `styles/projects.css` carried twice since #86, and points `#projects-popover` at `display:flex` to match its own stylesheet.

## Not done

The Tasks new-run modal still takes the active project read-only, as #86 made it. In sidebar mode that means picking the project elsewhere first. Its pre-#86 dropdown was inside that modal, not on the screen, so nothing is unreachable — it is one extra step.
