### PR TITLE
perf(chat): bound the mounted transcript and pause idle animations

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -18,6 +18,12 @@ document.addEventListener('visibilitychange', () => {
   document.body.classList.toggle('background-paused', document.hidden);
 });
 
+// macOS never reports the document hidden for a visible-but-unfocused window,
+// so the class above misses the common case. This pauses the perpetual
+// indicator animations (spinners, pulses, cursor) on blur — each one forces
+// the compositor to produce frames whose cost scales with the whole DOM.
+require('./src/renderer/services/IdleAnimationPauser').init();
+
 // Import all modules from src/renderer
 const {
   // Utils

--- a/src/main/windows/MainWindow.js
+++ b/src/main/windows/MainWindow.js
@@ -254,6 +254,18 @@ function createMainWindow({ isDev = false } = {}) {
     mainWindow.webContents.openDevTools();
   }
 
+  // Hidden DevTools access in packaged builds — profiling a real session needs
+  // a Performance trace on real data, and only DevTools can capture one. No
+  // menu exists in the frameless window, so without this there is no way in.
+  mainWindow.webContents.on('before-input-event', (event, input) => {
+    if (input.type !== 'keyDown') return;
+    if ((input.control || input.meta) && input.alt && input.shift
+      && String(input.key).toLowerCase() === 'i') {
+      mainWindow.webContents.toggleDevTools();
+      event.preventDefault();
+    }
+  });
+
   // Track normal (non-maximized) bounds for correct state restoration
   mainWindow.on('resize', () => {
     if (!mainWindow.isMaximized()) {

--- a/src/renderer/services/IdleAnimationPauser.js
+++ b/src/renderer/services/IdleAnimationPauser.js
@@ -1,0 +1,101 @@
+/**
+ * Pauses every infinite CSS animation while the window is unfocused.
+ *
+ * A composited animation forces the compositor to produce a frame on every
+ * vsync, and the per-frame cost grows with the size of the document — measured
+ * on a 68k-node transcript, a single 13px spinner costs ~30% of a core, and
+ * eleven of them cost barely more than one. All the perpetual animations in
+ * the app are "still working" indicators (spinners, status-dot pulses, the
+ * streaming cursor, the dancing mascot), so freezing them while the user is
+ * in another app changes nothing they can act on.
+ *
+ * Why not CSS? `.background-paused` in base.css already pauses everything on
+ * `visibilitychange`, but macOS only reports the document hidden when the
+ * window is minimized or fully occluded — a visible-but-unfocused window
+ * keeps burning. Extending that class to blur would also pause *entry*
+ * animations, and `chat-msg-in` starts at opacity 0: messages streamed into
+ * an unfocused-but-visible window would render invisible. Pausing through
+ * the Web Animations API instead lets us select exactly the animations whose
+ * iteration count is Infinity, across all stylesheets, present and future.
+ *
+ * Spec note: calling pause()/play() on a CSSAnimation detaches its play
+ * state from the `animation-play-state` property. That is safe here because
+ * this module only ever touches infinite animations, and it also fires on
+ * the blur that precedes every minimize — so the animations it manages are
+ * paused-by-API in exactly the states where the CSS class would have paused
+ * them.
+ */
+
+/** Animations paused by this module, to resume on focus — and nothing else. */
+let _paused = new Set();
+let _blurred = false;
+let _sweepTimer = null;
+
+function _isInfinite(anim) {
+  try {
+    return anim.effect?.getTiming?.().iterations === Infinity;
+  } catch (_) {
+    return false;
+  }
+}
+
+function _sweep() {
+  _sweepTimer = null;
+  if (!_blurred || typeof document.getAnimations !== 'function') return;
+  for (const anim of document.getAnimations()) {
+    if (anim.playState === 'running' && _isInfinite(anim)) {
+      try {
+        anim.pause();
+        _paused.add(anim);
+      } catch (_) { /* detached or already gone */ }
+    }
+  }
+}
+
+/** An animation that starts while blurred (new spinner in a background turn). */
+function _onAnimationStart() {
+  if (!_blurred || _sweepTimer) return;
+  _sweepTimer = setTimeout(_sweep, 100);
+}
+
+function _onBlur() {
+  _blurred = true;
+  _sweep();
+}
+
+function _onFocus() {
+  _blurred = false;
+  if (_sweepTimer) {
+    clearTimeout(_sweepTimer);
+    _sweepTimer = null;
+  }
+  for (const anim of _paused) {
+    try {
+      anim.play();
+    } catch (_) { /* element left the DOM while blurred */ }
+  }
+  _paused = new Set();
+}
+
+function init() {
+  window.addEventListener('blur', _onBlur);
+  window.addEventListener('focus', _onFocus);
+  // Capture phase: animationstart fires on the animated element and this
+  // listener must see it regardless of stopPropagation in component code.
+  document.addEventListener('animationstart', _onAnimationStart, true);
+  // The window can start life unfocused (launched minimized, restored session).
+  if (typeof document.hasFocus === 'function' && !document.hasFocus()) _onBlur();
+}
+
+/** Test seam: tear down listeners and state. */
+function _reset() {
+  window.removeEventListener('blur', _onBlur);
+  window.removeEventListener('focus', _onFocus);
+  document.removeEventListener('animationstart', _onAnimationStart, true);
+  if (_sweepTimer) clearTimeout(_sweepTimer);
+  _sweepTimer = null;
+  _blurred = false;
+  _paused = new Set();
+}
+
+module.exports = { init, _reset };

--- a/src/renderer/ui/components/ChatView.js
+++ b/src/renderer/ui/components/ChatView.js
@@ -19,6 +19,7 @@ const {
 const { t } = require('../../i18n');
 const { formatDuration: fmtDur } = require('../../utils/toolRegistry');
 const { heartbeat, skillsAgentsState } = require('../../state');
+const { createTranscriptPruner } = require('./TranscriptPruner');
 
 // ── Background task cards re-render on store update ─────────────────
 // Cards for Monitor/TaskOutput/TaskStop read state from bgTaskStore.
@@ -545,6 +546,9 @@ class ChatView extends BaseComponent {
   let searchHitIndex = -1;
   let searchDebounceTimer = null;
   let searchLastQuery = '';
+  // Assigned once the scroll state exists (it needs userHasScrolled); only
+  // user-triggered paths run before that, and they all guard with ?.
+  let transcriptPruner = null;
 
   function clearSearchHighlights() {
     for (const mark of messagesEl.querySelectorAll('mark.chat-search-hit')) {
@@ -658,6 +662,10 @@ class ChatView extends BaseComponent {
   function openSearch() {
     // The Changes tab hides the transcript, so there would be nothing to match against.
     if (messagesEl.hidden) tabbarEl.querySelector('.chat-tab[data-tab="conversation"]')?.click();
+    // Search walks the mounted DOM — bring the pruned entries back for its
+    // whole lifetime, or matches in older messages would silently vanish.
+    transcriptPruner?.suspend();
+    transcriptPruner?.mountAll();
     searchBarEl.hidden = false;
     // Seed with the current selection so "select then Ctrl+F" works like a browser.
     const selected = String(window.getSelection() || '').trim();
@@ -678,6 +686,7 @@ class ChatView extends BaseComponent {
     searchBarEl.hidden = true;
     searchBarEl.classList.remove('no-results');
     searchCountEl.textContent = '';
+    transcriptPruner?.resume();
     if (refocusInput) inputEl?.focus();
   }
 
@@ -5257,6 +5266,7 @@ class ChatView extends BaseComponent {
     userHasScrolled = !isAtBottom && messagesEl.scrollHeight > messagesEl.clientHeight;
 
     if (onNearHistoryTop) onNearHistoryTop();
+    transcriptPruner?.onScroll();
 
     if (isAtBottom) {
       userHasScrolled = false;
@@ -5287,6 +5297,15 @@ class ChatView extends BaseComponent {
     userHasScrolled = false;
     scrollToBottom();
   }
+
+  // Keep the mounted transcript bounded — interaction latency (tab reveal,
+  // typing, selection) scales with mounted element count, not visible content.
+  transcriptPruner = createTranscriptPruner({
+    messagesEl,
+    isPinnedToBottom: () => !userHasScrolled,
+    translate: t,
+  });
+  transcriptPruner.observe();
 
   // ── IPC: SDK Messages ──
 
@@ -6877,6 +6896,7 @@ class ChatView extends BaseComponent {
         } catch (e) { /* events not ready */ }
       }
       if (sessionId) api.chat.close({ sessionId });
+      transcriptPruner?.destroy();
       contextSuggestions.reset();
       followupChips.clear();
       // Clear permission reminder timers

--- a/src/renderer/ui/components/TranscriptPruner.js
+++ b/src/renderer/ui/components/TranscriptPruner.js
@@ -1,0 +1,154 @@
+/**
+ * Keeps the mounted transcript bounded.
+ *
+ * Interaction latency in the chat scales with the number of mounted elements,
+ * not with what is visible: measured on a 68k-node transcript, revealing the
+ * pane costs ~1.4s of main-thread work and a keystroke waits ~1s for its
+ * frame — with the exact same figures whether animations run or not, and
+ * `content-visibility` does not help because style recalc still walks every
+ * element. At ~5k nodes the same interactions cost 149ms / 29ms.
+ *
+ * So: when the user is pinned to the bottom (the only state in which the top
+ * of the transcript is out of reach anyway), everything beyond the newest
+ * `floor` entries is detached into an in-memory store, represented by a
+ * marker row at the top. Scrolling back up remounts the store chunk by chunk
+ * before the reader gets there, mirroring the disk-history pager that resumed
+ * sessions already use; the two compose because the disk pager inserts above
+ * this marker and the remounts insert below it, which is exactly document
+ * order (disk pages are older than pruned entries).
+ *
+ * The detached nodes keep their listeners and dataset, so remounting restores
+ * them byte-for-byte. Memory is unchanged by design — the nodes exist either
+ * way; only the rendering cost of keeping them mounted is shed.
+ */
+
+/** Entries the pruner must never absorb: the pagers' own top-of-list rows. */
+const SKIP_CLASSES = ['chat-history-top', 'chat-pruned-top'];
+
+function createTranscriptPruner({
+  messagesEl,
+  isPinnedToBottom,
+  translate,
+  cap = 300,
+  floor = 250,
+  chunk = 100,
+  remountPx = 600,
+}) {
+  const store = []; // detached entries, oldest first
+  let suspended = false;
+  let scheduled = false;
+  let destroyed = false;
+
+  const marker = document.createElement('div');
+  marker.className = 'chat-history-top chat-pruned-top';
+
+  const observer = new MutationObserver(schedulePrune);
+
+  function _isSkippable(el) {
+    return SKIP_CLASSES.some((c) => el.classList?.contains(c));
+  }
+
+  function _updateMarker() {
+    if (store.length === 0) {
+      marker.remove();
+      return;
+    }
+    marker.textContent = translate('chat.olderMessages', { count: store.length });
+    if (!marker.isConnected) {
+      // Below the disk pager's row if there is one, above everything else.
+      const historyTop = messagesEl.querySelector('.chat-history-top:not(.chat-pruned-top)');
+      if (historyTop) historyTop.after(marker);
+      else messagesEl.prepend(marker);
+    }
+  }
+
+  function schedulePrune() {
+    if (scheduled || suspended || destroyed) return;
+    scheduled = true;
+    setTimeout(() => {
+      scheduled = false;
+      prune();
+    }, 0);
+  }
+
+  function prune() {
+    if (suspended || destroyed) return;
+    // Pruning while the user reads upward would yank content they are heading
+    // for; pinned-to-bottom is the only state where the top is unreachable.
+    if (!isPinnedToBottom()) return;
+
+    const entries = Array.from(messagesEl.children).filter((el) => !_isSkippable(el));
+    if (entries.length <= cap) return;
+
+    const excess = entries.length - floor;
+    for (let i = 0; i < excess; i++) {
+      store.push(entries[i]);
+      entries[i].remove();
+    }
+    _updateMarker();
+  }
+
+  /** Remount the newest pruned chunk just below the marker, keeping the
+   *  viewport still. One chunk per call; the next scroll event pulls more. */
+  function remountChunk() {
+    if (store.length === 0) return;
+    const batch = store.splice(-chunk);
+    const beforeHeight = messagesEl.scrollHeight;
+    const beforeTop = messagesEl.scrollTop;
+    const frag = document.createDocumentFragment();
+    for (const el of batch) frag.appendChild(el);
+    _updateMarker(); // marker must exist (or vanish) before we anchor on it
+    if (marker.isConnected) marker.after(frag);
+    else messagesEl.prepend(frag);
+    messagesEl.scrollTop = beforeTop + (messagesEl.scrollHeight - beforeHeight);
+  }
+
+  /** Call from the transcript's scroll handler. */
+  function onScroll() {
+    if (suspended || destroyed || store.length === 0) return;
+    if (messagesEl.scrollTop <= remountPx) remountChunk();
+  }
+
+  /** Everything back in the DOM — in-chat search walks the mounted tree. */
+  function mountAll() {
+    while (store.length > 0) {
+      const batch = store.splice(-chunk);
+      const frag = document.createDocumentFragment();
+      for (const el of batch) frag.appendChild(el);
+      if (marker.isConnected) marker.after(frag);
+      else messagesEl.prepend(frag);
+    }
+    _updateMarker();
+  }
+
+  function suspend() {
+    suspended = true;
+  }
+
+  function resume() {
+    suspended = false;
+    schedulePrune();
+  }
+
+  function observe() {
+    observer.observe(messagesEl, { childList: true });
+    schedulePrune();
+  }
+
+  function destroy() {
+    destroyed = true;
+    observer.disconnect();
+    marker.remove();
+    store.length = 0;
+  }
+
+  return {
+    observe, onScroll, mountAll, suspend, resume, destroy,
+    /** Test seams. */
+    prune, remountChunk,
+    get prunedCount() { return store.length; },
+    get markerEl() { return marker; },
+  };
+}
+
+module.exports = { createTranscriptPruner };

--- a/tests/services/idleAnimationPauser.test.js
+++ b/tests/services/idleAnimationPauser.test.js
@@ -1,0 +1,97 @@
+/**
+ * IdleAnimationPauser — pauses infinite CSS animations on window blur and
+ * resumes exactly those on focus, leaving finite (entry) animations alone.
+ */
+const pauser = require('../../src/renderer/services/IdleAnimationPauser');
+
+function fakeAnim({ iterations, playState = 'running' }) {
+  return {
+    playState,
+    effect: { getTiming: () => ({ iterations }) },
+    pause: jest.fn(function () { this.playState = 'paused'; }),
+    play: jest.fn(function () { this.playState = 'running'; }),
+  };
+}
+
+describe('IdleAnimationPauser', () => {
+  let animations;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    animations = [];
+    document.getAnimations = jest.fn(() => animations);
+    document.hasFocus = jest.fn(() => true);
+    pauser.init();
+  });
+
+  afterEach(() => {
+    pauser._reset();
+    delete document.getAnimations;
+    jest.useRealTimers();
+  });
+
+  test('blur pauses infinite animations only', () => {
+    const spinner = fakeAnim({ iterations: Infinity });
+    const entry = fakeAnim({ iterations: 1 });
+    animations.push(spinner, entry);
+
+    window.dispatchEvent(new Event('blur'));
+
+    expect(spinner.pause).toHaveBeenCalled();
+    expect(entry.pause).not.toHaveBeenCalled();
+  });
+
+  test('focus resumes only what blur paused', () => {
+    const spinner = fakeAnim({ iterations: Infinity });
+    const alreadyPaused = fakeAnim({ iterations: Infinity, playState: 'paused' });
+    animations.push(spinner, alreadyPaused);
+
+    window.dispatchEvent(new Event('blur'));
+    window.dispatchEvent(new Event('focus'));
+
+    expect(spinner.play).toHaveBeenCalled();
+    // Paused by something else (e.g. .background-paused) — not ours to resume.
+    expect(alreadyPaused.play).not.toHaveBeenCalled();
+  });
+
+  test('an animation starting while blurred gets swept up', () => {
+    window.dispatchEvent(new Event('blur'));
+
+    const late = fakeAnim({ iterations: Infinity });
+    animations.push(late);
+    document.dispatchEvent(new Event('animationstart'));
+    jest.advanceTimersByTime(150);
+
+    expect(late.pause).toHaveBeenCalled();
+  });
+
+  test('animationstart while focused does nothing', () => {
+    const spinner = fakeAnim({ iterations: Infinity });
+    animations.push(spinner);
+
+    document.dispatchEvent(new Event('animationstart'));
+    jest.advanceTimersByTime(150);
+
+    expect(spinner.pause).not.toHaveBeenCalled();
+  });
+
+  test('a resume on an animation whose element died does not throw', () => {
+    const dead = fakeAnim({ iterations: Infinity });
+    dead.play = jest.fn(() => { throw new Error('detached'); });
+    animations.push(dead);
+
+    window.dispatchEvent(new Event('blur'));
+    expect(() => window.dispatchEvent(new Event('focus'))).not.toThrow();
+  });
+
+  test('starting unfocused pauses immediately on init', () => {
+    pauser._reset();
+    const spinner = fakeAnim({ iterations: Infinity });
+    animations.push(spinner);
+    document.hasFocus = jest.fn(() => false);
+
+    pauser.init();
+
+    expect(spinner.pause).toHaveBeenCalled();
+  });
+});

--- a/tests/services/transcriptPruner.test.js
+++ b/tests/services/transcriptPruner.test.js
@@ -1,0 +1,164 @@
+/**
+ * TranscriptPruner — bounds the mounted transcript, remounts on scroll-up,
+ * and composes with the disk-history pager without breaking document order.
+ */
+const { createTranscriptPruner } = require('../../src/renderer/ui/components/TranscriptPruner');
+
+const translate = (key, opts) => `${opts?.count} earlier`;
+
+function entry(i) {
+  const el = document.createElement('div');
+  el.className = 'chat-msg';
+  el.dataset.i = String(i);
+  return el;
+}
+
+function mountedIds(messagesEl) {
+  return Array.from(messagesEl.children)
+    .filter((el) => el.dataset.i !== undefined)
+    .map((el) => Number(el.dataset.i));
+}
+
+describe('TranscriptPruner', () => {
+  let messagesEl, pruner, pinned;
+
+  beforeEach(() => {
+    messagesEl = document.createElement('div');
+    document.body.appendChild(messagesEl);
+    pinned = true;
+    pruner = createTranscriptPruner({
+      messagesEl,
+      isPinnedToBottom: () => pinned,
+      translate,
+      cap: 10,
+      floor: 6,
+      chunk: 3,
+      remountPx: 100,
+    });
+  });
+
+  afterEach(() => {
+    pruner.destroy();
+    messagesEl.remove();
+  });
+
+  test('stays quiet under the cap', () => {
+    for (let i = 0; i < 10; i++) messagesEl.appendChild(entry(i));
+    pruner.prune();
+    expect(mountedIds(messagesEl)).toHaveLength(10);
+    expect(pruner.prunedCount).toBe(0);
+    expect(pruner.markerEl.isConnected).toBe(false);
+  });
+
+  test('over the cap, detaches the oldest down to the floor', () => {
+    for (let i = 0; i < 15; i++) messagesEl.appendChild(entry(i));
+    pruner.prune();
+    expect(mountedIds(messagesEl)).toEqual([9, 10, 11, 12, 13, 14]);
+    expect(pruner.prunedCount).toBe(9);
+    expect(pruner.markerEl.isConnected).toBe(true);
+    expect(messagesEl.firstElementChild).toBe(pruner.markerEl);
+    expect(pruner.markerEl.textContent).toBe('9 earlier');
+  });
+
+  test('never prunes while the user is scrolled up', () => {
+    for (let i = 0; i < 15; i++) messagesEl.appendChild(entry(i));
+    pinned = false;
+    pruner.prune();
+    expect(mountedIds(messagesEl)).toHaveLength(15);
+  });
+
+  test('scroll near the top remounts one chunk in order', () => {
+    for (let i = 0; i < 15; i++) messagesEl.appendChild(entry(i));
+    pruner.prune();
+
+    Object.defineProperty(messagesEl, 'scrollTop', { value: 50, writable: true });
+    pruner.onScroll();
+
+    expect(mountedIds(messagesEl)).toEqual([6, 7, 8, 9, 10, 11, 12, 13, 14]);
+    expect(pruner.prunedCount).toBe(6);
+    // Marker still sits above everything remounted
+    expect(messagesEl.firstElementChild).toBe(pruner.markerEl);
+  });
+
+  test('draining the store removes the marker', () => {
+    for (let i = 0; i < 12; i++) messagesEl.appendChild(entry(i));
+    pruner.prune();
+    Object.defineProperty(messagesEl, 'scrollTop', { value: 0, writable: true });
+    pruner.onScroll();
+    pruner.onScroll();
+    expect(pruner.prunedCount).toBe(0);
+    expect(pruner.markerEl.isConnected).toBe(false);
+    expect(mountedIds(messagesEl)).toEqual([...Array(12).keys()]);
+  });
+
+  test('mountAll restores everything in document order', () => {
+    for (let i = 0; i < 25; i++) messagesEl.appendChild(entry(i));
+    pruner.prune();
+    pruner.prune(); // idempotent second pass
+    pruner.mountAll();
+    expect(mountedIds(messagesEl)).toEqual([...Array(25).keys()]);
+    expect(pruner.markerEl.isConnected).toBe(false);
+  });
+
+  test('suspend blocks pruning until resume', () => {
+    jest.useFakeTimers();
+    for (let i = 0; i < 15; i++) messagesEl.appendChild(entry(i));
+    pruner.suspend();
+    pruner.prune();
+    expect(mountedIds(messagesEl)).toHaveLength(15);
+    pruner.resume();
+    jest.runAllTimers();
+    expect(mountedIds(messagesEl)).toHaveLength(6);
+    jest.useRealTimers();
+  });
+
+  test('the disk-history pager rows are never pruned and stay above', () => {
+    const historyTop = document.createElement('div');
+    historyTop.className = 'chat-history-top';
+    messagesEl.appendChild(historyTop);
+    for (let i = 0; i < 15; i++) messagesEl.appendChild(entry(i));
+
+    pruner.prune();
+
+    expect(historyTop.isConnected).toBe(true);
+    expect(messagesEl.children[0]).toBe(historyTop);
+    expect(messagesEl.children[1]).toBe(pruner.markerEl);
+    expect(mountedIds(messagesEl)).toEqual([9, 10, 11, 12, 13, 14]);
+  });
+
+  test('disk pages inserted above the marker keep order through a remount', () => {
+    const historyTop = document.createElement('div');
+    historyTop.className = 'chat-history-top';
+    messagesEl.appendChild(historyTop);
+    for (let i = 100; i < 115; i++) messagesEl.appendChild(entry(i));
+    pruner.prune(); // store: 100..108, mounted: 109..114
+
+    // The disk pager prepends an older page at historyTop.nextSibling,
+    // exactly like loadEarlier does.
+    const anchor = historyTop.nextSibling;
+    for (let i = 0; i < 3; i++) messagesEl.insertBefore(entry(i), anchor);
+
+    Object.defineProperty(messagesEl, 'scrollTop', { value: 0, writable: true });
+    pruner.onScroll(); // remounts 106..108 below the marker
+
+    // Top to bottom: disk page (oldest), marker, remounted, live tail.
+    expect(mountedIds(messagesEl)).toEqual([0, 1, 2, 106, 107, 108, 109, 110, 111, 112, 113, 114]);
+    const kids = Array.from(messagesEl.children);
+    expect(kids.indexOf(pruner.markerEl)).toBe(4); // after historyTop + 3 disk entries
+  });
+
+  test('observer prunes automatically after appends', async () => {
+    pruner.observe();
+    for (let i = 0; i < 15; i++) messagesEl.appendChild(entry(i));
+    await new Promise((r) => setTimeout(r, 5));
+    expect(mountedIds(messagesEl)).toHaveLength(6);
+  });
+
+  test('destroy detaches the observer and the marker', async () => {
+    pruner.observe();
+    pruner.destroy();
+    for (let i = 0; i < 15; i++) messagesEl.appendChild(entry(i));
+    await new Promise((r) => setTimeout(r, 5));
+    expect(mountedIds(messagesEl)).toHaveLength(15);
+  });
+});


### PR DESCRIPTION
Fixes #104.

Three commits, each self-contained:

**1. `perf(chat): pause infinite indicator animations while the window is unfocused`**
`IdleAnimationPauser` pauses every animation whose iteration count is Infinity on window blur (Web Animations API) and resumes on focus; a capture-phase `animationstart` listener sweeps up animations that start while blurred. This covers all stylesheets present and future without enumerating selectors. `.background-paused` could not be extended to blur: it also pauses entry animations, and `chat-msg-in` starts at opacity 0 - messages streamed into an unfocused-but-visible window would render invisible.

**2. `perf(chat): bound the mounted transcript to keep interaction latency flat`**
`TranscriptPruner` keeps the newest ~300 entries mounted; older ones detach into an in-memory store behind a marker row and remount chunk by chunk on scroll-up, before the reader reaches them. It composes with the resumed-session disk pager (disk pages insert above the marker, remounts below - document order), suspends while in-chat search is open (search walks the DOM), and re-prunes on close. Export reads `conversationHistory`, not the DOM. Detached nodes keep listeners and dataset, so remounting restores them byte-for-byte. Memory is unchanged by design - only the rendering cost of keeping nodes mounted is shed.

**3. `feat(window): open DevTools in packaged builds with a hidden shortcut`**
Ctrl/Cmd+Alt+Shift+I toggles DevTools via `before-input-event`, so real sessions can be Performance-traced. Droppable independently if unwanted.

## End-to-end results (real stylesheets, 4000-message transcript, Electron harness)

| | before | after |
|---|---|---|
| mounted DOM nodes | 68 052 | 2 162 |
| tab reveal (median) | 1 371 ms | 66 ms |
| keystroke → frame (median) | 1 051 ms | 26 ms (two frames - the floor) |
| focused idle work / 6s | 2 845 ms | 494 ms |
| unfocused idle work / 6s | 3 789 ms | 2 ms |

## Tests

17 new unit tests: pruner ordering invariants (cap/floor hysteresis, scroll remount order, disk-pager composition, suspend/resume, observer lifecycle) and pauser paths (blur/focus, finite animations untouched, late-starting animations, detached elements, launch-unfocused). Full suite green on this base (2209 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)