### PR TITLE
fix(chat): stop reporting 'success' after an in-band API error

### DIFF
--- a/src/main/services/ChatService.js
+++ b/src/main/services/ChatService.js
@@ -1229,6 +1229,12 @@ class ChatService {
    */
   async _processStream(sessionId, queryStream) {
     let msgCount = 0;
+    // Last in-band failure seen on the stream. API errors such as 529
+    // Overloaded don't throw: the SDK yields an assistant message tagged
+    // `error`, then a result flagged `is_error`, and the stream stays open
+    // (streaming input). Tracked so the final lifecycle event reports the
+    // session's real outcome; a later successful turn clears it.
+    let inbandError = null;
     const session = this.sessions.get(sessionId);
     // Assistant text for the turn in progress. Claude emits one assistant
     // message per text block — several per turn as soon as tools run in
@@ -1305,6 +1311,24 @@ class ChatService {
           session.sdkSessionId = message.session_id;
         }
 
+        // In-band failures: assistant messages tagged `error`, and results
+        // flagged `is_error` or carrying an error subtype. Fork-guard refusals
+        // never reach this point (`continue` above) — the renderer auto-resumes
+        // those, so they are not a session outcome.
+        if (message.type === 'assistant' && message.error) {
+          inbandError = `API error: ${message.error}`;
+        } else if (message.type === 'result') {
+          if (message.is_error || message.subtype !== 'success') {
+            const errors = Array.isArray(message.errors) ? message.errors.filter(Boolean) : [];
+            inbandError = errors.join('\n')
+              || inbandError
+              || (message.subtype !== 'success' ? message.subtype
+                : `API error${message.api_error_status ? ` (HTTP ${message.api_error_status})` : ''}`);
+          } else {
+            inbandError = null;
+          }
+        }
+
         // Accumulate assistant text for the chat_message trigger; dispatched
         // as one reply when the turn ends, not per streamed message.
         if (message.type === 'assistant' && Array.isArray(message.message?.content)) {
@@ -1321,7 +1345,15 @@ class ChatService {
       }
       flushReply();
       this._send('chat-done', { sessionId });
-      this._emitLifecycle('end', sessionId, { status: 'success' });
+      if (inbandError) {
+        // The stream closed cleanly, but the last turn had failed in-band —
+        // the renderer already displayed that error, so lifecycle consumers
+        // (claude_session_end triggers filter on `status`) must see the same
+        // outcome, not 'success'.
+        this._emitLifecycle('end', sessionId, { status: 'error', error: inbandError });
+      } else {
+        this._emitLifecycle('end', sessionId, { status: 'success' });
+      }
     } catch (err) {
       const wasInterrupted = session?.interrupting
         || err.name === 'AbortError'

--- a/src/renderer/ui/components/ChatView.js
+++ b/src/renderer/ui/components/ChatView.js
@@ -392,6 +392,7 @@ class ChatView extends BaseComponent {
   let blockIndex = 0;
   let currentMsgHasToolUse = false;
   let turnHadAssistantContent = false; // tracks if current turn displayed any streamed/assistant content
+  let turnErrorShown = false; // an in-band error banner (assistant msg.error) is already on screen for this turn
   let todoWidgetEl = null; // persistent task list widget
   let todoAllDone = false; // tracks if all tasks are completed
   // ── Task tool accumulator (SDK 0.3+ TaskCreate / TaskUpdate / TaskList) ──
@@ -2946,6 +2947,7 @@ class ChatView extends BaseComponent {
 
     if (!isStreaming) {
       turnHadAssistantContent = false;
+      turnErrorShown = false;
       setStreaming(true);
       appendThinkingIndicator();
     }
@@ -5453,9 +5455,20 @@ class ChatView extends BaseComponent {
             errorMsg = errors.length ? errors.join('\n') : t('chat.errorExecution');
           } else {
             const errors = message.errors || [];
-            errorMsg = errors.length ? errors.join('\n') : (message.subtype || t('chat.errorOccurred'));
+            if (errors.length) {
+              errorMsg = errors.join('\n');
+            } else if (message.subtype === 'success') {
+              // In-band API failure (e.g. 529 Overloaded): the result keeps
+              // subtype 'success' with is_error set — never echo that subtype
+              // as the error text, and skip the banner entirely when the
+              // assistant-level error for this turn is already on screen.
+              errorMsg = turnErrorShown ? null
+                : (message.api_error_status >= 500 ? t('chat.errorServer') : t('chat.errorOccurred'));
+            } else {
+              errorMsg = message.subtype || t('chat.errorOccurred');
+            }
           }
-          appendError(errorMsg);
+          if (errorMsg) appendError(errorMsg);
         }
         isAborting = false;
         setStreaming(false);
@@ -5504,6 +5517,7 @@ class ChatView extends BaseComponent {
         blockIndex = 0;
         currentMsgHasToolUse = false;
         turnHadAssistantContent = false;
+        turnErrorShown = false;
         // Update model from stream (reflects mid-session model changes)
         if (event.message?.model) {
           model = event.message.model;
@@ -5947,10 +5961,12 @@ class ChatView extends BaseComponent {
         invalid_request: t('chat.errorInvalidRequest'),
         max_output_tokens: t('chat.errorMaxTokens'),
         server_error: t('chat.errorServer'),
+        overloaded: t('chat.errorServer'),
       };
       const text = errorMessages[msg.error] || t('chat.errorOccurred');
       removeThinkingIndicator();
       appendError(text);
+      turnErrorShown = true;
       setStreaming(false);
       return;
     }

--- a/tests/services/ChatService.test.js
+++ b/tests/services/ChatService.test.js
@@ -290,3 +290,76 @@ describe('ChatService conversation context', () => {
     expect(fired[1].files).toEqual(['E:/repos/api/a.js', 'E:/repos/api/b.js']);
   });
 });
+
+// ── lifecycle status after in-band API errors (_processStream) ──
+
+describe('ChatService lifecycle status', () => {
+  const SESSION = 'sess-lifecycle';
+  const assistant = text => ({ type: 'assistant', message: { content: [{ type: 'text', text }] } });
+  const okResult = () => ({ type: 'result', subtype: 'success', is_error: false });
+
+  let lifecycle;
+  let originalSend;
+  let originalLifecycle;
+
+  beforeEach(() => {
+    lifecycle = [];
+    originalSend = chatService._send;
+    originalLifecycle = chatService._emitLifecycle;
+    chatService._send = () => {};
+    chatService._emitLifecycle = (event, sessionId, extra = {}) => lifecycle.push({ event, sessionId, ...extra });
+  });
+
+  afterEach(() => {
+    chatService._send = originalSend;
+    chatService._emitLifecycle = originalLifecycle;
+  });
+
+  const drive = async (messages) => {
+    async function* stream() { for (const m of messages) yield m; }
+    await chatService._processStream(SESSION, stream());
+  };
+
+  test('reports success when the stream ends after a clean result', async () => {
+    await drive([assistant('Done.'), okResult()]);
+
+    expect(lifecycle).toEqual([{ event: 'end', sessionId: SESSION, status: 'success' }]);
+  });
+
+  test('reports error when the API failed in-band (529 Overloaded)', async () => {
+    // A 529 never throws: the SDK yields an assistant message tagged `error`,
+    // then a result flagged is_error, and the stream ends normally. That used
+    // to be reported as 'success' right after the UI displayed the error.
+    await drive([
+      { type: 'assistant', error: 'overloaded', message: { content: [] } },
+      { type: 'result', subtype: 'success', is_error: true, api_error_status: 529 },
+    ]);
+
+    expect(lifecycle).toHaveLength(1);
+    expect(lifecycle[0].status).toBe('error');
+    expect(lifecycle[0].error).toContain('overloaded');
+  });
+
+  test('reports error for an error-subtype result', async () => {
+    await drive([
+      { type: 'result', subtype: 'error_during_execution', is_error: true, errors: ['boom'] },
+    ]);
+
+    expect(lifecycle[0].status).toBe('error');
+    expect(lifecycle[0].error).toBe('boom');
+  });
+
+  test('a later successful turn clears an earlier in-band failure', async () => {
+    // Streaming input keeps the session open across turns — the lifecycle
+    // event reports the session's final outcome, not its first hiccup.
+    await drive([
+      { type: 'assistant', error: 'overloaded', message: { content: [] } },
+      { type: 'result', subtype: 'success', is_error: true, api_error_status: 529 },
+      assistant('Retried fine.'),
+      okResult(),
+    ]);
+
+    expect(lifecycle).toHaveLength(1);
+    expect(lifecycle[0].status).toBe('success');
+  });
+});


### PR DESCRIPTION
Fixes #102.

API failures like 529 Overloaded never throw: the SDK yields an assistant message tagged `error`, then a result flagged `is_error` (its subtype stays `'success'`, with `api_error_status: 529`), and the stream ends cleanly. `_processStream` only covered thrown errors, so the session-end lifecycle reported `success` right after the UI had shown the server error - `claude_session_end` workflow triggers filtered on the wrong status - and the renderer's result handler echoed the raw `success` subtype as a second error banner.

### Approach

`_processStream` now tracks the last in-band failure seen on the stream: assistant messages tagged `error`, and results flagged `is_error` or carrying an error subtype (`errors[]` preferred as the message, then the assistant-level code, then the subtype or HTTP status). A later successful turn clears it - streaming input keeps the session open across turns, so the lifecycle reports the session's final outcome, not its first hiccup. Fork-guard refusals keep their early `continue` and never reach the tracker: the renderer auto-resumes those, so they are not an outcome. On a clean stream end the lifecycle now carries `{ status: 'error', error }` when the last turn had failed in-band. `chat-done` still fires so the renderer finalizes its cards, and no `chat-error` is added - the error is already on screen, delivered by the in-band messages themselves.

On the renderer side, the result handler never echoes a `success` subtype as banner text: for that shape it falls back to the server-error message (`api_error_status` >= 500) or the generic one, and skips the banner entirely when the assistant-level error for the turn is already displayed - one failure, one banner. The `overloaded` SDK error code now maps to the same server-error message as `server_error`.

### Tests

`tests/services/ChatService.test.js`, new `lifecycle status` block, 4 cases: a clean result reports success; the 529 shape (assistant `error` + result `is_error`) reports error and keeps the code in the message; an error-subtype result reports its `errors[]` text; a later successful turn clears an earlier in-band failure.

Full suite green (77 suites, 2196 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)