### PR TITLE
feat(tabs): lock custom names, add pinned tabs, fix session ordering

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -232,14 +232,18 @@ const { loadSessionData, clearProjectSessions, saveTerminalSessions } = require(
 
         for (const tab of saved.tabs) {
           const cwd = (await fileExists(tab.cwd)) ? tab.cwd : project.path;
-          await TerminalManager.createTerminal(project, {
+          const restoredId = await TerminalManager.createTerminal(project, {
             runClaude: !tab.isBasic,
             cwd,
             mode: tab.mode || null,
             skipPermissions: settingsState.get().skipPermissions,
             resumeSessionId: (!tab.isBasic && tab.claudeSessionId) ? tab.claudeSessionId : null,
             name: tab.name || null,
+            nameCustom: tab.nameCustom || false,
           });
+          if (tab.pinned && restoredId != null) {
+            try { TerminalManager.setTabPinned(restoredId, true); } catch (e) { /* ignore */ }
+          }
         }
 
         if (saved.activeCwd) {
@@ -1821,11 +1825,18 @@ async function _saveModalPins() {
 // Names given to sessions inside Claude Terminal, written by the Sessions panel.
 // Read fresh on every modal open rather than cached, so a rename made in the
 // panel shows up here instead of the two lists disagreeing.
+// Entries are `{ name, custom }`; bare strings predate the flag (non-custom).
 const _modalNamesFile = path.join(window.electron_nodeModules.os.homedir(), '.claude-terminal', 'session-names.json');
 
 async function _loadModalNames() {
   try {
-    return JSON.parse(await fsp.readFile(_modalNamesFile, 'utf8')) || {};
+    const raw = JSON.parse(await fsp.readFile(_modalNamesFile, 'utf8')) || {};
+    const normalized = {};
+    for (const [sid, entry] of Object.entries(raw)) {
+      if (typeof entry === 'string') normalized[sid] = { name: entry, custom: false };
+      else if (entry && entry.name) normalized[sid] = { name: entry.name, custom: !!entry.custom };
+    }
+    return normalized;
   } catch { return {}; }
 }
 
@@ -1894,12 +1905,16 @@ async function _preprocessModalSessions(sessions) {
     const promptResult = _cleanModalSessionText(session.firstPrompt);
     const summaryResult = _cleanModalSessionText(session.summary);
     const skillName = promptResult.skillName || summaryResult.skillName;
-    const customName = names[session.sessionId] || '';
+    const nameEntry = names[session.sessionId] || { name: '', custom: false };
+    // A deliberately chosen name — renamed here or in Claude Code — outranks
+    // every generated one and stays locked against auto renames on resume.
+    const lockedName = nameEntry.custom ? nameEntry.name : session.customTitle;
+    const customName = lockedName || nameEntry.name;
     let displayTitle = '', displaySubtitle = '', isSkill = false;
     // Same order as the Sessions panel: a name given inside Claude Terminal wins,
     // then the title Claude Code carries in the transcript (`custom-title`, else
     // `ai-title`), then the opening prompt, which can run to thousands of chars
-    if (customName) { displayTitle = customName; displaySubtitle = session.title || summaryResult.text || promptResult.text; }
+    if (customName) { displayTitle = customName; displaySubtitle = (session.title !== customName ? session.title : '') || summaryResult.text || promptResult.text; }
     else if (session.title) { displayTitle = session.title; displaySubtitle = summaryResult.text || promptResult.text; }
     else if (summaryResult.text) { displayTitle = summaryResult.text; displaySubtitle = promptResult.text; }
     else if (promptResult.text) { displayTitle = promptResult.text; }
@@ -1910,7 +1925,7 @@ async function _preprocessModalSessions(sessions) {
     const searchText = (displayTitle + ' ' + displaySubtitle + ' ' + (session.gitBranch || '')
       + ' ' + customName).toLowerCase();
     const pinned = !!pins[session.sessionId];
-    return { ...session, displayTitle, displaySubtitle, isSkill, freshness, searchText, pinned };
+    return { ...session, displayTitle, displaySubtitle, isSkill, nameLocked: Boolean(lockedName), freshness, searchText, pinned };
   });
 }
 
@@ -2152,11 +2167,16 @@ async function showSessionsModal(project) {
       const sessionId = card.dataset.sid;
       if (!sessionId) return;
       const session = sessionMap.get(sessionId);
-      const sessionName = session?.displayTitle || null;
+      // A user-chosen name passes through untouched; generated labels are
+      // bounded so a prompt-only session can't flood the tab bar.
+      const sessionName = (session?.nameLocked
+        ? session.displayTitle
+        : _truncateModalText(session?.displayTitle || '', 40)) || null;
       closeModal();
       TerminalManager.resumeSession(project, sessionId, {
         skipPermissions: settingsState.get().skipPermissions,
-        name: sessionName
+        name: sessionName,
+        nameCustom: !!session?.nameLocked
       });
     });
 

--- a/src/main/ipc/claude.ipc.js
+++ b/src/main/ipc/claude.ipc.js
@@ -109,10 +109,14 @@ async function extractSessionInfo(filePath) {
 const TITLE_TAIL_BYTES = 128 * 1024;
 
 /**
- * Read the session's current title from the tail of its JSONL file.
+ * Read the session's current title and last activity from the tail of its JSONL file.
+ * `lastActivity` is the timestamp of the last message line. File mtime is not
+ * reliable for ordering: Claude Code keeps appending housekeeping lines
+ * (titles, file-history snapshots…) well after the last real message, so an
+ * idle session can look more recent than one the user just worked in.
  * @param {string} filePath
  * @param {number} size - File size in bytes (from a stat the caller already did)
- * @returns {Promise<{customTitle: string, aiTitle: string}>}
+ * @returns {Promise<{customTitle: string, aiTitle: string, lastActivity: string}>}
  */
 async function readSessionTitle(filePath, size) {
   let handle;
@@ -129,19 +133,24 @@ async function readSessionTitle(filePath, size) {
 
     let customTitle = '';
     let aiTitle = '';
+    let lastActivity = '';
     for (let i = lines.length - 1; i >= 0; i--) {
       const line = lines[i];
-      if (!line || line.indexOf('-title"') === -1) continue; // cheap pre-filter
+      if (!line) continue;
+      const isTitleLine = line.indexOf('-title"') !== -1;
+      const mayHaveTimestamp = !lastActivity && line.indexOf('"timestamp"') !== -1;
+      if (!isTitleLine && !mayHaveTimestamp) continue; // cheap pre-filter
       try {
         const obj = JSON.parse(line);
         if (!customTitle && obj.type === 'custom-title' && obj.customTitle) customTitle = obj.customTitle;
         else if (!aiTitle && obj.type === 'ai-title' && obj.aiTitle) aiTitle = obj.aiTitle;
-        if (customTitle && aiTitle) break;
+        if (!lastActivity && obj.timestamp) lastActivity = obj.timestamp;
+        if (customTitle && aiTitle && lastActivity) break;
       } catch { /* skip malformed lines */ }
     }
-    return { customTitle, aiTitle };
+    return { customTitle, aiTitle, lastActivity };
   } catch {
-    return { customTitle: '', aiTitle: '' };
+    return { customTitle: '', aiTitle: '', lastActivity: '' };
   } finally {
     await handle?.close().catch(() => {});
   }
@@ -257,19 +266,27 @@ async function getClaudeSessions(projectPath) {
       }
     } catch { /* index may not exist or be stale, that's ok */ }
 
-    // Sort by modified date (most recent first) and limit to 50
-    const top = allSessions
+    // Pre-rank by mtime and read tails only for the head of that ranking: a
+    // 128 KB tail read per file is wasted on sessions that can't make the cut.
+    // The margin over 50 absorbs mtime drift (appends only push mtime forward,
+    // so a session with recent real activity is always near the top by mtime).
+    const candidates = allSessions
       .sort((a, b) => new Date(b.modified) - new Date(a.modified))
-      .slice(0, 50);
+      .slice(0, 80);
 
-    // Titles are read only for the sessions actually returned: a 128 KB tail read
-    // per file is wasted on the ones the slice above just dropped.
-    await Promise.all(top.map(async (session) => {
-      const { customTitle, aiTitle } = await readSessionTitle(session.filePath, session.size);
+    await Promise.all(candidates.map(async (session) => {
+      const { customTitle, aiTitle, lastActivity } = await readSessionTitle(session.filePath, session.size);
       session.title = customTitle || aiTitle || '';
       session.customTitle = customTitle;
       session.aiTitle = aiTitle;
+      // Order and time labels follow the conversation, not file housekeeping
+      if (lastActivity) session.modified = lastActivity;
     }));
+
+    // Final order by real last activity (most recent first), limit to 50
+    const top = candidates
+      .sort((a, b) => new Date(b.modified) - new Date(a.modified))
+      .slice(0, 50);
 
     const sessions = top.map(({ size, filePath, ...session }) => session);
     _sessionsCache.set(projectPath, {

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -2411,6 +2411,8 @@
   },
   "tabs": {
     "rename": "Rename",
+    "pin": "Pin Tab",
+    "unpin": "Unpin Tab",
     "close": "Close",
     "closeOthers": "Close Others",
     "closeToLeft": "Close Tabs to Left",

--- a/src/renderer/i18n/locales/es.json
+++ b/src/renderer/i18n/locales/es.json
@@ -2408,6 +2408,8 @@
   },
   "tabs": {
     "rename": "Renombrar",
+    "pin": "Fijar pestaña",
+    "unpin": "Dejar de fijar pestaña",
     "close": "Cerrar",
     "closeOthers": "Cerrar las demás",
     "closeToLeft": "Cerrar pestañas a la izquierda",

--- a/src/renderer/i18n/locales/fr.json
+++ b/src/renderer/i18n/locales/fr.json
@@ -2411,6 +2411,8 @@
   },
   "tabs": {
     "rename": "Renommer",
+    "pin": "Épingler l'onglet",
+    "unpin": "Désépingler l'onglet",
     "close": "Fermer",
     "closeOthers": "Fermer les autres",
     "closeToLeft": "Fermer les onglets à gauche",

--- a/src/renderer/i18n/locales/id.json
+++ b/src/renderer/i18n/locales/id.json
@@ -2411,6 +2411,8 @@
   },
   "tabs": {
     "rename": "Ganti nama",
+    "pin": "Sematkan Tab",
+    "unpin": "Lepas Sematan Tab",
     "close": "Tutup",
     "closeOthers": "Tutup Tab Lain",
     "closeToLeft": "Tutup Tab di Sebelah Kiri",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -2411,6 +2411,8 @@
   },
   "tabs": {
     "rename": "重命名",
+    "pin": "固定标签页",
+    "unpin": "取消固定标签页",
     "close": "关闭",
     "closeOthers": "关闭其他",
     "closeToLeft": "关闭左侧选项卡",

--- a/src/renderer/services/TerminalSessionService.js
+++ b/src/renderer/services/TerminalSessionService.js
@@ -98,6 +98,8 @@ async function saveTerminalSessionsImmediate() {
         mode: td.mode || 'terminal',
         claudeSessionId: td.claudeSessionId || null,
         name: td.name || null,
+        nameCustom: td.nameCustom || false,
+        pinned: td.pinned || false,
       };
 
       projectSessions[projectId].tabs.push(tab);

--- a/src/renderer/ui/components/ChatView.js
+++ b/src/renderer/ui/components/ChatView.js
@@ -99,7 +99,7 @@ function ensureWakeupTicker() {
   }, 1000);
 }
 const { getSetting, setSetting, isNotificationsEnabled } = require('../../state/settings.state');
-const { updateTerminal } = require('../../state/terminals.state');
+const { updateTerminal, getTerminal } = require('../../state/terminals.state');
 const { saveTerminalSessions } = require('../../services/TerminalSessionService');
 
 const MODEL_OPTIONS = [
@@ -382,6 +382,10 @@ class ChatView extends BaseComponent {
   let lastStartOpts = null; // cached so we can re-launch the SDK after an account switch
   let switchingAccount = false; // suppress error UI while we hot-swap credentials
   let tabNamePending = false; // avoid concurrent tab name requests
+  // True when the tab carries a user-chosen name that auto naming must not touch
+  const isTabNameLocked = () => {
+    try { return !!(terminalId != null && getTerminal(terminalId)?.nameCustom); } catch { return false; }
+  };
   let currentStreamEl = null;
   let currentStreamText = '';
   let currentThinkingEl = null;
@@ -3087,8 +3091,10 @@ class ChatView extends BaseComponent {
       sendLock = false;
     }
 
-    // Tab rename: instant truncation + async haiku polish
-    if (onTabRename && !text.startsWith('/') && getSetting('aiTabNaming') !== false) {
+    // Tab rename: instant truncation + async haiku polish.
+    // A tab whose name was chosen by the user (rename, custom title) is locked:
+    // no truncation flash, no haiku call.
+    if (onTabRename && !text.startsWith('/') && getSetting('aiTabNaming') !== false && !isTabNameLocked()) {
       // Immediate: smart truncation
       const words = text.split(/\s+/).slice(0, 5).join(' ');
       onTabRename(words.length > 30 ? words.slice(0, 28) + '...' : words);
@@ -6245,7 +6251,7 @@ class ChatView extends BaseComponent {
     if (sid !== sessionId) return;
     appendUserMessage(text, images || [], [], isStreaming);
     // Trigger tab rename for remote messages (same logic as _send)
-    if (onTabRename && text && !text.startsWith('/') && getSetting('aiTabNaming') !== false) {
+    if (onTabRename && text && !text.startsWith('/') && getSetting('aiTabNaming') !== false && !isTabNameLocked()) {
       const words = text.split(/\s+/).slice(0, 5).join(' ');
       onTabRename(words.length > 30 ? words.slice(0, 28) + '...' : words);
       if (!tabNamePending) {

--- a/src/renderer/ui/components/TerminalManager.js
+++ b/src/renderer/ui/components/TerminalManager.js
@@ -1428,6 +1428,20 @@ class TerminalManager extends BaseComponent {
     // Compact tabs truncate their label; the tooltip carries the full name
     tab.title = pinned ? (termData.name || '') : '';
 
+    // A visible pin marks the tab beyond its compact width — it stands where
+    // the close button was, and clicking it unpins, like an editor's tabs.
+    let pinIcon = tab.querySelector('.tab-pin-icon');
+    if (pinned && !pinIcon) {
+      pinIcon = document.createElement('span');
+      pinIcon.className = 'tab-pin-icon';
+      pinIcon.title = t('tabs.unpin');
+      pinIcon.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 17v5"/><path d="M15 9.34V6a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1v3.34a2 2 0 0 1-1.11 1.79l-1.24.62A2 2 0 0 0 5.55 13.55V15a1 1 0 0 0 1 1h11a1 1 0 0 0 1-1v-1.45a2 2 0 0 0-1.11-1.79l-1.24-.62A2 2 0 0 1 15 9.34Z"/></svg>';
+      pinIcon.onclick = (e) => { e.stopPropagation(); this.setTabPinned(id, false); };
+      tab.appendChild(pinIcon);
+    } else if (!pinned && pinIcon) {
+      pinIcon.remove();
+    }
+
     // Re-cluster. The same anchor serves both directions: right after the last
     // other pinned tab — the end of the pinned zone when pinning, the start of
     // the unpinned zone when unpinning.

--- a/src/renderer/ui/components/TerminalManager.js
+++ b/src/renderer/ui/components/TerminalManager.js
@@ -1211,6 +1211,8 @@ class TerminalManager extends BaseComponent {
       e.dataTransfer.dropEffect = 'move';
 
       if (!self._draggedTab || self._draggedTab === tab) return;
+      // Pinned and unpinned tabs live in separate zones, like browser tabs
+      if (self._draggedTab.classList.contains('pinned-tab') !== tab.classList.contains('pinned-tab')) return;
 
       const rect = tab.getBoundingClientRect();
       const midX = rect.left + rect.width / 2;
@@ -1229,6 +1231,8 @@ class TerminalManager extends BaseComponent {
       tab.classList.remove('drag-over-left', 'drag-over-right');
 
       if (!self._draggedTab || self._draggedTab === tab) return;
+      // No dropping across the pinned/unpinned boundary
+      if (self._draggedTab.classList.contains('pinned-tab') !== tab.classList.contains('pinned-tab')) return;
 
       const tabsContainer = document.getElementById('terminals-tabs');
       const rect = tab.getBoundingClientRect();
@@ -1245,14 +1249,27 @@ class TerminalManager extends BaseComponent {
 
   // ── Terminal tab name & status ──
 
-  async updateTerminalTabName(id, name) {
+  /**
+   * Rename a tab. Auto renames (AI naming, OSC titles, slash-command hook)
+   * leave `custom` unset and are ignored once the tab carries a name the user
+   * chose; a custom rename locks the tab against further auto renames.
+   */
+  async updateTerminalTabName(id, name, { custom = false } = {}) {
     const termData = getTerminal(id);
     if (!termData) return;
+    if (!custom && termData.nameCustom) return;
+    // PTY title scraping re-emits the same name continuously; a no-op rename
+    // is not worth a remote broadcast and a session save. A custom rename
+    // still passes so an unchanged name can acquire the lock.
+    if (!custom && termData.name === name) return;
 
-    updateTerminal(id, { name });
+    updateTerminal(id, custom ? { name, nameCustom: true } : { name });
 
     if (termData.claudeSessionId && name) {
-      await this._setSessionCustomName(termData.claudeSessionId, name);
+      await this._setSessionCustomName(termData.claudeSessionId, name, { custom });
+      if (this._api.remote?.notifyTabRenamed) {
+        this._api.remote.notifyTabRenamed({ sessionId: termData.claudeSessionId, tabName: name });
+      }
     }
 
     const tab = document.querySelector(`.terminal-tab[data-id="${id}"]`);
@@ -1261,6 +1278,7 @@ class TerminalManager extends BaseComponent {
       if (nameSpan) {
         nameSpan.textContent = name;
       }
+      if (tab.classList.contains('pinned-tab')) tab.title = name;
     }
     const TerminalSessionService = require('../../services/TerminalSessionService');
     TerminalSessionService.saveTerminalSessions();
@@ -1366,21 +1384,60 @@ class TerminalManager extends BaseComponent {
     input.focus();
     input.select();
 
+    let cancelled = false;
     const finishRename = () => {
-      const newName = input.value.trim() || currentName;
-      updateTerminal(id, { name: newName });
+      const typed = input.value.trim();
+      const newName = (!cancelled && typed) || currentName;
       const newSpan = document.createElement('span');
       newSpan.className = 'tab-name';
       newSpan.textContent = newName;
       newSpan.ondblclick = (e) => { e.stopPropagation(); self._startRenameTab(id); };
       input.replaceWith(newSpan);
+      if (cancelled) return;
+      if (typed) {
+        // A name typed by hand is custom: it sticks, auto renames stop
+        self.updateTerminalTabName(id, newName, { custom: true });
+      } else {
+        // Cleared: drop the custom lock so auto naming takes over again
+        updateTerminal(id, { nameCustom: false });
+        const td = getTerminal(id);
+        if (td?.claudeSessionId) self._setSessionCustomName(td.claudeSessionId, '');
+      }
     };
 
     input.onblur = finishRename;
     input.onkeydown = (e) => {
       if (e.key === 'Enter') { e.preventDefault(); input.blur(); }
-      if (e.key === 'Escape') { input.value = currentName; input.blur(); }
+      if (e.key === 'Escape') { cancelled = true; input.blur(); }
     };
+  }
+
+  // ── Tab pinning ──
+  //
+  // Chrome-style pinned tabs: compact, no close button, clustered at the
+  // start of the bar. Bulk close actions spare them; closing one stays
+  // available through its context menu.
+
+  setTabPinned(id, pinned) {
+    const termData = getTerminal(id);
+    const tab = document.querySelector(`.terminal-tab[data-id="${id}"]`);
+    if (!termData || !tab) return;
+
+    updateTerminal(id, { pinned: !!pinned });
+    tab.classList.toggle('pinned-tab', !!pinned);
+    // Compact tabs truncate their label; the tooltip carries the full name
+    tab.title = pinned ? (termData.name || '') : '';
+
+    // Re-cluster. The same anchor serves both directions: right after the last
+    // other pinned tab — the end of the pinned zone when pinning, the start of
+    // the unpinned zone when unpinning.
+    const tabsContainer = document.getElementById('terminals-tabs');
+    const otherPinned = Array.from(tabsContainer.querySelectorAll('.terminal-tab.pinned-tab')).filter(el => el !== tab);
+    const lastPinned = otherPinned[otherPinned.length - 1] || null;
+    tabsContainer.insertBefore(tab, lastPinned ? lastPinned.nextSibling : tabsContainer.firstChild);
+
+    const TerminalSessionService = require('../../services/TerminalSessionService');
+    TerminalSessionService.saveTerminalSessions();
   }
 
   _showTabContextMenu(e, id) {
@@ -1390,7 +1447,8 @@ class TerminalManager extends BaseComponent {
 
     const tabsContainer = document.getElementById('terminals-tabs');
     // Only act on tabs belonging to the same project as the target tab
-    const thisProjectId = getTerminal(id)?.project?.id;
+    const termData = getTerminal(id);
+    const thisProjectId = termData?.project?.id;
     const allTabs = Array.from(tabsContainer.querySelectorAll('.terminal-tab'))
       .filter(tab => getTerminal(tab.dataset.id)?.project?.id === thisProjectId);
     const thisTab = tabsContainer.querySelector(`.terminal-tab[data-id="${id}"]`);
@@ -1398,10 +1456,25 @@ class TerminalManager extends BaseComponent {
     const tabsToLeft = thisIndex > 0 ? allTabs.slice(0, thisIndex) : [];
     const tabsToRight = allTabs.slice(thisIndex + 1);
 
+    // Bulk close actions spare pinned tabs, like a browser's do
+    const isPinnedEl = (el) => el.classList.contains('pinned-tab');
+    const closableOthers = allTabs.filter(tab => tab !== thisTab && !isPinnedEl(tab));
+    const closableLeft = tabsToLeft.filter(tab => !isPinnedEl(tab));
+    const closableRight = tabsToRight.filter(tab => !isPinnedEl(tab));
+    const closableAll = allTabs.filter(tab => !isPinnedEl(tab));
+    const isPinned = !!termData?.pinned;
+
     showContextMenu({
       x: e.clientX,
       y: e.clientY,
       items: [
+        {
+          label: isPinned ? t('tabs.unpin') : t('tabs.pin'),
+          icon: isPinned
+            ? '<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 17v5"/><path d="M15 9.34V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H7.89"/><path d="m2 2 20 20"/><path d="M9 9v1.76A2 2 0 0 1 7.89 12.55L6.65 13.17A2 2 0 0 0 5.55 14.96V16a1 1 0 0 0 1 1h11"/></svg>'
+            : '<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 17v5"/><path d="M15 9.34V6a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1v3.34a2 2 0 0 1-1.11 1.79l-1.24.62A2 2 0 0 0 5.55 13.55V15a1 1 0 0 0 1 1h11a1 1 0 0 0 1-1v-1.45a2 2 0 0 0-1.11-1.79l-1.24-.62A2 2 0 0 1 15 9.34Z"/></svg>',
+          onClick: () => self.setTabPinned(id, !isPinned)
+        },
         {
           label: t('tabs.rename'),
           shortcut: 'Double-click',
@@ -1417,37 +1490,34 @@ class TerminalManager extends BaseComponent {
         {
           label: t('tabs.closeOthers'),
           icon: '<svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/></svg>',
-          disabled: allTabs.length <= 1,
+          disabled: closableOthers.length === 0,
           onClick: () => {
-            allTabs.forEach(tab => {
-              const tabId = tab.dataset.id;
-              if (tabId !== id) self.closeTerminal(tabId);
-            });
+            closableOthers.forEach(tab => self.closeTerminal(tab.dataset.id));
           }
         },
         {
           label: t('tabs.closeToLeft'),
           icon: '<svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/></svg>',
-          disabled: tabsToLeft.length === 0,
+          disabled: closableLeft.length === 0,
           onClick: () => {
-            tabsToLeft.forEach(tab => self.closeTerminal(tab.dataset.id));
+            closableLeft.forEach(tab => self.closeTerminal(tab.dataset.id));
           }
         },
         {
           label: t('tabs.closeToRight'),
           icon: '<svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/></svg>',
-          disabled: tabsToRight.length === 0,
+          disabled: closableRight.length === 0,
           onClick: () => {
-            tabsToRight.forEach(tab => self.closeTerminal(tab.dataset.id));
+            closableRight.forEach(tab => self.closeTerminal(tab.dataset.id));
           }
         },
         { separator: true },
         {
           label: t('tabs.closeAll'),
           icon: '<svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/></svg>',
-          disabled: allTabs.length === 0,
+          disabled: closableAll.length === 0,
           onClick: () => {
-            allTabs.forEach(tab => self.closeTerminal(tab.dataset.id));
+            closableAll.forEach(tab => self.closeTerminal(tab.dataset.id));
           }
         }
       ]
@@ -1643,13 +1713,13 @@ class TerminalManager extends BaseComponent {
   // ── Create terminal ──
 
   async createTerminal(project, options = {}) {
-    const { skipPermissions = false, runClaude = true, name: customName = null, mode: explicitMode = null, cwd: overrideCwd = null, initialPrompt = null, initialImages = null, initialModel = null, initialEffort = null, onSessionStart = null, resumeSessionId = null, systemPrompt = null, tabTag = null } = options;
+    const { skipPermissions = false, runClaude = true, name: customName = null, nameCustom = false, mode: explicitMode = null, cwd: overrideCwd = null, initialPrompt = null, initialImages = null, initialModel = null, initialEffort = null, onSessionStart = null, resumeSessionId = null, systemPrompt = null, tabTag = null } = options;
 
     const mode = explicitMode || (runClaude ? (getSetting('defaultTerminalMode') || 'terminal') : 'terminal');
 
     if (mode === 'chat' && runClaude) {
       const chatProject = overrideCwd ? { ...project, path: overrideCwd } : project;
-      return this._createChatTerminal(chatProject, { skipPermissions, name: customName, parentProjectId: overrideCwd ? project.id : null, resumeSessionId, initialPrompt, initialImages, initialModel, initialEffort, onSessionStart, systemPrompt, tabTag });
+      return this._createChatTerminal(chatProject, { skipPermissions, name: customName, nameCustom, parentProjectId: overrideCwd ? project.id : null, resumeSessionId, initialPrompt, initialImages, initialModel, initialEffort, onSessionStart, systemPrompt, tabTag });
     }
 
     const result = await this._api.terminal.create({
@@ -1696,6 +1766,7 @@ class TerminalManager extends BaseComponent {
       project,
       projectIndex,
       name: tabName,
+      nameCustom: !!(customName && nameCustom),
       status: initialStatus,
       inputBuffer: '',
       isBasic: isBasicTerminal,
@@ -2558,6 +2629,13 @@ class TerminalManager extends BaseComponent {
   }
 
   // ── Session Custom Names ──
+  //
+  // session-names.json holds the name a session is displayed under. Two
+  // provenances share the file: names the user chose (custom) and names the
+  // AI tab naming produced (kept only so the list matches what the tab
+  // showed). Entries are `{ name, custom }`; bare strings predate the flag
+  // and are read as non-custom, since the auto namer wrote the vast majority
+  // of them. Only custom names survive auto renames.
 
   async _loadSessionNames() {
     if (this._namesCache) return this._namesCache;
@@ -2576,19 +2654,40 @@ class TerminalManager extends BaseComponent {
     } catch { /* ignore write errors */ }
   }
 
-  async _getSessionCustomName(sessionId) {
-    return (await this._loadSessionNames())[sessionId] || '';
+  async _getSessionNameEntry(sessionId) {
+    const raw = (await this._loadSessionNames())[sessionId];
+    if (!raw) return { name: '', custom: false };
+    if (typeof raw === 'string') return { name: raw, custom: false };
+    return { name: raw.name || '', custom: !!raw.custom };
   }
 
-  async _setSessionCustomName(sessionId, name) {
+  async _setSessionCustomName(sessionId, name, { custom = true } = {}) {
     const names = await this._loadSessionNames();
+    const existing = names[sessionId];
+    // An auto rename never clobbers a name the user chose
+    if (!custom && existing && typeof existing === 'object' && existing.custom) return;
     if (name) {
-      names[sessionId] = name;
+      names[sessionId] = { name, custom };
     } else {
       delete names[sessionId];
     }
     this._namesCache = names;
     await this._saveSessionNames();
+  }
+
+  // Mirror a rename made in the sessions list onto any open tab running that
+  // session, so the tab does not overwrite it on the next auto rename.
+  _applyNameToOpenTabs(sessionId, name, custom) {
+    terminalsState.get().terminals.forEach((td, id) => {
+      if (td?.claudeSessionId !== sessionId) return;
+      updateTerminal(id, name ? { name, nameCustom: !!custom } : { nameCustom: false });
+      const tab = document.querySelector(`.terminal-tab[data-id="${id}"]`);
+      if (tab && name) {
+        const nameSpan = tab.querySelector('.tab-name');
+        if (nameSpan) nameSpan.textContent = name;
+        if (tab.classList.contains('pinned-tab')) tab.title = name;
+      }
+    });
   }
 
   async _preprocessSessions(sessions) {
@@ -2598,7 +2697,11 @@ class TerminalManager extends BaseComponent {
       const promptResult = cleanSessionText(session.firstPrompt);
       const summaryResult = cleanSessionText(session.summary);
       const skillName = promptResult.skillName || summaryResult.skillName;
-      const customName = await this._getSessionCustomName(session.sessionId);
+      const nameEntry = await this._getSessionNameEntry(session.sessionId);
+      // A deliberately chosen name — renamed here or in Claude Code — outranks
+      // every generated one and is never auto-renamed again.
+      const lockedName = nameEntry.custom ? nameEntry.name : session.customTitle;
+      const customName = lockedName || nameEntry.name;
 
       let displayTitle = '';
       let displaySubtitle = '';
@@ -2607,8 +2710,8 @@ class TerminalManager extends BaseComponent {
 
       if (customName) {
         displayTitle = customName;
-        displaySubtitle = session.title || summaryResult.text || promptResult.text;
-        isRenamed = true;
+        displaySubtitle = (session.title !== customName ? session.title : '') || summaryResult.text || promptResult.text;
+        isRenamed = Boolean(lockedName);
       } else if (session.title) {
         // Title Claude Code itself carries in the transcript: `custom-title` when
         // renamed there, `ai-title` otherwise. Far more useful than the raw
@@ -2635,7 +2738,7 @@ class TerminalManager extends BaseComponent {
         + ' ' + customName).toLowerCase();
 
       const pinned = await this._isSessionPinned(session.sessionId);
-      results.push({ ...session, displayTitle, displaySubtitle, isSkill, isRenamed, freshness, searchText, pinned });
+      results.push({ ...session, displayTitle, displaySubtitle, isSkill, isRenamed, nameLocked: Boolean(lockedName), freshness, searchText, pinned });
     }
     return results;
   }
@@ -2663,12 +2766,19 @@ class TerminalManager extends BaseComponent {
       cleanup();
       if (newName && newName !== currentName) {
         await self._setSessionCustomName(sessionId, newName);
+        self._applyNameToOpenTabs(sessionId, newName, true);
         if (sessionData) {
           sessionData.displayTitle = newName;
           sessionData.isRenamed = true;
+          sessionData.nameLocked = true;
         }
       } else if (!newName) {
         await self._setSessionCustomName(sessionId, '');
+        self._applyNameToOpenTabs(sessionId, null, false);
+        if (sessionData) {
+          sessionData.isRenamed = false;
+          sessionData.nameLocked = false;
+        }
       }
       if (onDone) onDone();
     }
@@ -2858,7 +2968,17 @@ class TerminalManager extends BaseComponent {
         const sessionId = card.dataset.sid;
         if (!sessionId) return;
         const skipPermissions = getSetting('skipPermissions') || false;
-        self.resumeSession(project, sessionId, { skipPermissions });
+        const session = sessionMap.get(sessionId);
+        // A user-chosen name passes through untouched; generated labels are
+        // bounded so a prompt-only session can't flood the tab bar.
+        const tabLabel = session?.nameLocked
+          ? session.displayTitle
+          : truncateText(session?.displayTitle || '', 40);
+        self.resumeSession(project, sessionId, {
+          skipPermissions,
+          name: tabLabel || null,
+          nameCustom: !!session?.nameLocked
+        });
       });
 
       emptyState.querySelector('.sessions-new-btn').onclick = () => {
@@ -2918,12 +3038,12 @@ class TerminalManager extends BaseComponent {
   // ── Resume session ──
 
   async resumeSession(project, sessionId, options = {}) {
-    const { skipPermissions = false, name: sessionName = null } = options;
+    const { skipPermissions = false, name: sessionName = null, nameCustom = false } = options;
 
     const mode = getSetting('defaultTerminalMode') || 'terminal';
     if (mode === 'chat') {
       console.log(`[TerminalManager] Resuming in chat mode — sessionId: ${sessionId}`);
-      return this._createChatTerminal(project, { skipPermissions, resumeSessionId: sessionId, name: sessionName });
+      return this._createChatTerminal(project, { skipPermissions, resumeSessionId: sessionId, name: sessionName, nameCustom });
     }
 
     const result = await this._api.terminal.create({
@@ -2966,6 +3086,7 @@ class TerminalManager extends BaseComponent {
       project,
       projectIndex,
       name: sessionName || t('terminals.resuming'),
+      nameCustom: !!(sessionName && nameCustom),
       status: 'working',
       inputBuffer: '',
       isBasic: false,
@@ -2978,7 +3099,9 @@ class TerminalManager extends BaseComponent {
 
     addTerminal(id, termData);
 
-    if (sessionName) {
+    // Only a name the user actually chose is worth locking in; the display
+    // title a resume happens to carry would otherwise masquerade as a rename.
+    if (sessionName && nameCustom) {
       await this._setSessionCustomName(sessionId, sessionName);
     }
 
@@ -3770,7 +3893,7 @@ class TerminalManager extends BaseComponent {
   // ── Chat terminal ──
 
   async _createChatTerminal(project, options = {}) {
-    const { skipPermissions = false, name: customName = null, resumeSessionId = null, forkSession = false, resumeSessionAt = null, resumeDropsTurn = null, parentProjectId = null, initialPrompt = null, initialImages = null, initialModel = null, initialEffort = null, onSessionStart = null, systemPrompt = null, tabTag = null } = options;
+    const { skipPermissions = false, name: customName = null, nameCustom = false, resumeSessionId = null, forkSession = false, resumeSessionAt = null, resumeDropsTurn = null, parentProjectId = null, initialPrompt = null, initialImages = null, initialModel = null, initialEffort = null, onSessionStart = null, systemPrompt = null, tabTag = null } = options;
 
     const id = `chat-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     let _chatSessionId = null;
@@ -3785,6 +3908,7 @@ class TerminalManager extends BaseComponent {
       project,
       projectIndex,
       name: tabName,
+      nameCustom: !!(customName && nameCustom),
       status: 'ready',
       inputBuffer: '',
       isBasic: false,
@@ -3851,24 +3975,17 @@ class TerminalManager extends BaseComponent {
       onSessionStart: (sid) => {
         _chatSessionId = sid;
         updateTerminal(id, { claudeSessionId: sid });
+        // A tab renamed before its session existed persists the name now
+        const td = getTerminal(id);
+        if (td?.nameCustom && td.name) self._setSessionCustomName(sid, td.name);
         if (onSessionStart) onSessionStart(sid);
       },
-      onTabRename: async (name) => {
-        const nameEl = tab.querySelector('.tab-name');
-        if (nameEl) nameEl.textContent = name;
-        const data = getTerminal(id);
-        if (data) data.name = name;
-        if (_chatSessionId && name) {
-          await self._setSessionCustomName(_chatSessionId, name);
-        }
-        if (_chatSessionId && self._api.remote?.notifyTabRenamed) {
-          self._api.remote.notifyTabRenamed({ sessionId: _chatSessionId, tabName: name });
-        }
-      },
+      onTabRename: (name) => self.updateTerminalTabName(id, name),
       onStatusChange: (status, substatus) => self._updateChatTerminalStatus(id, status, substatus),
       onSwitchTerminal: (dir) => self._callbacks.onSwitchTerminal?.(dir),
       onSwitchProject: (dir) => self._callbacks.onSwitchProject?.(dir),
       onForkSession: ({ resumeSessionId: forkSid, resumeSessionAt: forkAt, resumeDropsTurn: forkDrops, model: forkModel, effort: forkEffort, skipPermissions: forkSkipPerms }) => {
+        const src = getTerminal(id);
         self._createChatTerminal(project, {
           resumeSessionId: forkSid,
           forkSession: true,
@@ -3877,7 +3994,8 @@ class TerminalManager extends BaseComponent {
           skipPermissions: forkSkipPerms || false,
           initialModel: forkModel || null,
           initialEffort: forkEffort || null,
-          name: `Fork: ${tabName}`
+          name: `Fork: ${src?.name || tabName}`,
+          nameCustom: !!src?.nameCustom
         });
       },
     });
@@ -3989,11 +4107,7 @@ class TerminalManager extends BaseComponent {
         initialEffort: projSettings.effortLevel || null,
         builtinSystemPrompt: getBuiltinSystemPrompt(project.type),
         onSessionStart: (sid) => updateTerminal(id, { claudeSessionId: sid }),
-        onTabRename: (name) => {
-          const nameEl = tab.querySelector('.tab-name');
-          if (nameEl) nameEl.textContent = name;
-          updateTerminal(id, { name });
-        },
+        onTabRename: (name) => self.updateTerminalTabName(id, name),
         onStatusChange: (status, substatus) => self._updateChatTerminalStatus(id, status, substatus),
         onSwitchTerminal: (dir) => self._callbacks.onSwitchTerminal?.(dir),
         onSwitchProject: (dir) => self._callbacks.onSwitchProject?.(dir),
@@ -4561,7 +4675,8 @@ module.exports = {
   writeApiConsole: (projectIndex, data) => _getInstance().writeApiConsole(projectIndex, data),
   switchTerminalMode: (id) => _getInstance().switchTerminalMode(id),
   setScrapingCallback: (cb) => _getInstance().setScrapingCallback(cb),
-  updateTerminalTabName: (id, name) => _getInstance().updateTerminalTabName(id, name),
+  updateTerminalTabName: (id, name, opts) => _getInstance().updateTerminalTabName(id, name, opts),
+  setTabPinned: (id, pinned) => _getInstance().setTabPinned(id, pinned),
   cleanupProjectMaps: (projectIndex) => _getInstance().cleanupProjectMaps(projectIndex),
   scheduleScrollAfterRestore: (id) => _getInstance().scheduleScrollAfterRestore(id),
   // MCP orchestration

--- a/src/renderer/ui/panels/ControlTowerPanel.js
+++ b/src/renderer/ui/panels/ControlTowerPanel.js
@@ -1781,7 +1781,7 @@ function _startRenameMaximized() {
       } catch { /* ignore */ }
       try {
         const TerminalManager = require('../components/TerminalManager');
-        TerminalManager.updateTerminalTabName(agent.terminalId, value);
+        TerminalManager.updateTerminalTabName(agent.terminalId, value, { custom: true });
       } catch { /* state-only rename still shows in Control Tower */ }
     }
     titleEl.textContent = agent.sessionName || agent.projectName;

--- a/styles/terminal.css
+++ b/styles/terminal.css
@@ -1047,6 +1047,24 @@
   border-top: 2px solid var(--accent);
 }
 
+/* Pinned tabs — Chrome-style: compact, clustered at the start of the bar,
+   no close button (closing stays available via the context menu) */
+.terminal-tab.pinned-tab {
+  padding: 8px 10px;
+  gap: 6px;
+}
+
+.terminal-tab.pinned-tab .tab-name {
+  max-width: 72px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.terminal-tab.pinned-tab .tab-close,
+.terminal-tab.pinned-tab .tab-mode-toggle {
+  display: none;
+}
+
 .tab-name {
   cursor: pointer;
 }

--- a/styles/terminal.css
+++ b/styles/terminal.css
@@ -1065,6 +1065,24 @@
   display: none;
 }
 
+/* The pin glyph takes the close button's spot; clicking it unpins */
+.tab-pin-icon {
+  display: flex;
+  align-items: center;
+  color: var(--text-muted);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.tab-pin-icon svg {
+  width: 11px;
+  height: 11px;
+}
+
+.tab-pin-icon:hover {
+  color: var(--accent);
+}
+
 .tab-name {
   cursor: pointer;
 }

--- a/tests/ipc/claudeSessionTitle.test.js
+++ b/tests/ipc/claudeSessionTitle.test.js
@@ -25,13 +25,14 @@ const { getClaudeSessions, readSessionTitle, invalidateSessionsCache } = require
 const PROJECT_PATH = '/tmp/title-demo';
 const sessionsDir = () => path.join(TMP_HOME, '.claude', 'projects', PROJECT_PATH.replace(/[^a-zA-Z0-9]/g, '-'));
 
-/** @param {{sessionId: string, customTitle?: string, aiTitle?: string, padding?: number}} opts */
-function writeSession({ sessionId, customTitle, aiTitle, padding = 0 }) {
+/** @param {{sessionId: string, customTitle?: string, aiTitle?: string, padding?: number, ts?: string}} opts */
+function writeSession({ sessionId, customTitle, aiTitle, padding = 0, ts }) {
   const dir = sessionsDir();
   fs.mkdirSync(dir, { recursive: true });
 
   const lines = [JSON.stringify({
     type: 'user', uuid: 'u-0', sessionId, cwd: PROJECT_PATH, gitBranch: 'main',
+    ...(ts ? { timestamp: ts } : {}),
     message: { role: 'user', content: 'the opening prompt' }
   })];
   if (aiTitle) lines.push(JSON.stringify({ type: 'ai-title', aiTitle, sessionId }));
@@ -60,8 +61,16 @@ describe('readSessionTitle', () => {
 
     expect(await readSessionTitle(file, size)).toEqual({
       customTitle: 'Renamed by hand',
-      aiTitle: 'Generated'
+      aiTitle: 'Generated',
+      lastActivity: ''
     });
+  });
+
+  test('reports the timestamp of the last stamped line as lastActivity', async () => {
+    const file = writeSession({ sessionId: 'a1b', aiTitle: 'Generated', ts: '2026-03-01T10:00:00.000Z' });
+    const { size } = fs.statSync(file);
+
+    expect((await readSessionTitle(file, size)).lastActivity).toBe('2026-03-01T10:00:00.000Z');
   });
 
   test('falls back to ai-title when the session was never renamed', async () => {
@@ -101,7 +110,7 @@ describe('readSessionTitle', () => {
 
   test('returns empty titles for an unreadable file', async () => {
     expect(await readSessionTitle(path.join(sessionsDir(), 'nope.jsonl'), 10)).toEqual({
-      customTitle: '', aiTitle: ''
+      customTitle: '', aiTitle: '', lastActivity: ''
     });
   });
 });
@@ -128,13 +137,14 @@ describe('getClaudeSessions', () => {
     expect(sessions.find(s => s.sessionId === 'b2').title).toBe('');
   });
 
-  test('reads a title only for the sessions it returns', async () => {
-    // The result is capped at 50, so on a project with more sessions than that a
-    // tail read per file would be spent on transcripts nobody is about to see.
+  test('reads tails only for the ranking candidates, not every session', async () => {
+    // The result is capped at 50 and tail reads at 80 candidates (pre-ranked by
+    // mtime), so a project with hundreds of transcripts doesn't pay a 128 KB
+    // read for files that can't make the cut anyway.
     const dir = sessionsDir();
     fs.rmSync(dir, { recursive: true, force: true });
 
-    const total = 60;
+    const total = 90;
     for (let i = 0; i < total; i++) {
       const id = `c${String(i).padStart(2, '0')}`;
       const file = writeSession({ sessionId: id, customTitle: `Title ${i}`, padding: 1 });
@@ -149,14 +159,34 @@ describe('getClaudeSessions', () => {
       const sessions = await getClaudeSessions(PROJECT_PATH);
 
       expect(sessions).toHaveLength(50);
-      expect(openSpy).toHaveBeenCalledTimes(50);
+      expect(openSpy).toHaveBeenCalledTimes(80);
       // The 50 kept are the most recent ones, and each carries its title
-      expect(sessions[0].sessionId).toBe('c59');
-      expect(sessions[0].title).toBe('Title 59');
+      expect(sessions[0].sessionId).toBe('c89');
+      expect(sessions[0].title).toBe('Title 89');
       expect(sessions.every(s => s.title.startsWith('Title '))).toBe(true);
     } finally {
       openSpy.mockRestore();
     }
+  });
+
+  test('orders by last message timestamp, not by file mtime', async () => {
+    // Claude Code keeps appending housekeeping lines after the last real
+    // message, so mtime can leapfrog a genuinely more recent conversation.
+    const dir = sessionsDir();
+    fs.rmSync(dir, { recursive: true, force: true });
+
+    const active = writeSession({ sessionId: 'e-active', padding: 1, ts: '2026-02-01T12:00:00.000Z' });
+    const idle = writeSession({ sessionId: 'e-idle', padding: 1, ts: '2026-02-01T11:00:00.000Z' });
+    // The idle session's file was touched later than the active one's
+    fs.utimesSync(active, new Date('2026-02-01T12:01:00Z'), new Date('2026-02-01T12:01:00Z'));
+    fs.utimesSync(idle, new Date('2026-02-01T13:00:00Z'), new Date('2026-02-01T13:00:00Z'));
+
+    const sessions = await getClaudeSessions(PROJECT_PATH);
+
+    expect(sessions.map(s => s.sessionId)).toEqual(['e-active', 'e-idle']);
+    // `modified` follows the conversation so time groups and labels stay truthful
+    expect(sessions[0].modified).toBe('2026-02-01T12:00:00.000Z');
+    expect(sessions[1].modified).toBe('2026-02-01T11:00:00.000Z');
   });
 
   test('does not leak the internal filePath into the returned sessions', async () => {


### PR DESCRIPTION
## Summary

Three session/tab UX fixes and features:

### 1. User-chosen names stop being auto-renamed
- Auto naming (haiku titles, OSC scraping, slash-command hook) renamed tabs on every message, even over a name the user had set, and persisted its output to `session-names.json` as if it were a user rename.
- Tab names now carry a `custom` flag. A name set by hand — tab double-click, sessions list, Control Tower, or a Claude Code `custom-title` — locks the tab: no truncation flash, no haiku call, no OSC/hook rename. The lock survives restart, resume and fork, and follows the session when renamed from the list while its tab is open.
- Clearing the rename field hands the tab back to auto naming (documented escape hatch); `Escape` cancels without locking.
- `session-names.json` entries become `{ name, custom }`; bare legacy strings are read as non-custom since the auto namer wrote most of them.

### 2. Sessions ordered by real activity, not file mtime
- Claude Code keeps appending housekeeping lines (titles, snapshots) after the last real message, so mtime drifts by up to ~an hour (measured on real data: 4 files out of 17) and the list looked randomly shuffled.
- The last message timestamp is now read from the same 128 KB tail pass that already extracts titles, bounded to 80 mtime-ranked candidates, and the list sorts on it. Time groups and relative labels follow the conversation too.

### 3. Chrome-style pinned tabs
- Pin/unpin from the tab context menu: pinned tabs cluster compact at the start of the bar (truncated label, full name as tooltip), lose their close button (context-menu close still works), and bulk close actions spare them.
- Drag and drop keeps the pinned and unpinned zones separate; state persists in `terminal-sessions.json` and is restored on startup.
- i18n keys added to all five locales.

## Test plan
- `npx jest` — 2194 tests green on this base, including 5 new/updated tests covering activity-based ordering, the tail-read candidate cap, and `lastActivity` extraction.
- Manual: rename a tab then send messages (name holds), clear rename (auto naming resumes), resume renamed/unrenamed sessions from panel and modal, pin/unpin/drag tabs, restart to check restore.

Fork PR with the same changes on the fork's base: bleleve/claude-terminal#19

🤖 Generated with [Claude Code](https://claude.com/claude-code)