### PR TITLE
feat(files): a Files screen, with per-session diffs rendered like GitHub

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,17 +104,23 @@
           </svg>
           <span data-i18n="ui.tabClaude">Claude</span>
         </button>
-        <button class="nav-tab" data-tab="git" title="Git" data-i18n-title="ui.tooltipGit">
-          <svg viewBox="0 0 24 24" fill="currentColor">
-            <path d="M2.6 10.59L8.38 4.8l1.69 1.7c-.24.85.15 1.78.93 2.23v5.54c-.6.34-1 .99-1 1.73a2 2 0 0 0 2 2 2 2 0 0 0 2-2c0-.74-.4-1.39-1-1.73V9.41l1.35 1.36c-.02.13-.03.26-.03.4a2 2 0 0 0 2 2 2 2 0 0 0 2-2 2 2 0 0 0-2-2c-.14 0-.27.01-.4.04L13.2 7.07a2 2 0 0 0-1.12-2.51L13.71 2.9 21.41 10.59a2 2 0 0 1 0 2.82L13.41 21.41a2 2 0 0 1-2.82 0L2.59 13.41a2 2 0 0 1 0-2.82z"/>
-          </svg>
-          <span data-i18n="ui.tabGit">Git</span>
-        </button>
         <button class="nav-tab" data-tab="dashboard" title="Dashboard" data-i18n-title="ui.tooltipDashboard">
           <svg viewBox="0 0 24 24" fill="currentColor">
             <path d="M3 13h8V3H3v10zm0 8h8v-6H3v6zm10 0h8V11h-8v10zm0-18v6h8V3h-8z"/>
           </svg>
           <span data-i18n="ui.tabDashboard">Dashboard</span>
+        </button>
+        <button class="nav-tab" data-tab="files" title="Files" data-i18n-title="ui.tooltipFiles">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M4 4h6v4H4V4zm10 6h6v4h-6v-4zm0 8h6v4h-6v-4zM7 8v12m0-6h7m-7 6h7"/>
+          </svg>
+          <span data-i18n="ui.tabFiles">Fichiers</span>
+        </button>
+        <button class="nav-tab" data-tab="git" title="Git" data-i18n-title="ui.tooltipGit">
+          <svg viewBox="0 0 24 24" fill="currentColor">
+            <path d="M2.6 10.59L8.38 4.8l1.69 1.7c-.24.85.15 1.78.93 2.23v5.54c-.6.34-1 .99-1 1.73a2 2 0 0 0 2 2 2 2 0 0 0 2-2c0-.74-.4-1.39-1-1.73V9.41l1.35 1.36c-.02.13-.03.26-.03.4a2 2 0 0 0 2 2 2 2 0 0 0 2-2 2 2 0 0 0-2-2c-.14 0-.27.01-.4.04L13.2 7.07a2 2 0 0 0-1.12-2.51L13.71 2.9 21.41 10.59a2 2 0 0 1 0 2.82L13.41 21.41a2 2 0 0 1-2.82 0L2.59 13.41a2 2 0 0 1 0-2.82z"/>
+          </svg>
+          <span data-i18n="ui.tabGit">Git</span>
         </button>
         <button class="nav-tab" data-tab="session-replay" title="Session Replay" data-i18n-title="ui.tooltipSessionReplay">
           <svg viewBox="0 0 24 24" fill="currentColor">
@@ -444,38 +450,8 @@
           </button>
           <!-- In sidebar mode the projects host is moved in here and docked as a
                column; in tab-bar mode it stays a popover above the content. -->
-          <!-- File Explorer Panel -->
-          <div class="file-explorer-panel" id="file-explorer-panel" style="display: none;">
-            <div class="panel-header">
-              <h2 data-i18n="fileExplorer.title">Explorer</h2>
-              <div class="panel-actions">
-                <button class="btn-icon" id="btn-collapse-explorer" data-i18n-title="ui.collapseAll" title="Collapse all">
-                  <svg viewBox="0 0 24 24" fill="currentColor"><path d="M7.41 18.59L8.83 20 12 16.83 15.17 20l1.41-1.41L12 14l-4.59 4.59zM16.59 5.41L15.17 4 12 7.17 8.83 4 7.41 5.41 12 10l4.59-4.59z"/></svg>
-                </button>
-                <button class="btn-icon" id="btn-refresh-explorer" data-i18n-title="common.refresh" title="Refresh">
-                  <svg viewBox="0 0 24 24" fill="currentColor"><path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"/></svg>
-                </button>
-                <button class="btn-icon" id="btn-close-explorer" data-i18n-title="common.close" title="Close">
-                  <svg viewBox="0 0 12 12"><path d="M1 1l10 10M11 1L1 11" stroke="currentColor" stroke-width="1.5" fill="none"/></svg>
-                </button>
-              </div>
-            </div>
-            <div class="fe-search-container" id="fe-search-container" style="display: none;">
-              <svg class="fe-search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.35-4.35"/></svg>
-              <input type="text" id="fe-search-input" class="fe-search-input" data-i18n-placeholder="fileExplorer.searchPlaceholder" placeholder="Search files...">
-              <button class="fe-content-search-toggle" id="fe-content-search-toggle" data-i18n-title="fileExplorer.searchContentToggle" title="Search in contents">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="12" height="12"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
-              </button>
-              <button class="fe-sort-btn" id="fe-sort-btn" data-i18n-title="fileExplorer.sortFiles" title="Sort">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="12" height="12"><path d="M3 6h18M3 12h12M3 18h6"/></svg>
-              </button>
-              <button class="fe-search-clear" id="fe-search-clear" data-i18n-title="ui.clearSearch" title="Clear" style="display: none;">
-                <svg viewBox="0 0 12 12"><path d="M1 1l10 10M11 1L1 11" stroke="currentColor" stroke-width="1.5" fill="none"/></svg>
-              </button>
-            </div>
-            <div class="file-explorer-tree" id="file-explorer-tree"></div>
-            <div class="panel-resizer" id="file-explorer-resizer"></div>
-          </div>
+          <!-- The file explorer used to be docked here as a third column. It is
+               its own screen now (#tab-files), reached from the project menu. -->
 
           <!-- Terminals Panel -->
           <div class="terminals-panel">
@@ -486,17 +462,9 @@
             <!-- Session tabs row: session actions sit to the left of the tabs -->
             <div class="terminals-tabs-row">
               <div class="session-actions">
-                <!-- Side-panel glyph, not a folder: this shows/hides the file
-                     explorer panel rather than opening a folder. -->
-                <button class="btn-icon btn-toggle-explorer" id="btn-toggle-explorer" data-i18n-title="ui.toggleExplorer">
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <rect x="3" y="4" width="18" height="16" rx="2"/>
-                    <line x1="9" y1="4" x2="9" y2="20"/>
-                    <line x1="5.5" y1="8.5" x2="6.5" y2="8.5"/>
-                    <line x1="5.5" y1="12" x2="6.5" y2="12"/>
-                    <line x1="5.5" y1="15.5" x2="6.5" y2="15.5"/>
-                  </svg>
-                </button>
+                <!-- The file explorer is reached from the project menu
+                     ("Files") or Ctrl+E — an unlabelled side-panel glyph here
+                     read as a folder button and told nobody what it did. -->
                 <!-- Single + opens the session menu: new session, terminal,
                      or search an existing session. -->
                 <button class="session-action-btn" id="btn-new-terminal" data-i18n-title="terminals.addSession" aria-haspopup="menu" aria-expanded="false">
@@ -628,6 +596,10 @@
 
 
       <!-- Git Tab -->
+      <!-- Files: tree + viewer. Markup is built by FilesPanel on first activate,
+           because FileExplorer binds its listeners to ids that must exist first. -->
+      <div class="tab-content" id="tab-files"></div>
+
       <div class="tab-content" id="tab-git">
         <div class="git-tab-layout">
           <div class="git-tab-sidebar">

--- a/renderer.js
+++ b/renderer.js
@@ -116,7 +116,7 @@ const {
 const registry = require('./src/project-types/registry');
 const { mergeTranslations } = require('./src/renderer/i18n');
 const ModalComponent = require('./src/renderer/ui/components/Modal');
-const { MemoryEditor, GitChangesPanel, ShortcutsManager, SettingsPanel, SkillsAgentsPanel, PluginsPanel, MarketplacePanel, McpPanel, WorkflowPanel, DatabasePanel, CloudPanel, ConnectivityPanel, ControlTowerPanel, SessionReplayPanel, ParallelTaskPanel, WorkspacePanel, ErrorLogPanel } = require('./src/renderer/ui/panels');
+const { MemoryEditor, GitChangesPanel, ShortcutsManager, SettingsPanel, SkillsAgentsPanel, PluginsPanel, MarketplacePanel, McpPanel, WorkflowPanel, DatabasePanel, CloudPanel, ConnectivityPanel, ControlTowerPanel, SessionReplayPanel, ParallelTaskPanel, WorkspacePanel, ErrorLogPanel, FilesPanel } = require('./src/renderer/ui/panels');
 // Not re-exported by the panels index: ConnectivityPanel embeds it as a sub-tab,
 // but its polling lifecycle is driven from the tab registry below.
 const RemotePanel = require('./src/renderer/ui/panels/RemotePanel');
@@ -144,7 +144,9 @@ const localState = {
   gitRepoStatus: new Map(),
   gitStatusInitialized: false,
   // Dashboard scope: 'project' (the project bar's active tab) or 'overview'.
-  dashboardScope: 'project'
+  dashboardScope: 'project',
+  // Same split for the Files screen: 'project' or 'overview'.
+  filesScope: 'project'
 };
 
 // ========== I18N STATIC TEXT UPDATES ==========
@@ -2745,6 +2747,7 @@ ProjectList.setCallbacks({
   onGitPull: gitPull,
   onGitPush: gitPush,
   onNewWorktree: openNewWorktreeModal,
+  onOpenProjectFiles: openProjectFiles,
   onCloudUpload: cloudUploadProject,
   onCloudDelete: cloudDeleteProject,
   onCloudReset: resetCloudState,
@@ -2829,8 +2832,10 @@ function selectProjectFromBar(projectIndex) {
   const tabs = document.getElementById('terminals-tabs');
   if (tabs) tabs.style.display = '';
 
-  // Picking a project tab is the way out of the dashboard's Overview tab.
+  // Picking a project tab is the way out of an Overview, on either screen.
   localState.dashboardScope = 'project';
+  localState.filesScope = 'project';
+  FilesPanel.setScope('project');
   ProjectBar.setOverviewActive(false);
 
   TerminalManager.filterByProject(projectIndex);
@@ -2875,7 +2880,15 @@ ProjectBar.initProjectBar({
   onCloseProject: (project) => closeProjectFromBar(project),
   onContextMenu: (project, x, y) => showProjectTabContextMenu(project, x, y),
   onOpenPicker: (anchor) => toggleProjectsPopover(anchor),
+  // Two screens have an all-projects view now, so the Overview tab belongs to
+  // whichever one is showing.
   onSelectOverview: () => {
+    if (document.body.dataset.activeTab === 'files') {
+      localState.filesScope = 'overview';
+      FilesPanel.setScope('overview');
+      ProjectBar.setOverviewActive(true);
+      return;
+    }
     localState.dashboardScope = 'overview';
     renderDashboardForScope();
   },
@@ -3167,21 +3180,17 @@ api.window.onCtrlTab((dir) => {
   api.window.setCtrlTabEnabled(ctrlTabEnabled);
 }
 
-// Setup FileExplorer
-FileExplorer.setCallbacks({
+// The Files screen owns the explorer's callbacks (a click lands in its own
+// viewer, not in a session tab); these two still need the host.
+FilesPanel.setCallbacks({
   onOpenInTerminal: (folderPath) => {
     const selectedFilter = projectsState.get().selectedProjectFilter;
     const projects = projectsState.get().projects;
     if (selectedFilter !== null && projects[selectedFilter]) {
       const project = { ...projects[selectedFilter], path: folderPath };
       TerminalManager.createTerminal(project, { runClaude: false });
+      document.querySelector('[data-tab="claude"]')?.click();
     }
-  },
-  onOpenFile: (filePath) => {
-    const selectedFilter = projectsState.get().selectedProjectFilter;
-    const projects = projectsState.get().projects;
-    const project = selectedFilter !== null ? projects[selectedFilter] : null;
-    TerminalManager.openFileTab(filePath, project);
   },
   onAddToChat: (relativePath, fullPath) => {
     const activeId = terminalsState.get().activeTerminal;
@@ -3189,15 +3198,28 @@ FileExplorer.setCallbacks({
     const termData = terminalsState.get().terminals.get(activeId);
     if (termData?.chatView?.addMentionChip) {
       termData.chatView.addMentionChip('file', { path: relativePath, fullPath });
+      document.querySelector('[data-tab="claude"]')?.click();
     }
   }
 });
-FileExplorer.init();
 
-// Toggle explorer button
-const btnToggleExplorer = document.getElementById('btn-toggle-explorer');
-if (btnToggleExplorer) {
-  btnToggleExplorer.onclick = () => FileExplorer.toggle();
+/**
+ * Show the Files screen for a project. Entry points are the project menu's
+ * "Files" item and Ctrl+E; both land here.
+ * @param {Object} project
+ */
+function openProjectFiles(project) {
+  if (!project) return;
+  const projectIndex = getProjectIndex(project.id);
+  if (projectIndex !== -1 && projectsState.get().selectedProjectFilter !== projectIndex) {
+    TerminalManager.filterByProject(projectIndex);
+    saveTerminalSessions();
+    applyProjectContext(projectIndex);
+  }
+  closeProjectsPopover();
+  // Clicking the nav element keeps scroll save/restore and the lifecycle hooks
+  // in one place — the hook is what mounts the panel.
+  document.querySelector('.nav-tab[data-tab="files"]')?.click();
 }
 
 // Wire "+" new terminal button
@@ -3257,7 +3279,8 @@ api.explorer.onWatchLimitWarning((totalPaths) => {
   showToast({ type: 'warning', title: t('fileExplorer.title'), message: t('fileExplorer.watchLimitWarning', { count: totalPaths }) });
 });
 // Wire lightbulb resume session button
-// Subscribe to project selection changes for FileExplorer
+// Follow the active project. The Files screen repoints itself on activate, so
+// this only has to keep the watcher and the tree root in step.
 projectsState.subscribe(() => {
   const state = projectsState.get();
   const selectedFilter = state.selectedProjectFilter;
@@ -3266,6 +3289,9 @@ projectsState.subscribe(() => {
   if (selectedFilter !== null && projects[selectedFilter]) {
     FileExplorer.setRootPath(projects[selectedFilter].path);
     api.explorer.watchDir(projects[selectedFilter].path);
+    if (document.body.dataset.activeTab === 'files') {
+      FilesPanel.loadPanel(document.getElementById('tab-files'), projects[selectedFilter]);
+    }
   } else {
     FileExplorer.hide();
     api.explorer.stopWatch();
@@ -3548,6 +3574,16 @@ const _TAB_LIFECYCLE = {
     // <select> widgets that init() builds exactly once.
     deactivate: () => SessionReplayPanel.onDeactivate()
   },
+  files: {
+    activate: () => {
+      const container = document.getElementById('tab-files');
+      if (!container) return;
+      FilesPanel.loadPanel(container, getCurrentProjectFromBar());
+      FilesPanel.setScope(localState.filesScope);
+    },
+    // Stops the explorer's 10s git-status poll while the screen is off.
+    deactivate: () => FilesPanel.onDeactivate()
+  },
   memory: { activate: () => MemoryEditor.loadMemory() },
   workspace: {
     activate: () => {
@@ -3635,9 +3671,14 @@ document.querySelectorAll('.nav-tab[data-tab]').forEach(tab => {
     document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
     document.getElementById(`tab-${tabId}`).classList.add('active');
     // Drives which parts of the project bar are relevant (tools are Claude-only,
-    // the Overview tab is dashboard-only) — see projects.css.
+    // the Overview tab belongs to Dashboard and Files) — see projects.css.
     document.body.dataset.activeTab = tabId;
-    ProjectBar.setOverviewActive(tabId === 'dashboard' && localState.dashboardScope === 'overview');
+    // Each screen remembers its own scope, so the tab reflects the one you are
+    // looking at rather than the last one you set anywhere.
+    ProjectBar.setOverviewActive(
+      (tabId === 'dashboard' && localState.dashboardScope === 'overview')
+      || (tabId === 'files' && localState.filesScope === 'overview')
+    );
     // Tear down the tab we are leaving, then wake up the one we entered.
     _leaveCurrentTab(tabId);
     _runTabHook(tabId, 'activate');
@@ -3651,7 +3692,7 @@ document.querySelectorAll('.nav-tab[data-tab]').forEach(tab => {
 // ========== PINNED TABS SYSTEM ==========
 // Canonical order — must mirror the grouping in index.html, since the groups
 // carry meaning (whether the project tab drives the screen).
-const _ALL_TABS_ORDER = ['claude', 'git', 'dashboard', 'session-replay', 'tasks', 'control-tower', 'workspace', 'memory', 'timetracking', 'database', 'skills', 'agents', 'plugins', 'mcp', 'workflows', 'errorlog', 'connectivity'];
+const _ALL_TABS_ORDER = ['claude', 'dashboard', 'files', 'git', 'session-replay', 'tasks', 'control-tower', 'workspace', 'memory', 'timetracking', 'database', 'skills', 'agents', 'plugins', 'mcp', 'workflows', 'errorlog', 'connectivity'];
 
 function applyPinnedTabs() {
   const pinned = settingsState.get().pinnedTabs || _ALL_TABS_ORDER;

--- a/src/main/ipc/claude.ipc.js
+++ b/src/main/ipc/claude.ipc.js
@@ -664,6 +664,210 @@ async function parseSessionReplay(projectPath, sessionId, options = {}) {
   });
 }
 
+// ─── Session file changes ───────────────────────────────────────────────────
+// Every file-editing tool call is already in the transcript, and Claude Code
+// attaches the diff it computed alongside it as `toolUseResult.structuredPatch`
+// — real hunks with exact oldStart/newStart line numbers. So "what did this
+// session change" is a read, not something the app has to record as it goes,
+// and the line numbers are the tool's own rather than a guess made afterwards
+// by hunting for an anchor in a file that has since moved on.
+//
+// Works retroactively on every transcript already on disk, for terminal
+// sessions as much as chat ones.
+
+const FILE_EDIT_TOOLS = new Set(['Write', 'Edit', 'MultiEdit', 'NotebookEdit']);
+// Measured on real sessions: ~52 KB of patch for 59 edits. This is a runaway
+// guard, not a budget anyone should reach.
+const CHANGES_MAX_PATCH_BYTES = 8 * 1024 * 1024;
+
+/** Additions and deletions in a structuredPatch. */
+function countPatchLines(hunks) {
+  let additions = 0, deletions = 0;
+  for (const hunk of hunks || []) {
+    for (const line of hunk.lines || []) {
+      if (line[0] === '+') additions++;
+      else if (line[0] === '-') deletions++;
+    }
+  }
+  return { additions, deletions };
+}
+
+/** The path a file-editing tool call targeted. */
+function editedPath(toolName, input) {
+  if (!input) return null;
+  if (toolName === 'NotebookEdit') return input.notebook_path || input.file_path || null;
+  return input.file_path || null;
+}
+
+/**
+ * Keep only what the renderer draws. A hunk's `lines` already carry their
+ * +/-/space prefix, which is the whole payload.
+ */
+function normalizeHunks(patch) {
+  const out = [];
+  for (const h of patch || []) {
+    if (!h || !Array.isArray(h.lines)) continue;
+    out.push({
+      oldStart: h.oldStart, oldLines: h.oldLines,
+      newStart: h.newStart, newLines: h.newLines,
+      lines: h.lines,
+    });
+  }
+  return out;
+}
+
+// A Write that creates a file reports `type: "create"` with an EMPTY
+// structuredPatch and the whole file in `content` — there was no previous
+// version to diff against. Left alone that reads as "+0 -0, no diff
+// available" on exactly the files a session added, which is the opposite of
+// useful. Build the patch the tool would have produced.
+const CREATED_FILE_MAX_LINES = 3000;
+
+function patchForCreatedFile(content) {
+  const text = String(content || '');
+  if (!text) return [];
+  let lines = text.split('\n');
+  // A generated lockfile should not ship 40k rows over IPC.
+  const truncated = lines.length > CREATED_FILE_MAX_LINES;
+  if (truncated) lines = lines.slice(0, CREATED_FILE_MAX_LINES);
+  return [{
+    oldStart: 0,
+    oldLines: 0,
+    newStart: 1,
+    newLines: lines.length,
+    lines: lines.map(l => '+' + l),
+  }];
+}
+
+/**
+ * Every file a session edited, with the diff hunks behind each one.
+ *
+ * Deliberately does NOT go through sanitizeToolInput: that caps inputs at 2000
+ * chars for the replay panel, which would empty out most of this.
+ *
+ * @param {string} projectPath
+ * @param {string} sessionId
+ * @param {object} [options]
+ * @param {boolean} [options.statsOnly] - Skip the hunks, keep the counters.
+ * @returns {Promise<{files: Array, totals: object}>}
+ */
+async function parseSessionFileChanges(projectPath, sessionId, options = {}) {
+  const statsOnly = !!options.statsOnly;
+  const sessionsDir = getProjectSessionsDir(projectPath);
+  const empty = () => ({ files: [], totals: { files: 0, additions: 0, deletions: 0, edits: 0, truncated: false } });
+
+  const filePath = await resolveSessionFile(sessionsDir, sessionId);
+  if (!filePath) return empty();
+
+  return new Promise((resolve) => {
+    const byPath = new Map();       // path -> entry
+    const pendingEdits = new Map(); // tool_use_id -> path, until its result lands
+    // A subagent tool call can appear both streamed and in the full assistant
+    // message; ids keep each edit counted once.
+    const seenToolUseIds = new Set();
+    let patchBytes = 0;
+    let truncated = false;
+
+    function entryFor(path) {
+      let entry = byPath.get(path);
+      if (!entry) {
+        entry = {
+          path, additions: 0, deletions: 0, edits: 0,
+          hunks: [], viaSubagent: false, lastEditedAt: null,
+        };
+        byPath.set(path, entry);
+      }
+      return entry;
+    }
+
+    const stream = fs.createReadStream(filePath, { encoding: 'utf8' });
+    const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+
+    // Closing the readline interface does not release the file handle, and
+    // Windows refuses to delete a file that still has one open.
+    const release = () => { rl.close(); stream.destroy(); };
+
+    rl.on('line', (line) => {
+      if (!line.trim()) return;
+      let obj;
+      try { obj = JSON.parse(line); } catch { return; }
+
+      // ── The call: note which file it targets, keyed by its id ──
+      const isAssistant = obj.type === 'assistant' || (!obj.type && obj.message?.role === 'assistant');
+      if (isAssistant && Array.isArray(obj.message?.content)) {
+        for (const block of obj.message.content) {
+          if (block.type !== 'tool_use' || !FILE_EDIT_TOOLS.has(block.name)) continue;
+          if (block.id && seenToolUseIds.has(block.id)) continue;
+          const path = editedPath(block.name, block.input);
+          if (!path) continue;
+          if (block.id) seenToolUseIds.add(block.id);
+
+          const entry = entryFor(path);
+          entry.edits++;
+          if (obj.isSidechain) entry.viaSubagent = true;
+          if (obj.timestamp) entry.lastEditedAt = obj.timestamp;
+          if (block.id) pendingEdits.set(block.id, path);
+        }
+      }
+
+      // ── The result: the patch the tool actually applied ──
+      // It rides as a sibling field on the line carrying the tool_result.
+      const result = obj.toolUseResult;
+      if (!result || typeof result !== 'object' || !Array.isArray(result.structuredPatch)) return;
+
+      // Only patches belonging to a file-editing call we saw. Matching on the
+      // result's own filePath instead would count any tool that happens to
+      // carry a structuredPatch, which is how a Read ends up in the list.
+      let path = null;
+      if (Array.isArray(obj.message?.content)) {
+        for (const block of obj.message.content) {
+          if (block.type === 'tool_result' && pendingEdits.has(block.tool_use_id)) {
+            path = pendingEdits.get(block.tool_use_id);
+            pendingEdits.delete(block.tool_use_id);
+            break;
+          }
+        }
+      }
+      if (!path) return;
+
+      const entry = entryFor(path);
+      const hunks = result.structuredPatch.length === 0 && result.type === 'create'
+        ? patchForCreatedFile(result.content)
+        : normalizeHunks(result.structuredPatch);
+      const counts = countPatchLines(hunks);
+      entry.additions += counts.additions;
+      entry.deletions += counts.deletions;
+
+      if (statsOnly) return;
+      const bytes = JSON.stringify(hunks).length;
+      if (patchBytes + bytes > CHANGES_MAX_PATCH_BYTES) { truncated = true; return; }
+      patchBytes += bytes;
+      entry.hunks.push(...hunks);
+    });
+
+    rl.on('close', () => {
+      release();
+      // An edit whose result never landed (session cut mid-call) leaves an
+      // entry with zeroed counters; keep it, the file was still touched.
+      const files = [...byPath.values()].sort(
+        (a, b) => (b.additions + b.deletions) - (a.additions + a.deletions)
+      );
+      resolve({
+        files,
+        totals: {
+          files: files.length,
+          additions: files.reduce((n, f) => n + f.additions, 0),
+          deletions: files.reduce((n, f) => n + f.deletions, 0),
+          edits: files.reduce((n, f) => n + f.edits, 0),
+          truncated,
+        },
+      });
+    });
+    rl.on('error', () => { release(); resolve(empty()); });
+    stream.on('error', () => { release(); resolve(empty()); });
+  });
+}
+
 // ─── Session index cache ────────────────────────────────────────────────────
 // Maps sessionId -> filePath, built per sessions directory on first scan.
 // Avoids O(N) sequential file reads on every session lookup.
@@ -1053,6 +1257,16 @@ function registerClaudeHandlers() {
     }
   });
 
+  // Every file a session edited, with its diff hunks
+  ipcMain.handle('claude-session-changes', async (event, { projectPath, sessionId, statsOnly }) => {
+    try {
+      return { success: true, ...(await parseSessionFileChanges(projectPath, sessionId, { statsOnly })) };
+    } catch (err) {
+      console.error('[claude-session-changes] Error:', err.message);
+      return { success: false, error: err.message, files: [], totals: {} };
+    }
+  });
+
   // Delete a session .jsonl file
   ipcMain.handle('claude-delete-session', async (event, { projectPath, sessionId }) => {
     try {
@@ -1084,4 +1298,4 @@ function registerClaudeHandlers() {
   });
 }
 
-module.exports = { registerClaudeHandlers, getClaudeSessions, loadSessionHistory, parseSessionReplay, moveSession, findStraySidecars, readSessionTitle, invalidateSessionsCache };
+module.exports = { registerClaudeHandlers, getClaudeSessions, loadSessionHistory, parseSessionReplay, parseSessionFileChanges, moveSession, findStraySidecars, readSessionTitle, invalidateSessionsCache };

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -542,6 +542,7 @@ contextBridge.exposeInMainWorld('electron_api', {
   claude: {
     sessions: (projectPath) => ipcRenderer.invoke('claude-sessions', projectPath),
     sessionReplay: (params) => ipcRenderer.invoke('claude-session-replay', params),
+    sessionChanges: (params) => ipcRenderer.invoke('claude-session-changes', params),
     deleteSession: (params) => ipcRenderer.invoke('claude-delete-session', params),
     exportSession: (params) => ipcRenderer.invoke('claude-export-session', params),
     moveSession: (params) => ipcRenderer.invoke('claude-move-session', params)

--- a/src/main/windows/MainWindow.js
+++ b/src/main/windows/MainWindow.js
@@ -183,6 +183,13 @@ function createMainWindow({ isDev = false } = {}) {
     frame: isMac ? undefined : false,
     titleBarStyle: isMac ? 'hiddenInset' : undefined,
     trafficLightPosition: isMac ? { x: 12, y: 10 } : undefined,
+    // Without this, macOS spends the first click on an unfocused window just
+    // focusing it: every action costs two clicks whenever you come back from
+    // another app. The tradeoff is that a click used to raise the window now
+    // also hits whatever is under the cursor, so it can fire a close or a
+    // delete you only meant to focus with. Worth it for an app you switch into
+    // constantly. No-op off macOS.
+    acceptFirstMouse: true,
     backgroundColor: '#0d0d0d',
     webPreferences: {
       nodeIntegration: false,

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -47,6 +47,7 @@
     "globalDefault": "Default (global)",
     "customize": "Customize",
     "basicTerminal": "Basic terminal",
+    "files": "Files",
     "openClaude": "Open Claude Code",
     "newFolder": "New folder",
     "gitPull": "Git Pull",
@@ -1081,7 +1082,9 @@
     "separatorProject": "Project",
     "separatorAllProjects": "All projects",
     "separatorCapabilities": "Capabilities",
-    "separatorSystem": "System"
+    "separatorSystem": "System",
+    "tabFiles": "Files",
+    "tooltipFiles": "Files"
   },
   "memory": {
     "panelDescription": "Configure how Claude behaves in your projects. Global settings apply everywhere, project settings override them.",
@@ -1743,6 +1746,10 @@
     "filesChanged": "files changed",
     "fileChanged": "file changed",
     "noChangesYet": "No files modified yet.",
+    "diffMoreLines": "… {count} more lines",
+    "noDiffAvailable": "No diff available.",
+    "diffVsCurrent": "Compare with the file on disk",
+    "diffNoCurrentChanges": "No uncommitted changes for this file.",
     "todoTitle": "Tasks",
     "todoAllDone": "All done",
     "subagentLaunching": "Launching agent...",
@@ -3953,5 +3960,23 @@
     "settingsHint": "How you switch between projects",
     "optionTabs": "Project tabs",
     "optionSidebar": "Projects sidebar"
+  },
+  "files": {
+    "modifiedOnly": "Modified only",
+    "filesTouched": "file(s) touched",
+    "sessionNoChanges": "This session changed no file.",
+    "noProject": "Open a project to browse its files.",
+    "pickAFile": "Pick a file in the tree.",
+    "viewContent": "Content",
+    "viewDiff": "Diff",
+    "toggleSplit": "Unified / side-by-side",
+    "openInTab": "Open in a tab",
+    "openInEditor": "Open in the editor",
+    "previewInTab": "This format previews in a tab.",
+    "tooLarge": "File too large to display here ({size}).",
+    "linesTruncated": "… {count} more lines",
+    "sessionCaption": "Session",
+    "noSession": "None",
+    "noSessionHint": "browse the whole tree"
   }
 }

--- a/src/renderer/i18n/locales/es.json
+++ b/src/renderer/i18n/locales/es.json
@@ -47,6 +47,7 @@
     "globalDefault": "Por defecto (global)",
     "customize": "Personalizar",
     "basicTerminal": "Terminal básica",
+    "files": "Archivos",
     "openClaude": "Abrir Claude Code",
     "newFolder": "Nueva carpeta",
     "gitPull": "Git Pull",
@@ -1078,7 +1079,9 @@
     "separatorProject": "Proyecto",
     "separatorAllProjects": "Todos los proyectos",
     "separatorCapabilities": "Capacidades",
-    "separatorSystem": "Sistema"
+    "separatorSystem": "Sistema",
+    "tabFiles": "Archivos",
+    "tooltipFiles": "Archivos"
   },
   "memory": {
     "panelDescription": "Configura como Claude se comporta en tus proyectos. Los ajustes globales aplican en todos lados, los de proyecto los reemplazan.",
@@ -1735,6 +1738,10 @@
     "filesChanged": "archivos modificados",
     "fileChanged": "archivo modificado",
     "noChangesYet": "Aún no se ha modificado ningún archivo.",
+    "diffMoreLines": "… {count} líneas más",
+    "noDiffAvailable": "No hay diff disponible.",
+    "diffVsCurrent": "Comparar con el archivo en disco",
+    "diffNoCurrentChanges": "No hay cambios sin confirmar para este archivo.",
     "todoTitle": "Tareas",
     "todoAllDone": "Todo listo",
     "subagentLaunching": "Lanzando agente...",
@@ -3953,5 +3960,23 @@
     "settingsHint": "Cómo cambias de proyecto",
     "optionTabs": "Pestañas de proyecto",
     "optionSidebar": "Columna de proyectos"
+  },
+  "files": {
+    "modifiedOnly": "Solo modificados",
+    "filesTouched": "archivo(s) tocado(s)",
+    "sessionNoChanges": "Esta sesión no modificó ningún archivo.",
+    "noProject": "Abre un proyecto para explorar sus archivos.",
+    "pickAFile": "Elige un archivo en el árbol.",
+    "viewContent": "Contenido",
+    "viewDiff": "Diff",
+    "toggleSplit": "Unificado / lado a lado",
+    "openInTab": "Abrir en una pestaña",
+    "openInEditor": "Abrir en el editor",
+    "previewInTab": "Este formato se previsualiza en una pestaña.",
+    "tooLarge": "Archivo demasiado grande para mostrarse aquí ({size}).",
+    "linesTruncated": "… {count} líneas más",
+    "sessionCaption": "Sesión",
+    "noSession": "Ninguna",
+    "noSessionHint": "explorar todo el árbol"
   }
 }

--- a/src/renderer/i18n/locales/fr.json
+++ b/src/renderer/i18n/locales/fr.json
@@ -47,6 +47,7 @@
     "globalDefault": "Par défaut (global)",
     "customize": "Personnaliser",
     "basicTerminal": "Terminal basique",
+    "files": "Fichiers",
     "openClaude": "Ouvrir Claude Code",
     "newFolder": "Nouveau dossier",
     "gitPull": "Git Pull",
@@ -1176,7 +1177,9 @@
     "separatorProject": "Projet",
     "separatorAllProjects": "Tous les projets",
     "separatorCapabilities": "Capacités",
-    "separatorSystem": "Système"
+    "separatorSystem": "Système",
+    "tabFiles": "Fichiers",
+    "tooltipFiles": "Fichiers"
   },
   "memory": {
     "panelDescription": "Configurez le comportement de Claude dans vos projets. Les reglages globaux s'appliquent partout, les reglages projet les remplacent.",
@@ -1743,6 +1746,10 @@
     "filesChanged": "fichiers modifiés",
     "fileChanged": "fichier modifié",
     "noChangesYet": "Aucun fichier modifié pour l'instant.",
+    "diffMoreLines": "… {count} lignes de plus",
+    "noDiffAvailable": "Aucun diff disponible.",
+    "diffVsCurrent": "Comparer avec le fichier sur le disque",
+    "diffNoCurrentChanges": "Aucune modification non commitée pour ce fichier.",
     "todoTitle": "Tâches",
     "todoAllDone": "Terminé",
     "subagentLaunching": "Lancement de l'agent...",
@@ -3953,5 +3960,23 @@
     "settingsHint": "Comment tu passes d'un projet à l'autre",
     "optionTabs": "Onglets de projet",
     "optionSidebar": "Colonne projets"
+  },
+  "files": {
+    "modifiedOnly": "Modifiés uniquement",
+    "filesTouched": "fichier(s) touché(s)",
+    "sessionNoChanges": "Cette session n'a modifié aucun fichier.",
+    "noProject": "Ouvrez un projet pour parcourir ses fichiers.",
+    "pickAFile": "Choisissez un fichier dans l’arborescence.",
+    "viewContent": "Contenu",
+    "viewDiff": "Diff",
+    "toggleSplit": "Unifié / côte à côte",
+    "openInTab": "Ouvrir dans un onglet",
+    "openInEditor": "Ouvrir dans l’éditeur",
+    "previewInTab": "Ce format s’affiche dans un onglet.",
+    "tooLarge": "Fichier trop volumineux pour être affiché ici ({size}).",
+    "linesTruncated": "… {count} lignes de plus",
+    "sessionCaption": "Session",
+    "noSession": "Aucune",
+    "noSessionHint": "parcourir toute l’arborescence"
   }
 }

--- a/src/renderer/i18n/locales/id.json
+++ b/src/renderer/i18n/locales/id.json
@@ -47,6 +47,7 @@
     "globalDefault": "Default (global)",
     "customize": "Kustomisasi",
     "basicTerminal": "Terminal dasar",
+    "files": "Berkas",
     "openClaude": "Buka Claude Code",
     "newFolder": "Folder baru",
     "gitPull": "Git Pull",
@@ -1081,7 +1082,9 @@
     "separatorProject": "Proyek",
     "separatorAllProjects": "Semua proyek",
     "separatorCapabilities": "Kemampuan",
-    "separatorSystem": "Sistem"
+    "separatorSystem": "Sistem",
+    "tabFiles": "Berkas",
+    "tooltipFiles": "Berkas"
   },
   "memory": {
     "panelDescription": "Atur bagaimana Claude berperilaku dalam proyek Anda. Pengaturan global berlaku di mana saja, pengaturan proyek akan menimpanya.",
@@ -1743,6 +1746,10 @@
     "filesChanged": "file diubah",
     "fileChanged": "file diubah",
     "noChangesYet": "Belum ada file yang diubah.",
+    "diffMoreLines": "… {count} baris lagi",
+    "noDiffAvailable": "Tidak ada diff yang tersedia.",
+    "diffVsCurrent": "Bandingkan dengan file di disk",
+    "diffNoCurrentChanges": "Tidak ada perubahan yang belum di-commit untuk file ini.",
     "todoTitle": "Tugas",
     "todoAllDone": "Semua selesai",
     "subagentLaunching": "Menjalankan agent...",
@@ -3953,5 +3960,23 @@
     "settingsHint": "Cara Anda berpindah antar proyek",
     "optionTabs": "Tab proyek",
     "optionSidebar": "Kolom proyek"
+  },
+  "files": {
+    "modifiedOnly": "Hanya yang diubah",
+    "filesTouched": "file tersentuh",
+    "sessionNoChanges": "Sesi ini tidak mengubah file apa pun.",
+    "noProject": "Buka proyek untuk menjelajahi file-nya.",
+    "pickAFile": "Pilih file di pohon.",
+    "viewContent": "Konten",
+    "viewDiff": "Diff",
+    "toggleSplit": "Terpadu / berdampingan",
+    "openInTab": "Buka di tab",
+    "openInEditor": "Buka di editor",
+    "previewInTab": "Format ini ditampilkan di tab.",
+    "tooLarge": "File terlalu besar untuk ditampilkan di sini ({size}).",
+    "linesTruncated": "… {count} baris lagi",
+    "sessionCaption": "Sesi",
+    "noSession": "Tidak ada",
+    "noSessionHint": "jelajahi seluruh pohon"
   }
 }

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -47,6 +47,7 @@
     "globalDefault": "默认（全局）",
     "customize": "自定义",
     "basicTerminal": "基础终端",
+    "files": "文件",
     "openClaude": "打开 Claude Code",
     "newFolder": "新建文件夹",
     "gitPull": "Git 拉取",
@@ -1081,7 +1082,9 @@
     "separatorProject": "项目",
     "separatorAllProjects": "所有项目",
     "separatorCapabilities": "能力",
-    "separatorSystem": "系统"
+    "separatorSystem": "系统",
+    "tabFiles": "文件",
+    "tooltipFiles": "文件"
   },
   "memory": {
     "panelDescription": "配置 Claude 在您的项目中的行为方式。全局设置适用于所有地方，项目设置会覆盖它们。",
@@ -1743,6 +1746,10 @@
     "filesChanged": "文件已更改",
     "fileChanged": "文件已更改",
     "noChangesYet": "尚未修改任何文件。",
+    "diffMoreLines": "… 还有 {count} 行",
+    "noDiffAvailable": "没有可用的差异。",
+    "diffVsCurrent": "与磁盘上的文件比较",
+    "diffNoCurrentChanges": "该文件没有未提交的更改。",
     "todoTitle": "任务",
     "todoAllDone": "全部完成",
     "subagentLaunching": "启动智能体...",
@@ -3953,5 +3960,23 @@
     "settingsHint": "你在项目之间切换的方式",
     "optionTabs": "项目标签页",
     "optionSidebar": "项目侧栏"
+  },
+  "files": {
+    "modifiedOnly": "仅已修改",
+    "filesTouched": "个文件被改动",
+    "sessionNoChanges": "该会话未修改任何文件。",
+    "noProject": "打开一个项目以浏览其文件。",
+    "pickAFile": "在文件树中选择一个文件。",
+    "viewContent": "内容",
+    "viewDiff": "差异",
+    "toggleSplit": "统一 / 并排",
+    "openInTab": "在标签页中打开",
+    "openInEditor": "在编辑器中打开",
+    "previewInTab": "该格式在标签页中预览。",
+    "tooLarge": "文件过大，无法在此显示（{size}）。",
+    "linesTruncated": "… 还有 {count} 行",
+    "sessionCaption": "会话",
+    "noSession": "无",
+    "noSessionHint": "浏览整个文件树"
   }
 }

--- a/src/renderer/services/DiffRenderer.js
+++ b/src/renderer/services/DiffRenderer.js
@@ -1,0 +1,249 @@
+/**
+ * Diff Renderer
+ *
+ * Renders a unified diff the way GitHub does: two gutters (old line, new line),
+ * hunk headers, syntax highlighting inside the code, and word-level marks on the
+ * parts of a line that actually changed.
+ *
+ * The input is Claude Code's `structuredPatch`, which every file-editing tool
+ * call already carries in the session transcript:
+ *
+ *   { oldStart, oldLines, newStart, newLines, lines: ["  ctx", "-old", "+new"] }
+ *
+ * That matters more than it sounds. The patch is computed by the tool that made
+ * the edit, so the line numbers are exact — no guessing an anchor's position in
+ * a file that has moved on since. Everything here is a rendering concern.
+ */
+
+const { escapeHtml, highlight } = require('../utils');
+const { t } = require('../i18n');
+
+// A single view can hold several files; past this many lines a diff is folded
+// behind a "show the rest" affordance instead of mounting all of it.
+const MAX_LINES_RENDERED = 1200;
+
+function extOf(filePath) {
+  const base = String(filePath || '').split(/[\\/]/).pop();
+  const dot = base.lastIndexOf('.');
+  return dot === -1 ? '' : base.slice(dot + 1).toLowerCase();
+}
+
+/**
+ * Highlight one line of code, falling back to plain escaping. highlight.js
+ * needs whole tokens, so a lone line can trip it; escaping is always correct.
+ */
+function highlightLine(text, ext) {
+  if (!text) return '';
+  try {
+    return highlight(text, ext);
+  } catch {
+    return escapeHtml(text);
+  }
+}
+
+// ── Word-level marks ─────────────────────────────────────────────────────────
+
+function tokenize(text) {
+  // Split on word boundaries but keep the separators, so joining restores the
+  // original exactly.
+  return text.match(/(\w+|\s+|[^\w\s])/g) || [];
+}
+
+/**
+ * Common prefix/suffix of two token lists, in token counts. Cheap, and enough
+ * for the "what part of this line moved" cue — a full word-diff would be
+ * heavier for a marginal gain at this size.
+ */
+function tokenAffixes(a, b) {
+  let start = 0;
+  while (start < a.length && start < b.length && a[start] === b[start]) start++;
+  let endA = a.length, endB = b.length;
+  while (endA > start && endB > start && a[endA - 1] === b[endB - 1]) { endA--; endB--; }
+  return { start, endA, endB };
+}
+
+/**
+ * Wrap the changed middle of a line in <mark>. Returns escaped HTML, so it is
+ * used instead of syntax highlighting rather than on top of it: nesting marks
+ * inside highlight.js spans would mean parsing its output.
+ */
+function markedLine(text, counterpart) {
+  const mine = tokenize(text);
+  const theirs = tokenize(counterpart);
+  const { start, endA } = tokenAffixes(mine, theirs);
+  if (start === 0 && endA === mine.length) return escapeHtml(text);
+  const head = escapeHtml(mine.slice(0, start).join(''));
+  const mid = escapeHtml(mine.slice(start, endA).join(''));
+  const tail = escapeHtml(mine.slice(endA).join(''));
+  return `${head}${mid ? `<mark class="dr-word">${mid}</mark>` : ''}${tail}`;
+}
+
+/**
+ * Pair each `-` with the `+` that replaced it, within one run of changes, so
+ * word marks only appear where a line was rewritten rather than added outright.
+ * @returns {Map<number, number>} index of a line -> index of its counterpart
+ */
+function pairRuns(lines) {
+  const pairs = new Map();
+  let i = 0;
+  while (i < lines.length) {
+    if (lines[i][0] !== '-') { i++; continue; }
+    let dels = i;
+    while (dels < lines.length && lines[dels][0] === '-') dels++;
+    let adds = dels;
+    while (adds < lines.length && lines[adds][0] === '+') adds++;
+    const delCount = dels - i;
+    const addCount = adds - dels;
+    // Only pair a balanced run: 3 lines replaced by 1 has no line-to-line story.
+    if (delCount === addCount) {
+      for (let k = 0; k < delCount; k++) {
+        pairs.set(i + k, dels + k);
+        pairs.set(dels + k, i + k);
+      }
+    }
+    i = adds > i ? adds : i + 1;
+  }
+  return pairs;
+}
+
+// ── Rows ─────────────────────────────────────────────────────────────────────
+
+function row(cls, oldNo, newNo, sign, html) {
+  return `<div class="dr-row${cls ? ' ' + cls : ''}">`
+    + `<span class="dr-ln dr-ln-old">${oldNo == null ? '' : oldNo}</span>`
+    + `<span class="dr-ln dr-ln-new">${newNo == null ? '' : newNo}</span>`
+    + `<span class="dr-sign">${sign}</span>`
+    + `<span class="dr-code">${html}</span>`
+    + '</div>';
+}
+
+function hunkHeaderRow(hunk) {
+  const label = `@@ -${hunk.oldStart},${hunk.oldLines} +${hunk.newStart},${hunk.newLines} @@`;
+  return `<div class="dr-row dr-hunk">`
+    + `<span class="dr-ln dr-ln-old"></span><span class="dr-ln dr-ln-new"></span>`
+    + `<span class="dr-sign"></span>`
+    + `<span class="dr-code">${escapeHtml(label)}</span></div>`;
+}
+
+/**
+ * One hunk as unified rows.
+ * @param {{oldStart:number, oldLines:number, newStart:number, newLines:number, lines:string[]}} hunk
+ */
+function renderHunkUnified(hunk, ext) {
+  const lines = hunk.lines || [];
+  const pairs = pairRuns(lines);
+  let oldNo = hunk.oldStart;
+  let newNo = hunk.newStart;
+  const out = [hunkHeaderRow(hunk)];
+
+  lines.forEach((line, i) => {
+    const sign = line[0];
+    const text = line.slice(1);
+    if (sign === '-') {
+      const mate = pairs.get(i);
+      const html = mate == null ? highlightLine(text, ext) : markedLine(text, lines[mate].slice(1));
+      out.push(row('dr-del', oldNo++, null, '-', html));
+    } else if (sign === '+') {
+      const mate = pairs.get(i);
+      const html = mate == null ? highlightLine(text, ext) : markedLine(text, lines[mate].slice(1));
+      out.push(row('dr-add', null, newNo++, '+', html));
+    } else {
+      out.push(row('', oldNo++, newNo++, ' ', highlightLine(text, ext)));
+    }
+  });
+
+  return out;
+}
+
+/** Side-by-side: old on the left, new on the right, aligned per changed run. */
+function renderHunkSplit(hunk, ext) {
+  const lines = hunk.lines || [];
+  const pairs = pairRuns(lines);
+  let oldNo = hunk.oldStart;
+  let newNo = hunk.newStart;
+  const out = [hunkHeaderRow(hunk)];
+
+  function side(cls, no, sign, html) {
+    return `<span class="dr-side${cls ? ' ' + cls : ''}">`
+      + `<span class="dr-ln">${no == null ? '' : no}</span>`
+      + `<span class="dr-sign">${sign}</span>`
+      + `<span class="dr-code">${html}</span></span>`;
+  }
+
+  let i = 0;
+  while (i < lines.length) {
+    const sign = lines[i][0];
+    if (sign === ' ') {
+      const html = highlightLine(lines[i].slice(1), ext);
+      out.push(`<div class="dr-row dr-split">${side('', oldNo++, ' ', html)}${side('', newNo++, ' ', html)}</div>`);
+      i++;
+      continue;
+    }
+    // Collect the whole run of -/+ so the two columns stay level.
+    let dels = i;
+    while (dels < lines.length && lines[dels][0] === '-') dels++;
+    let adds = dels;
+    while (adds < lines.length && lines[adds][0] === '+') adds++;
+    const delLines = lines.slice(i, dels);
+    const addLines = lines.slice(dels, adds);
+
+    for (let k = 0; k < Math.max(delLines.length, addLines.length); k++) {
+      const d = delLines[k];
+      const a = addLines[k];
+      const left = d == null
+        ? side('dr-empty', null, '', '')
+        : side('dr-del', oldNo++, '-', a == null ? highlightLine(d.slice(1), ext) : markedLine(d.slice(1), a.slice(1)));
+      const right = a == null
+        ? side('dr-empty', null, '', '')
+        : side('dr-add', newNo++, '+', d == null ? highlightLine(a.slice(1), ext) : markedLine(a.slice(1), d.slice(1)));
+      out.push(`<div class="dr-row dr-split">${left}${right}</div>`);
+    }
+    i = adds > i ? adds : i + 1;
+  }
+  return out;
+}
+
+/**
+ * Render a file's hunks.
+ * @param {Array} hunks - structuredPatch hunks
+ * @param {object} [opts]
+ * @param {string} [opts.filePath] - drives syntax highlighting
+ * @param {'unified'|'split'} [opts.mode]
+ * @returns {string} HTML
+ */
+function renderPatch(hunks, opts = {}) {
+  if (!Array.isArray(hunks) || !hunks.length) {
+    return `<div class="dr-empty">${escapeHtml(t('chat.noDiffAvailable'))}</div>`;
+  }
+  const ext = extOf(opts.filePath);
+  const split = opts.mode === 'split';
+  let rows = [];
+  for (const hunk of hunks) {
+    if (!hunk || !Array.isArray(hunk.lines)) continue;
+    rows = rows.concat(split ? renderHunkSplit(hunk, ext) : renderHunkUnified(hunk, ext));
+  }
+  if (!rows.length) {
+    return `<div class="dr-empty">${escapeHtml(t('chat.noDiffAvailable'))}</div>`;
+  }
+  let note = '';
+  if (rows.length > MAX_LINES_RENDERED) {
+    const hidden = rows.length - MAX_LINES_RENDERED;
+    rows = rows.slice(0, MAX_LINES_RENDERED);
+    note = `<div class="dr-truncated">${escapeHtml(t('chat.diffMoreLines', { count: hidden }))}</div>`;
+  }
+  return `<div class="dr-diff${split ? ' dr-diff--split' : ''}">${rows.join('')}${note}</div>`;
+}
+
+/** Total +/- across a file's hunks. */
+function countPatch(hunks) {
+  let additions = 0, deletions = 0;
+  for (const hunk of hunks || []) {
+    for (const line of hunk.lines || []) {
+      if (line[0] === '+') additions++;
+      else if (line[0] === '-') deletions++;
+    }
+  }
+  return { additions, deletions };
+}
+
+module.exports = { renderPatch, countPatch, MAX_LINES_RENDERED };

--- a/src/renderer/services/markdown/blocks/git.js
+++ b/src/renderer/services/markdown/blocks/git.js
@@ -68,10 +68,14 @@ function renderGitCommitBlock(code) {
       }).join('')}</div>`
     : '';
 
-  const hasStats = stats.files || stats.add || stats.del;
+  // "stats: +203" with no file count used to render "0 files +203". The listed
+  // files are a better count than zero, and if there are none either, the chip
+  // has nothing to say and is dropped.
+  const fileCount = stats.files || files.length;
+  const hasStats = fileCount || stats.add || stats.del;
   const statsHtml = hasStats
     ? `<div class="chat-git-commit-stats">`
-      + `<span class="chat-git-stat-files">${stats.files} file${stats.files !== 1 ? 's' : ''}</span>`
+      + (fileCount ? `<span class="chat-git-stat-files">${fileCount} file${fileCount !== 1 ? 's' : ''}</span>` : '')
       + (stats.add ? `<span class="chat-git-stat-add">+${stats.add}</span>` : '')
       + (stats.del ? `<span class="chat-git-stat-del">-${stats.del}</span>` : '')
       + `</div>`

--- a/src/renderer/state/settings.state.js
+++ b/src/renderer/state/settings.state.js
@@ -70,7 +70,7 @@ const defaultSettings = {
   enhancePrompts: false, // Opt-in: reformulate prompts via Haiku for better prompt engineering before sending
   // Every tab is pinned by default: the grouped sidebar fits without overflow,
   // so the More menu is now opt-in rather than the default state.
-  pinnedTabs: ['claude', 'git', 'dashboard', 'session-replay', 'tasks', 'control-tower', 'workspace', 'memory', 'timetracking', 'database', 'skills', 'agents', 'plugins', 'mcp', 'workflows', 'errorlog', 'connectivity'],
+  pinnedTabs: ['claude', 'dashboard', 'files', 'git', 'session-replay', 'tasks', 'control-tower', 'workspace', 'memory', 'timetracking', 'database', 'skills', 'agents', 'plugins', 'mcp', 'workflows', 'errorlog', 'connectivity'],
   activeTab: 'claude', // Last active sidebar tab (restored on restart)
   openProjectIds: [], // Projects with a tab in the project bar, in tab order (restored on restart)
   navigationMode: null, // 'tabs' | 'sidebar' | null = never chosen, ask once on next launch
@@ -152,6 +152,21 @@ function _migrateSettings(saved) {
     for (const id of ['workspace', 'errorlog']) {
       if (!saved.pinnedTabs.includes(id)) saved.pinnedTabs.push(id);
     }
+    // Files is new, so an existing array cannot have deliberately excluded it.
+    // Slot it under Dashboard, where it sits in the Project group.
+    if (!saved.pinnedTabs.includes('files')) {
+      const after = saved.pinnedTabs.indexOf('dashboard');
+      saved.pinnedTabs.splice(after === -1 ? saved.pinnedTabs.length : after + 1, 0, 'files');
+    }
+  }
+
+  // Same for a custom nav order. _applyTabsOrder re-inserts the tabs it knows
+  // after the group anchor, so an id missing from the array gets pushed to the
+  // bottom of its group — Files would sink below Tasks on any account that has
+  // ever reordered the sidebar.
+  if (Array.isArray(saved.tabsOrder) && saved.tabsOrder.length && !saved.tabsOrder.includes('files')) {
+    const after = saved.tabsOrder.indexOf('dashboard');
+    saved.tabsOrder.splice(after === -1 ? saved.tabsOrder.length : after + 1, 0, 'files');
   }
 }
 

--- a/src/renderer/ui/components/ChatView.js
+++ b/src/renderer/ui/components/ChatView.js
@@ -124,6 +124,7 @@ const EFFORT_OPTIONS = [
 // ── Markdown Renderer (delegated to MarkdownRenderer service) ──
 
 const MarkdownRenderer = require('../../services/MarkdownRenderer');
+const DiffRenderer = require('../../services/DiffRenderer');
 
 function renderMarkdown(text) {
   return MarkdownRenderer.render(text);
@@ -3888,74 +3889,65 @@ class ChatView extends BaseComponent {
   }
 
   // ── Session changes tab (files modified during this session) ──
-  // Accumulates per-file added/removed line counts from every file-editing tool
-  // (Write / Edit / MultiEdit / NotebookEdit), including subagents and resumed
-  // history. The map lives in this component instance, so it is session-scoped.
-  const sessionFileChanges = new Map(); // filePath -> { additions, deletions, edits }
+  // Only the tally lives here, so the tab badge can react the moment a tool
+  // runs. The diffs come from the transcript: Claude Code writes the patch it
+  // applied — exact hunks, exact line numbers — next to every edit, which beats
+  // anything this component could reconstruct from old_string/new_string.
+  const sessionFileTally = new Map(); // filePath -> { edits }
+  // A subagent tool_use arrives twice, once streamed and once in the full
+  // assistant message, so count it by id.
+  const recordedToolUseIds = new Set();
 
-  // Count changed lines between two text blocks by stripping the common prefix
-  // and suffix — mirrors how `git diff` reports +/- on the changed hunk only.
-  function _diffLineCounts(oldStr, newStr) {
-    const oldLines = oldStr ? String(oldStr).split('\n') : [];
-    const newLines = newStr ? String(newStr).split('\n') : [];
-    let start = 0;
-    while (start < oldLines.length && start < newLines.length && oldLines[start] === newLines[start]) start++;
-    let oldEnd = oldLines.length;
-    let newEnd = newLines.length;
-    while (oldEnd > start && newEnd > start && oldLines[oldEnd - 1] === newLines[newEnd - 1]) { oldEnd--; newEnd--; }
-    return { additions: Math.max(0, newEnd - start), deletions: Math.max(0, oldEnd - start) };
-  }
-
-  function recordFileChange(toolName, input) {
+  function recordFileChange(toolName, input, toolUseId) {
     if (!input || !toolName) return;
-    const hits = []; // { path, additions, deletions }
+    if (toolUseId) {
+      if (recordedToolUseIds.has(toolUseId)) return;
+      recordedToolUseIds.add(toolUseId);
+    }
+    let path = null;
     switch (toolName) {
       case 'Write':
-        if (input.file_path) hits.push({ path: input.file_path, additions: String(input.content || '').split('\n').length, deletions: 0 });
+      case 'Edit':
+      case 'MultiEdit':
+        path = input.file_path || null;
         break;
-      case 'Edit': {
-        if (!input.file_path) break;
-        const c = _diffLineCounts(input.old_string, input.new_string);
-        hits.push({ path: input.file_path, additions: c.additions, deletions: c.deletions });
+      case 'NotebookEdit':
+        path = input.notebook_path || input.file_path || null;
         break;
-      }
-      case 'MultiEdit': {
-        if (!input.file_path) break;
-        let additions = 0, deletions = 0;
-        for (const e of (input.edits || [])) {
-          const c = _diffLineCounts(e.old_string, e.new_string);
-          additions += c.additions; deletions += c.deletions;
-        }
-        hits.push({ path: input.file_path, additions, deletions });
-        break;
-      }
-      case 'NotebookEdit': {
-        const path = input.notebook_path || input.file_path;
-        if (path) hits.push({ path, additions: String(input.new_source || '').split('\n').length, deletions: 0 });
-        break;
-      }
       default:
         return;
     }
-    if (!hits.length) return;
-    for (const h of hits) {
-      const cur = sessionFileChanges.get(h.path) || { additions: 0, deletions: 0, edits: 0 };
-      cur.additions += h.additions;
-      cur.deletions += h.deletions;
-      cur.edits += 1;
-      sessionFileChanges.set(h.path, cur);
-    }
+    if (!path) return;
+    const cur = sessionFileTally.get(path) || { edits: 0 };
+    cur.edits += 1;
+    sessionFileTally.set(path, cur);
+    // The transcript now has one more edit than we last read.
+    liveChangesStale = true;
     updateChangesTab();
   }
 
-  function updateChangesTab() {
-    const count = sessionFileChanges.size;
+  /**
+   * Badge only. Kept separate from updateChangesTab because the transcript read
+   * refreshes the count, and repainting the panel from there would collapse a
+   * diff the reader has open.
+   */
+  function _updateChangesBadge() {
+    // The tally reveals the tab the instant a tool runs; the transcript count
+    // supersedes it once read, so the badge and the panel agree.
+    const count = liveFileCount == null
+      ? sessionFileTally.size
+      : Math.max(liveFileCount, sessionFileTally.size);
     if (count > 0 && tabbarEl.hidden) tabbarEl.hidden = false;
     if (changesBadgeEl) {
       changesBadgeEl.textContent = String(count);
       changesBadgeEl.hidden = count === 0;
     }
-    // Re-render live if the panel is currently visible
+  }
+
+  function updateChangesTab() {
+    _updateChangesBadge();
+    // Re-render live only while the panel shows this session — repainting it
+    // under someone reading a past session would collapse their open diffs.
     if (!changesPanelEl.hidden) renderChangesPanel();
   }
 
@@ -3969,8 +3961,74 @@ class ChatView extends BaseComponent {
     if (isChanges) renderChangesPanel();
   }
 
+  // ── This session's changes ──
+  // Claude Code appends each edit's patch to the transcript as it runs, so this
+  // panel is just "the transcript of the session I am in", re-read when the
+  // tally says there is something new. Browsing *other* sessions belongs in the
+  // Files screen, where a tree gives it somewhere to land.
+  let changesSourceEntries = null; // Map<path, entry>
+  let changesSourceLoading = false;
+  let liveChangesStale = true;     // an edit landed since we last read the file
+  // File count once the transcript has been read. The tally is only what we
+  // watched go by, and replayed history is capped, so the two disagree on a
+  // long resumed session — the transcript is the one to believe.
+  let liveFileCount = null;
+  let changesDiffMode = getSetting('filesDiffMode') === 'split' ? 'split' : 'unified';
+
+  function _changesEntries() {
+    return changesSourceEntries || new Map();
+  }
+
+  /**
+   * Re-read this session's transcript. `force` skips the staleness check.
+   */
+  async function _loadChangesFor({ force = false } = {}) {
+    // sdkSessionId is the live truth once the SDK has started. Before that — a
+    // resumed tab whose history is on screen but whose query has not begun —
+    // the transcript we replayed is the one to read.
+    const targetId = sdkSessionId || resumeSessionId;
+    if (!targetId) {
+      // No transcript to read yet (the SDK has not handed us a session id).
+      // Clearing the flag matters: renderChangesPanel re-renders on the way
+      // out, and a flag left set turns that into an endless render loop.
+      changesSourceEntries = changesSourceEntries || new Map();
+      liveChangesStale = false;
+      return;
+    }
+    if (!force && !liveChangesStale && changesSourceEntries) return;
+
+    changesSourceLoading = true;
+    // Cleared up front, not on success: a read that fails must not leave the
+    // panel asking for the same file on every repaint. The next edit re-arms it.
+    liveChangesStale = false;
+    try {
+      const res = await api.claude.sessionChanges({ projectPath: project.path, sessionId: targetId });
+      const files = (res && res.success ? res.files : []);
+      liveFileCount = files.length;
+      _updateChangesBadge();
+      changesSourceEntries = new Map(files.map(f => [f.path, f]));
+    } catch {
+      if (!changesSourceEntries) changesSourceEntries = new Map();
+    } finally {
+      changesSourceLoading = false;
+    }
+  }
+
   function renderChangesPanel() {
-    const files = [...sessionFileChanges.entries()];
+    // Entering the tab after an edit landed: re-read the transcript, then
+    // repaint. The tally already moved the badge, so this is never a blocker.
+    if (liveChangesStale && !changesSourceLoading) {
+      _loadChangesFor().then(() => {
+        if (!changesPanelEl.hidden) renderChangesPanel();
+      });
+    }
+
+    if (changesSourceLoading && !changesSourceEntries) {
+      changesPanelEl.innerHTML = `<div class="chat-changes-empty">${escapeHtml(t('common.loading') || 'Loading...')}</div>`;
+      return;
+    }
+
+    const files = [...(_changesEntries().entries())];
     if (!files.length) {
       changesPanelEl.innerHTML = `<div class="chat-changes-empty">${escapeHtml(t('chat.noChangesYet') || 'No files modified yet.')}</div>`;
       return;
@@ -3982,16 +4040,26 @@ class ChatView extends BaseComponent {
       const base = path.split(/[\\/]/).pop();
       const dir = path.slice(0, path.length - base.length);
       return `
-        <div class="chat-change-item" data-path="${escapeHtml(path)}" title="${escapeHtml(path)}">
-          <div class="chat-change-file">
-            <span class="chat-change-base">${escapeHtml(base)}</span>
-            <span class="chat-change-dir">${escapeHtml(dir)}</span>
+        <div class="chat-change-item" data-path="${escapeHtml(path)}">
+          <div class="chat-change-row" role="button" tabindex="0" title="${escapeHtml(path)}">
+            <svg class="chat-change-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18l6-6-6-6"/></svg>
+            <div class="chat-change-file">
+              <span class="chat-change-base">${escapeHtml(base)}</span>
+              <span class="chat-change-dir">${escapeHtml(dir)}</span>
+            </div>
+            <div class="chat-change-stats">
+              ${s.edits > 1 ? `<span class="chat-change-edits">${s.edits}×</span>` : ''}
+              <span class="chat-change-add">+${s.additions}</span>
+              <span class="chat-change-del">-${s.deletions}</span>
+              <button class="chat-change-current" title="${escapeHtml(t('chat.diffVsCurrent') || 'Compare with the file on disk')}">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 0 1-9 9 9 9 0 0 1-7.35-3.82"/><path d="M3 12a9 9 0 0 1 9-9 9 9 0 0 1 7.35 3.82"/><polyline points="21 3 19.35 6.82 15.5 6"/><polyline points="3 21 4.65 17.18 8.5 18"/></svg>
+              </button>
+              <button class="chat-change-open" title="${escapeHtml(t('chat.openFile') || 'Open file')}">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+              </button>
+            </div>
           </div>
-          <div class="chat-change-stats">
-            ${s.edits > 1 ? `<span class="chat-change-edits">${s.edits}×</span>` : ''}
-            <span class="chat-change-add">+${s.additions}</span>
-            <span class="chat-change-del">-${s.deletions}</span>
-          </div>
+          <div class="chat-change-diff" hidden></div>
         </div>`;
     }).join('');
     const fileLabel = files.length > 1
@@ -4003,6 +4071,11 @@ class ChatView extends BaseComponent {
         <span class="chat-changes-totals">
           <span class="chat-change-add">+${totalAdd}</span>
           <span class="chat-change-del">-${totalDel}</span>
+          <button class="chat-changes-split" title="${escapeHtml(t('files.toggleSplit'))}">
+            ${changesDiffMode === 'split'
+    ? '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="16" rx="1"/><line x1="12" y1="4" x2="12" y2="20"/></svg>'
+    : '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="16" rx="1"/><line x1="3" y1="12" x2="21" y2="12"/></svg>'}
+          </button>
         </span>
       </div>
       <div class="chat-changes-list">${rows}</div>
@@ -4014,11 +4087,122 @@ class ChatView extends BaseComponent {
     if (btn) switchChatTab(btn.dataset.tab);
   });
 
+  /**
+   * Expand or collapse a file's diff. The rows are built on expand and dropped
+   * on collapse: a session can touch dozens of files, and keeping every diff
+   * mounted is exactly the kind of DOM weight that slows the transcript down.
+   */
+  async function toggleFileDiff(item, mode = 'session') {
+    const path = item.dataset.path;
+    const diffEl = item.querySelector('.chat-change-diff');
+    if (!path || !diffEl) return;
+
+    // Clicking the same view again collapses; switching view re-renders.
+    if (item.classList.contains('expanded') && item.dataset.diffMode === mode) {
+      item.classList.remove('expanded');
+      delete item.dataset.diffMode;
+      diffEl.hidden = true;
+      diffEl.innerHTML = '';
+      return;
+    }
+
+    const entry = _changesEntries().get(path);
+    if (!entry) return;
+    item.classList.add('expanded');
+    item.dataset.diffMode = mode;
+    diffEl.hidden = false;
+
+    if (mode === 'current') {
+      diffEl.innerHTML = `<div class="chat-change-note">${escapeHtml(t('common.loading') || 'Loading...')}</div>`;
+      const html = await _buildCurrentDiffHtml(path);
+      if (item.classList.contains('expanded') && item.dataset.diffMode === mode) diffEl.innerHTML = html;
+      return;
+    }
+    // The session diff needs no I/O: the patch came with the transcript.
+    diffEl.innerHTML = DiffRenderer.renderPatch(entry.hunks, { filePath: path, mode: changesDiffMode });
+  }
+
+  /**
+   * The file's uncommitted diff, as git sees it right now. The session hunks
+   * say what the agent wrote at the time; this says what survived — an edit
+   * since reverted or overwritten shows up nowhere here.
+   */
+  async function _buildCurrentDiffHtml(filePath) {
+    let diff;
+    try {
+      diff = await api.git.fileDiff({ projectPath: project.path, filePath });
+    } catch (e) {
+      diff = { error: true, message: e.message };
+    }
+    if (!diff || diff.error) {
+      const msg = (diff && diff.message) || t('chat.noDiffAvailable') || 'No diff available.';
+      return `<div class="chat-change-note">${escapeHtml(msg)}</div>`;
+    }
+    if (typeof diff !== 'string' || !diff.trim()) {
+      return `<div class="chat-change-note">${escapeHtml(t('chat.diffNoCurrentChanges') || 'No uncommitted changes for this file.')}</div>`;
+    }
+    // Reshape git's textual output into the same hunks DiffRenderer draws, so
+    // both readings of a file look alike.
+    return DiffRenderer.renderPatch(_parseUnifiedDiff(diff), { filePath, mode: changesDiffMode });
+  }
+
+  /** Textual unified diff -> structuredPatch-shaped hunks. */
+  function _parseUnifiedDiff(diff) {
+    const hunks = [];
+    let current = null;
+    for (const line of diff.split('\n')) {
+      const header = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/.exec(line);
+      if (header) {
+        current = {
+          oldStart: Number(header[1]), oldLines: Number(header[2] ?? 1),
+          newStart: Number(header[3]), newLines: Number(header[4] ?? 1),
+          lines: [],
+        };
+        hunks.push(current);
+        continue;
+      }
+      if (!current) continue; // file headers before the first hunk
+      if (line.startsWith('\\')) continue; // "\ No newline at end of file"
+      if (line[0] === '+' || line[0] === '-' || line[0] === ' ') current.lines.push(line);
+    }
+    return hunks;
+  }
+
   changesPanelEl.addEventListener('click', (e) => {
+    if (e.target.closest('.chat-changes-split')) {
+      changesDiffMode = changesDiffMode === 'split' ? 'unified' : 'split';
+      setSetting('filesDiffMode', changesDiffMode);
+      // Repaint whatever diffs are open in the new layout.
+      const expanded = [...changesPanelEl.querySelectorAll('.chat-change-item.expanded')]
+        .map(el => [el.dataset.path, el.dataset.diffMode]);
+      renderChangesPanel();
+      for (const [path, mode] of expanded) {
+        const el = changesPanelEl.querySelector(`.chat-change-item[data-path="${CSS.escape(path)}"]`);
+        if (el) toggleFileDiff(el, mode);
+      }
+      return;
+    }
+
     const item = e.target.closest('.chat-change-item');
     if (!item || !item.dataset.path) return;
-    const editor = getSetting('editor') || 'code';
-    api.dialog.openInEditor({ editor, path: item.dataset.path });
+    if (e.target.closest('.chat-change-open')) {
+      const editor = getSetting('editor') || 'code';
+      api.dialog.openInEditor({ editor, path: item.dataset.path });
+      return;
+    }
+    if (e.target.closest('.chat-change-current')) {
+      toggleFileDiff(item, 'current');
+      return;
+    }
+    toggleFileDiff(item);
+  });
+
+  changesPanelEl.addEventListener('keydown', (e) => {
+    if (e.key !== 'Enter' && e.key !== ' ') return;
+    const row = e.target.closest('.chat-change-row');
+    if (!row) return;
+    e.preventDefault();
+    toggleFileDiff(row.closest('.chat-change-item'));
   });
 
   // ── Subagent (Task tool) card ──
@@ -4532,7 +4716,7 @@ class ChatView extends BaseComponent {
             try {
               const toolInput = JSON.parse(jsonStr);
               const name = mini.dataset.toolName || mini.querySelector('.sa-tool-name')?.textContent || '';
-              recordFileChange(name, toolInput);
+              recordFileChange(name, toolInput, mini.dataset.toolUseId);
               const detail = getToolDisplayInfo(name, toolInput);
               const detailEl = mini.querySelector('.sa-tool-detail');
               if (detailEl && detail) {
@@ -4563,7 +4747,7 @@ class ChatView extends BaseComponent {
 
     for (const block of content) {
       if (block.type === 'tool_use' && block.name !== 'TodoWrite' && block.name !== 'TaskCreate' && block.name !== 'TaskUpdate' && block.name !== 'TaskList' && block.name !== 'TaskGet') {
-        recordFileChange(block.name, block.input);
+        recordFileChange(block.name, block.input, block.id);
         const detail = getToolDisplayInfo(block.name, block.input);
         info.activityEl.textContent = `${block.name}...`;
 
@@ -5693,7 +5877,7 @@ class ChatView extends BaseComponent {
             if (card) {
               card.dataset.toolInput = JSON.stringify(toolInput);
               const name = card.dataset.toolName || card.querySelector('.chat-tool-name')?.textContent || '';
-              recordFileChange(name, toolInput);
+              recordFileChange(name, toolInput, card.dataset.toolUseId);
               // Custom card renderer (ScheduleWakeup, CronCreate, Worktree, Notification)
               const customHtml = renderToolCardHtml(name, toolInput);
               if (customHtml) {
@@ -6823,7 +7007,7 @@ class ChatView extends BaseComponent {
             continue;
           }
 
-          recordFileChange(msg.toolName, msg.toolInput || {});
+          recordFileChange(msg.toolName, msg.toolInput || {}, msg.toolUseId);
           const detail = getToolDisplayInfo(msg.toolName, msg.toolInput || {});
           const el = document.createElement('div');
           el.className = 'chat-tool-card history';

--- a/src/renderer/ui/components/FileExplorer.js
+++ b/src/renderer/ui/components/FileExplorer.js
@@ -133,6 +133,13 @@ class FileExplorer extends BaseComponent {
     };
     this._isVisible = false;
 
+    // Session overlay, pushed in by FilesPanel. null = plain tree.
+    this._sessionFiles = null;
+    this._modifiedOnly = false;
+    // Non-empty only in the Files screen's Overview: every open project drawn
+    // side by side. Rendering only — see setExtraRoots.
+    this._extraRoots = [];
+
     this._gitStatusMap = new Map();
     this._gitPollingInterval = null;
 
@@ -285,6 +292,90 @@ class FileExplorer extends BaseComponent {
       this.show();
       this.render();
     }
+  }
+
+  // ========== SESSION OVERLAY ==========
+  // "What did session X change", painted onto the same tree. Pushed in by
+  // FilesPanel so the tree never has to reach back up into the panel.
+
+  /**
+   * @param {{files: Map<string,object>|null, modifiedOnly: boolean}} overlay
+   */
+  setSessionOverlay(overlay) {
+    this._sessionFiles = (overlay && overlay.files) || null;
+    this._modifiedOnly = !!(overlay && overlay.modifiedOnly) && !!this._sessionFiles;
+  }
+
+  /** Per-file change stats, or null when the file is untouched. */
+  _sessionChangeFor(filePath) {
+    return this._sessionFiles ? this._sessionFiles.get(filePath) || null : null;
+  }
+
+  /**
+   * Rolled-up counts under a folder, so a collapsed directory still shows that
+   * something inside it moved.
+   */
+  _sessionRollupFor(dirPath) {
+    if (!this._sessionFiles) return null;
+    const prefix = dirPath.endsWith(this._path.sep) ? dirPath : dirPath + this._path.sep;
+    let files = 0, additions = 0, deletions = 0;
+    for (const [p, s] of this._sessionFiles) {
+      if (!p.startsWith(prefix)) continue;
+      files++; additions += s.additions; deletions += s.deletions;
+    }
+    return files ? { files, additions, deletions } : null;
+  }
+
+  /** True when the overlay says this node should be hidden by the filter. */
+  _hiddenByFilter(item) {
+    if (!this._modifiedOnly) return false;
+    return item.isDirectory
+      ? !this._sessionRollupFor(item.path)
+      : !this._sessionChangeFor(item.path);
+  }
+
+  /**
+   * Expand every folder on the way to these paths, then repaint once. Selecting
+   * a session is useless if its files stay buried in collapsed directories.
+   * @param {string[]} paths
+   */
+  async revealPaths(paths) {
+    if (!this._rootPath || !paths || !paths.length) { this.render(); return; }
+    const wanted = new Set();
+    for (const p of paths) {
+      let dir = this._path.dirname(p);
+      // Walk up to the root, collecting each ancestor inside the project.
+      while (dir && dir.startsWith(this._rootPath) && dir !== this._rootPath) {
+        wanted.add(dir);
+        const parent = this._path.dirname(dir);
+        if (parent === dir) break;
+        dir = parent;
+      }
+    }
+    // Load shallowest first: a child's folder entry is only reachable once its
+    // parent has been read.
+    const ordered = [...wanted].sort((a, b) => a.length - b.length);
+    for (const dir of ordered) {
+      if (this._expandedFolders.get(dir)?.loaded) continue;
+      try {
+        const children = await this._readDirectoryAsync(dir);
+        this._expandedFolders.set(dir, { children, loaded: true, loading: false });
+      } catch { /* unreadable folder — skip it, the rest still expands */ }
+    }
+    this.render();
+  }
+
+  /**
+   * Point the explorer at a project and reveal it, whether or not it was
+   * already open. Unlike toggle(), this never closes — it backs the project
+   * menu's "Files" entry, where the intent is always "show me the tree".
+   * @param {string} projectPath
+   */
+  open(projectPath) {
+    if (projectPath) this.setRootPath(projectPath);
+    if (!this._rootPath) return;
+    this.show();
+    this.render();
   }
 
   // ========== GIT STATUS ==========
@@ -930,9 +1021,31 @@ class FileExplorer extends BaseComponent {
     this.render();
   }
 
+  // ========== EXTRA ROOTS ==========
+  // The Files screen's Overview shows every open project at once. Only the
+  // *rendering* is multi-root: _rootPath stays the active project, so the
+  // path guards, the git poll and search keep their single, unambiguous
+  // scope. Browsing another root works; writing into one does not, because
+  // isPathSafe still measures against _rootPath. Refusing is the safe way to
+  // be wrong here.
+  setExtraRoots(paths) {
+    const next = Array.isArray(paths) ? paths.filter(Boolean) : [];
+    const same = next.length === this._extraRoots.length
+      && next.every((p, i) => p === this._extraRoots[i]);
+    if (same) return;
+    this._extraRoots = next;
+  }
+
+  /** Every root to draw, active project first, in project-bar order. */
+  _allRoots() {
+    if (!this._extraRoots.length) return this._rootPath ? [this._rootPath] : [];
+    return this._extraRoots;
+  }
+
   // ========== RENDER ==========
   render() {
-    if (!this._rootPath) return;
+    const roots = this._allRoots();
+    if (!roots.length) return;
 
     const treeEl = document.getElementById('file-explorer-tree');
     if (!treeEl) return;
@@ -941,10 +1054,30 @@ class FileExplorer extends BaseComponent {
       treeEl.innerHTML = this._renderContentSearchResults();
     } else if (this._searchQuery.trim()) {
       treeEl.innerHTML = this._renderSearchResults();
+    } else if (roots.length === 1) {
+      treeEl.innerHTML = this._renderTreeNodes(roots[0], 0);
     } else {
-      treeEl.innerHTML = this._renderTreeNodes(this._rootPath, 0);
+      treeEl.innerHTML = roots.map(r => this._renderRootNode(r)).join('');
     }
     this._attachListeners();
+  }
+
+  /** A project as a collapsible top-level folder, for the Overview tree. */
+  _renderRootNode(rootPath) {
+    const name = this._path.basename(rootPath) || rootPath;
+    const isExpanded = this._expandedFolders.has(rootPath) && this._expandedFolders.get(rootPath).loaded;
+    const roll = this._sessionRollupFor(rootPath);
+    const badge = roll
+      ? `<span class="fe-session-badge fe-session-badge--dir" title="+${roll.additions} -${roll.deletions}">${roll.files}</span>`
+      : '';
+    if (this._modifiedOnly && this._sessionFiles && !roll) return '';
+
+    return `<div class="fe-node fe-dir fe-root" data-path="${escapeHtml(rootPath)}" data-name="${escapeHtml(name)}" data-is-dir="true" style="padding-left: 8px;">
+      <span class="fe-node-chevron ${isExpanded ? 'expanded' : ''}">${CHEVRON_ICON}</span>
+      <span class="fe-node-icon">${getFileIcon(name, true, isExpanded)}</span>
+      <span class="fe-node-name" title="${escapeHtml(rootPath)}">${escapeHtml(name)}</span>
+      ${badge}
+    </div>${isExpanded ? this._renderTreeNodes(rootPath, 1) : ''}`;
   }
 
   _renderTreeNodes(dirPath, depth) {
@@ -969,6 +1102,8 @@ class FileExplorer extends BaseComponent {
         continue;
       }
 
+      if (this._hiddenByFilter(item)) continue;
+
       const isExpanded = this._expandedFolders.has(item.path) && this._expandedFolders.get(item.path).loaded;
       const isSelected = this._selectedFiles.has(item.path);
       const isCut = this._cutPaths.includes(item.path);
@@ -981,8 +1116,9 @@ class FileExplorer extends BaseComponent {
         : `<span class="fe-node-chevron-spacer"></span>`;
 
       const gitBadge = getGitBadgeHtml(item.path, item.isDirectory, this._gitStatusMap, this._rootPath, this._path);
+      const sessionBadge = this._sessionBadgeHtml(item);
 
-      parts.push(`<div class="fe-node ${isSelected ? 'selected' : ''} ${isCut ? 'fe-cut' : ''} ${isCopied ? 'fe-copied' : ''} ${item.isDirectory ? 'fe-dir' : 'fe-file'}"
+      parts.push(`<div class="fe-node ${isSelected ? 'selected' : ''} ${isCut ? 'fe-cut' : ''} ${isCopied ? 'fe-copied' : ''} ${item.isDirectory ? 'fe-dir' : 'fe-file'}${sessionBadge ? ' fe-session-touched' : ''}"
       data-path="${escapeHtml(item.path)}"
       data-name="${escapeHtml(item.name)}"
       data-is-dir="${item.isDirectory}"
@@ -991,6 +1127,7 @@ class FileExplorer extends BaseComponent {
       ${chevron}
       <span class="fe-node-icon">${icon}</span>
       <span class="fe-node-name" title="${escapeHtml(item.path)}">${escapeHtml(item.name)}</span>
+      ${sessionBadge}
       ${gitBadge}
     </div>`);
 
@@ -1000,6 +1137,19 @@ class FileExplorer extends BaseComponent {
     }
 
     return parts.join('');
+  }
+
+  /** `+n −m` for a touched file, or a file count for a folder holding some. */
+  _sessionBadgeHtml(item) {
+    if (!this._sessionFiles) return '';
+    if (item.isDirectory) {
+      const roll = this._sessionRollupFor(item.path);
+      if (!roll) return '';
+      return `<span class="fe-session-badge fe-session-badge--dir" title="${roll.files} file(s) · +${roll.additions} -${roll.deletions}">${roll.files}</span>`;
+    }
+    const s = this._sessionChangeFor(item.path);
+    if (!s) return '';
+    return `<span class="fe-session-badge" title="${s.edits} edit(s)"><span class="fe-session-add">+${s.additions}</span><span class="fe-session-del">-${s.deletions}</span></span>`;
   }
 
   // ========== OPEN FILE ==========
@@ -1813,6 +1963,11 @@ module.exports = {
   show: () => _getInstance().show(),
   hide: () => _getInstance().hide(),
   toggle: () => _getInstance().toggle(),
+  open: (projectPath) => _getInstance().open(projectPath),
+  render: () => _getInstance().render(),
+  setSessionOverlay: (overlay) => _getInstance().setSessionOverlay(overlay),
+  setExtraRoots: (paths) => _getInstance().setExtraRoots(paths),
+  revealPaths: (paths) => _getInstance().revealPaths(paths),
   toggleDotfiles: () => _getInstance().toggleDotfiles(),
   init: () => _getInstance().init(),
   applyWatcherChanges: (changes) => _getInstance().applyWatcherChanges(changes),

--- a/src/renderer/ui/components/FileViewer.js
+++ b/src/renderer/ui/components/FileViewer.js
@@ -1,0 +1,208 @@
+/**
+ * File Viewer
+ *
+ * The right-hand pane of the Files screen: a file's contents, or — when the
+ * selected session touched it — the diff that session applied.
+ *
+ * Scope is deliberate. Text, markdown and images render here; PDF, 3D models,
+ * audio and video hand off to `openFileTab`, which already carries the
+ * bootstrapping those need. Duplicating it would be a lot of code for formats
+ * you rarely browse a diff of.
+ */
+
+const { escapeHtml, highlight, getFileIcon } = require('../../utils');
+const { t } = require('../../i18n');
+const api = window.electron_api;
+const DiffRenderer = require('../../services/DiffRenderer');
+const MarkdownRenderer = require('../../services/MarkdownRenderer');
+const { getSetting } = require('../../state');
+
+// Reading a whole file into the DOM has a ceiling; past this we show the head
+// and point at the editor.
+const MAX_CONTENT_BYTES = 2 * 1024 * 1024;
+const MAX_CONTENT_LINES = 5000;
+
+const IMAGE_EXTS = new Set(['png', 'jpg', 'jpeg', 'gif', 'bmp', 'webp', 'svg', 'ico', 'avif']);
+const HANDOFF_EXTS = new Set(['pdf', 'mp4', 'webm', 'mov', 'mp3', 'wav', 'flac', 'aac', 'ogg', 'obj', 'stl', 'gltf', 'glb']);
+
+let _state = null; // { filePath, change, mode, diffMode }
+
+function extOf(filePath) {
+  const base = String(filePath || '').split(/[\\/]/).pop();
+  const dot = base.lastIndexOf('.');
+  return dot === -1 ? '' : base.slice(dot + 1).toLowerCase();
+}
+
+function fmtSize(bytes) {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function _headerHtml(filePath, change, mode, diffMode, meta) {
+  const base = filePath.split(/[\\/]/).pop();
+  const dir = filePath.slice(0, filePath.length - base.length);
+  const icon = getFileIcon(base, false, false);
+
+  const stats = change
+    ? `<span class="fv-stats"><span class="chat-change-add">+${change.additions}</span><span class="chat-change-del">-${change.deletions}</span></span>`
+    : (meta ? `<span class="fv-meta">${escapeHtml(meta)}</span>` : '');
+
+  // Only a file the session touched has a diff to switch to.
+  const modeToggle = change ? `
+    <div class="fv-modes" role="tablist">
+      <button class="fv-mode${mode === 'content' ? ' active' : ''}" data-mode="content" role="tab">${escapeHtml(t('files.viewContent'))}</button>
+      <button class="fv-mode${mode === 'diff' ? ' active' : ''}" data-mode="diff" role="tab">${escapeHtml(t('files.viewDiff'))}</button>
+    </div>` : '';
+
+  const diffLayout = (change && mode === 'diff') ? `
+    <button class="fv-action" data-action="toggle-split" title="${escapeHtml(t('files.toggleSplit'))}">
+      ${diffMode === 'split'
+    ? '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="16" rx="1"/><line x1="12" y1="4" x2="12" y2="20"/></svg>'
+    : '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="16" rx="1"/><line x1="3" y1="12" x2="21" y2="12"/></svg>'}
+    </button>` : '';
+
+  return `
+    <div class="fv-header">
+      <span class="fv-icon">${icon}</span>
+      <span class="fv-path" title="${escapeHtml(filePath)}">
+        <span class="fv-base">${escapeHtml(base)}</span><span class="fv-dir">${escapeHtml(dir)}</span>
+      </span>
+      ${stats}
+      ${modeToggle}
+      ${diffLayout}
+      <button class="fv-action" data-action="open-tab" title="${escapeHtml(t('files.openInTab'))}">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+      </button>
+      <button class="fv-action" data-action="open-editor" title="${escapeHtml(t('files.openInEditor'))}">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 18l6-6-6-6M8 6l-6 6 6 6"/></svg>
+      </button>
+    </div>`;
+}
+
+async function _bodyHtml(filePath, change, mode, diffMode) {
+  if (mode === 'diff') {
+    if (!change || !change.hunks || !change.hunks.length) {
+      return `<div class="fv-empty">${escapeHtml(t('chat.noDiffAvailable'))}</div>`;
+    }
+    return DiffRenderer.renderPatch(change.hunks, { filePath, mode: diffMode });
+  }
+
+  const ext = extOf(filePath);
+  const fileUrl = 'file:///' + filePath.replace(/\\/g, '/').replace(/^\//, '');
+
+  if (IMAGE_EXTS.has(ext)) {
+    return `<div class="fv-media"><img src="${escapeHtml(fileUrl)}" alt="${escapeHtml(filePath)}" draggable="false" /></div>`;
+  }
+  if (HANDOFF_EXTS.has(ext)) {
+    return `<div class="fv-empty">
+      <p>${escapeHtml(t('files.previewInTab'))}</p>
+      <button class="fv-handoff" data-action="open-tab">${escapeHtml(t('files.openInTab'))}</button>
+    </div>`;
+  }
+
+  const { fs } = window.electron_nodeModules;
+  let content;
+  let size = 0;
+  try {
+    const stat = await fs.promises.stat(filePath);
+    size = stat.size;
+    if (size > MAX_CONTENT_BYTES) {
+      return `<div class="fv-empty"><p>${escapeHtml(t('files.tooLarge', { size: fmtSize(size) }))}</p>
+        <button class="fv-handoff" data-action="open-editor">${escapeHtml(t('files.openInEditor'))}</button></div>`;
+    }
+    content = await fs.promises.readFile(filePath, 'utf8');
+  } catch (e) {
+    return `<div class="fv-empty fv-error">${escapeHtml(e.message)}</div>`;
+  }
+
+  if (ext === 'md') {
+    try {
+      return `<div class="fv-markdown chat-markdown">${MarkdownRenderer.render(content)}</div>`;
+    } catch {
+      // Fall through to the plain-text path rather than showing nothing.
+    }
+  }
+
+  let lines = content.split('\n');
+  let truncated = 0;
+  if (lines.length > MAX_CONTENT_LINES) {
+    truncated = lines.length - MAX_CONTENT_LINES;
+    lines = lines.slice(0, MAX_CONTENT_LINES);
+  }
+  const shown = lines.join('\n');
+  const nums = lines.map((_, i) => `<span class="fv-ln">${i + 1}</span>`).join('');
+  return `<div class="fv-code">
+      <div class="fv-lines">${nums}</div>
+      <pre class="fv-pre"><code>${highlight(shown, ext)}</code></pre>
+    </div>
+    ${truncated ? `<div class="fv-truncated">${escapeHtml(t('files.linesTruncated', { count: truncated }))}</div>` : ''}`;
+}
+
+function _wire(container, project) {
+  container.onclick = async (e) => {
+    const btn = e.target.closest('[data-mode], [data-action]');
+    if (!btn || !_state) return;
+
+    if (btn.dataset.mode) {
+      if (btn.dataset.mode === _state.mode) return;
+      _state.mode = btn.dataset.mode;
+      await _paint(container, project);
+      return;
+    }
+
+    switch (btn.dataset.action) {
+      case 'toggle-split':
+        _state.diffMode = _state.diffMode === 'split' ? 'unified' : 'split';
+        await _paint(container, project);
+        break;
+      case 'open-tab': {
+        // Required lazily: TerminalManager pulls in a large graph, and the
+        // Files screen must not drag it in just to be mounted.
+        const TerminalManager = require('./TerminalManager');
+        TerminalManager.openFileTab(_state.filePath, project);
+        document.querySelector('.nav-tab[data-tab="claude"]')?.click();
+        break;
+      }
+      case 'open-editor':
+        api.dialog.openInEditor({
+          editor: getSetting('editor') || 'code',
+          path: _state.filePath,
+        });
+        break;
+    }
+  };
+}
+
+async function _paint(container, project) {
+  const { filePath, change, mode, diffMode } = _state;
+  container.innerHTML = _headerHtml(filePath, change, mode, diffMode, null)
+    + `<div class="fv-body"><div class="fv-empty">${escapeHtml(t('common.loading'))}</div></div>`;
+  const body = await _bodyHtml(filePath, change, mode, diffMode);
+  // A different file may have been picked while we read this one.
+  if (_state.filePath !== filePath || _state.mode !== mode) return;
+  const bodyEl = container.querySelector('.fv-body');
+  if (bodyEl) bodyEl.innerHTML = body;
+}
+
+/**
+ * Show a file.
+ * @param {HTMLElement} container
+ * @param {string} filePath
+ * @param {object} [opts]
+ * @param {object} [opts.project]
+ * @param {object} [opts.change] - session change entry, with `hunks`
+ * @param {'content'|'diff'} [opts.initialMode]
+ */
+async function render(container, filePath, opts = {}) {
+  _state = {
+    filePath,
+    change: opts.change || null,
+    mode: opts.change && opts.initialMode === 'diff' ? 'diff' : 'content',
+    diffMode: getSetting('filesDiffMode') === 'split' ? 'split' : 'unified',
+  };
+  _wire(container, opts.project);
+  await _paint(container, opts.project);
+}
+
+module.exports = { render };

--- a/src/renderer/ui/components/ProjectBar.js
+++ b/src/renderer/ui/components/ProjectBar.js
@@ -206,7 +206,10 @@ class ProjectBar extends BaseComponent {
     const project = getProject(projectId);
     if (!project) return;
     const projectIndex = getProjectIndex(projectId);
-    if (projectsState.get().selectedProjectFilter === projectIndex) return;
+    // Re-selecting the active project is normally a no-op, but not while the
+    // Overview is showing: its tab is how you get back to a single project,
+    // and clicking the one you were already on has to work.
+    if (!this._overviewActive && projectsState.get().selectedProjectFilter === projectIndex) return;
     // The host owns the switch (it also drives the screens), so it opens the tab.
     if (this._callbacks.onSelectProject) this._callbacks.onSelectProject(projectIndex, project);
   }

--- a/src/renderer/ui/components/ProjectList.js
+++ b/src/renderer/ui/components/ProjectList.js
@@ -109,6 +109,7 @@ class ProjectList extends BaseComponent {
       onGitPull: null,
       onGitPush: null,
       onNewWorktree: null,
+      onOpenProjectFiles: null,
       onDeleteProject: null,
       onRenameProject: null,
       onRenderProjects: null,
@@ -430,6 +431,10 @@ class ProjectList extends BaseComponent {
     <button class="more-actions-item btn-basic-terminal" data-project-id="${project.id}">
       ${menuIcons.terminal}
       ${t('projects.basicTerminal')}
+    </button>
+    <button class="more-actions-item btn-project-files" data-project-id="${project.id}">
+      ${menuIcons.fileTree}
+      ${t('projects.files')}
     </button>
     <button class="more-actions-item btn-open-folder" data-project-id="${project.id}">
       ${menuIcons.folderOpen}
@@ -925,6 +930,12 @@ class ProjectList extends BaseComponent {
       self.closeAllMoreActionsMenus();
       if (self._callbacks.onRenderProjects) self._callbacks.onRenderProjects();
       if (self._callbacks.onCreateBasicTerminal) self._callbacks.onCreateBasicTerminal(project);
+    } else if (btn.classList.contains('btn-project-files')) {
+      const project = getProject(projectId);
+      self.closeAllMoreActionsMenus();
+      // The host switches project context and screen: the explorer panel only
+      // exists on the Claude screen.
+      if (project && self._callbacks.onOpenProjectFiles) self._callbacks.onOpenProjectFiles(project);
     } else if (btn.classList.contains('btn-locate-project')) {
       self.closeAllMoreActionsMenus();
       if (self._callbacks.onLocateProject) self._callbacks.onLocateProject(projectId);

--- a/src/renderer/ui/icons/menuIcons.js
+++ b/src/renderer/ui/icons/menuIcons.js
@@ -12,6 +12,8 @@ const menuIcons = {
   // File operations
   folder: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"/></svg>',
   folderOpen: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5 19l2.757-6.351A2 2 0 019.595 11.5h8.81a2 2 0 011.838 1.212l1.756 4.052M5 19a2 2 0 002 2h10a2 2 0 002-2M5 19l-.757-1.757A2 2 0 013 15.405V7a2 2 0 012-2h6l2 2h6a2 2 0 012 2v4.405a2 2 0 01-1.243 1.838L19 17"/></svg>',
+  // A tree, not a folder: this opens the in-app explorer rather than the OS one.
+  fileTree: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4 4h6v4H4V4zm10 6h6v4h-6v-4zm0 8h6v4h-6v-4zM7 8v12m0-6h7m-7 6h7"/></svg>',
 
   // Terminal & Code
   terminal: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg>',

--- a/src/renderer/ui/panels/FilesPanel.js
+++ b/src/renderer/ui/panels/FilesPanel.js
@@ -1,0 +1,425 @@
+/**
+ * Files Panel
+ *
+ * The file explorer as a screen of its own, rather than a third column docked
+ * into the Claude layout behind an unlabelled glyph. Two panes: the project
+ * tree on the left, the file it selects on the right.
+ *
+ * The tree is still FileExplorer — 60 KB of working behaviour (ignore patterns,
+ * git badges, content search, rename/create/delete, drag & drop) that would be
+ * silly to rewrite. It binds to fixed ids (`file-explorer-tree`,
+ * `fe-search-*`…), so this panel renders that markup and then hands over. Its
+ * listeners are `onclick =` assignments re-applied on every render(), which is
+ * what makes mounting it late safe.
+ *
+ * The session picker overlays "what did session X change" onto the same tree:
+ * touched files get a +/- badge, and selecting one opens its diff rather than
+ * its contents.
+ */
+
+const FileExplorer = require('../components/FileExplorer');
+const FileViewer = require('../components/FileViewer');
+const { escapeHtml } = require('../../utils');
+const { t } = require('../../i18n');
+const { getOpenProjects } = require('../../state');
+
+const api = window.electron_api;
+
+let _root = null;
+let _project = null;
+let _mounted = false;
+// 'project' = the active project's tree. 'overview' = every open project at
+// once, the same scope split the Dashboard has.
+let _scope = 'project';
+
+// ── Session overlay state ──
+// null = show the plain tree; otherwise the sessionId whose changes decorate it.
+let _sessionId = null;
+let _sessionLabel = '';
+let _sessionFiles = null;   // Map<path, {additions, deletions, edits, hunks}>
+let _sessions = null;       // cached picker list
+let _loadingSession = false;
+let _modifiedOnly = false;
+let _selectedPath = null;
+
+const ICONS = {
+  collapse: '<svg viewBox="0 0 24 24" fill="currentColor"><path d="M7.41 18.59L8.83 20 12 16.83 15.17 20l1.41-1.41L12 14l-4.59 4.59zM16.59 5.41L15.17 4 12 7.17 8.83 4 7.41 5.41 12 10l4.59-4.59z"/></svg>',
+  refresh: '<svg viewBox="0 0 24 24" fill="currentColor"><path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"/></svg>',
+  chevronDown: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6 6-6"/></svg>',
+  search: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.35-4.35"/></svg>',
+  file: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>',
+  sort: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="12" height="12"><path d="M3 6h18M3 12h12M3 18h6"/></svg>',
+  close: '<svg viewBox="0 0 12 12"><path d="M1 1l10 10M11 1L1 11" stroke="currentColor" stroke-width="1.5" fill="none"/></svg>',
+  folder: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"/></svg>',
+  history: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v5h5"/><path d="M3.05 13A9 9 0 106 5.3L3 8"/><path d="M12 7v5l4 2"/></svg>',
+  diff: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v18M5 8h14M5 16h14"/></svg>',
+};
+
+/** "il y a 3 h" style label, so the session order is visible in the menu. */
+function _relativeTime(iso) {
+  if (!iso) return '';
+  const then = new Date(iso).getTime();
+  if (!then || Number.isNaN(then)) return '';
+  const mins = Math.max(0, Math.round((Date.now() - then) / 60000));
+  if (mins < 60) return t('time.minutesAgo', { count: mins });
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return t('time.hoursAgo', { count: hours });
+  return t('time.daysAgo', { count: Math.round(hours / 24) });
+}
+
+function _screenHtml() {
+  return `
+    <div class="files-screen">
+      <div class="files-toolbar">
+        <!-- No project selector here: the project bar above the screen is the
+             one control for that, shared with Claude, Git, Dashboard and the
+             rest of the Project group. A second one would be a second truth. -->
+        <div class="files-picker files-picker--session" id="files-session">
+          <button class="files-picker-btn" id="files-session-btn" aria-haspopup="menu" aria-expanded="false">
+            <span class="files-picker-icon">${ICONS.history}</span>
+            <span class="files-picker-caption">${escapeHtml(t('files.sessionCaption'))}</span>
+            <span class="files-picker-value" id="files-session-label">${escapeHtml(t('files.noSession'))}</span>
+            <span class="files-picker-arrow">${ICONS.chevronDown}</span>
+          </button>
+          <div class="files-picker-menu files-picker-menu--wide" id="files-session-menu" role="menu" hidden></div>
+        </div>
+
+        <span class="files-session-totals" id="files-session-totals"></span>
+        <div class="files-toolbar-spacer"></div>
+        <button class="btn-icon" id="btn-collapse-explorer" title="${escapeHtml(t('ui.collapseAll'))}">${ICONS.collapse}</button>
+        <button class="btn-icon" id="btn-refresh-explorer" title="${escapeHtml(t('common.refresh'))}">${ICONS.refresh}</button>
+      </div>
+
+      <div class="files-body">
+        <div class="files-tree-pane" id="file-explorer-panel">
+          <div class="fe-search-container" id="fe-search-container">
+            <span class="fe-search-icon">${ICONS.search}</span>
+            <input type="text" id="fe-search-input" class="fe-search-input" placeholder="${escapeHtml(t('fileExplorer.searchPlaceholder'))}">
+            <button class="fe-content-search-toggle" id="fe-content-search-toggle" title="${escapeHtml(t('fileExplorer.searchContentToggle'))}">${ICONS.file}</button>
+            <button class="fe-sort-btn" id="fe-sort-btn" title="${escapeHtml(t('fileExplorer.sortFiles'))}">${ICONS.sort}</button>
+            <!-- Sits with the other tree filters rather than up in the toolbar:
+                 it narrows the same tree the search box does. -->
+            <button class="fe-modified-btn" id="fe-modified-btn" title="${escapeHtml(t('files.modifiedOnly'))}" hidden>${ICONS.diff}</button>
+            <button class="fe-search-clear" id="fe-search-clear" title="${escapeHtml(t('ui.clearSearch'))}" style="display: none;">${ICONS.close}</button>
+          </div>
+          <div class="file-explorer-tree" id="file-explorer-tree"></div>
+          <div class="panel-resizer" id="file-explorer-resizer"></div>
+        </div>
+        <div class="files-viewer-pane" id="files-viewer"></div>
+      </div>
+    </div>`;
+}
+
+/** Empty-state when no project is open — the tree has nothing to point at. */
+function _noProjectHtml() {
+  return `<div class="files-empty">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"/></svg>
+    <p>${escapeHtml(t('files.noProject'))}</p>
+  </div>`;
+}
+
+// ── Session overlay ──────────────────────────────────────────────────────────
+
+/**
+ * Push the overlay down into the tree rather than having the tree reach back up
+ * for it — FilesPanel already requires FileExplorer, and the reverse would be a
+ * cycle.
+ */
+function _pushOverlay() {
+  FileExplorer.setSessionOverlay({
+    files: _sessionFiles,
+    modifiedOnly: _modifiedOnly && !!_sessionFiles,
+  });
+}
+
+function getSessionChange(path) {
+  return _sessionFiles ? _sessionFiles.get(path) || null : null;
+}
+
+async function _loadSessions() {
+  if (_sessions) return _sessions;
+  try {
+    const list = await api.claude.sessions(_project.path) || [];
+    // The API already orders by real last activity; sorting again keeps the
+    // menu right even if that ever changes upstream.
+    _sessions = [...list].sort((a, b) => new Date(b.modified || 0) - new Date(a.modified || 0));
+  } catch {
+    _sessions = [];
+  }
+  return _sessions;
+}
+
+function _sessionText(session) {
+  const raw = session.summary || session.firstPrompt || session.sessionId || '';
+  const line = raw.replace(/\s+/g, ' ').trim();
+  if (!line) return session.sessionId.slice(0, 8);
+  return line.length > 70 ? line.slice(0, 67) + '…' : line;
+}
+
+async function selectSession(sessionId, label) {
+  _sessionId = sessionId || null;
+  _sessionLabel = label || '';
+  _sessionFiles = null;
+  _selectedPath = null;
+
+  const labelEl = document.getElementById('files-session-label');
+  if (labelEl) labelEl.textContent = _sessionId ? _sessionLabel : t('files.noSession');
+  // The picker reads as "on" while a session is driving the tree.
+  document.getElementById('files-session')?.classList.toggle('active', !!_sessionId);
+
+  const modifiedBtn = document.getElementById('fe-modified-btn');
+  if (modifiedBtn) {
+    modifiedBtn.hidden = !_sessionId;
+    if (!_sessionId) modifiedBtn.classList.remove('active');
+  }
+  if (!_sessionId) _modifiedOnly = false;
+
+  _renderTotals();
+  _renderViewerPlaceholder();
+
+  if (!_sessionId) {
+    _pushOverlay();
+    FileExplorer.render();
+    return;
+  }
+
+  _loadingSession = true;
+  try {
+    const res = await api.claude.sessionChanges({ projectPath: _project.path, sessionId: _sessionId });
+    if (_sessionId !== sessionId) return; // a later pick won the race
+    _sessionFiles = new Map((res && res.success ? res.files : []).map(f => [f.path, f]));
+  } catch {
+    if (_sessionId === sessionId) _sessionFiles = new Map();
+  } finally {
+    if (_sessionId === sessionId) {
+      _loadingSession = false;
+      _renderTotals();
+      _pushOverlay();
+      // Expanding down to every touched file is what makes the overlay legible;
+      // otherwise the badges stay hidden inside collapsed folders.
+      await FileExplorer.revealPaths([..._sessionFiles.keys()]);
+    }
+  }
+}
+
+function _renderTotals() {
+  const el = document.getElementById('files-session-totals');
+  if (!el) return;
+  if (!_sessionId) { el.innerHTML = ''; return; }
+  if (_loadingSession) { el.textContent = t('common.loading'); return; }
+  if (!_sessionFiles || _sessionFiles.size === 0) {
+    el.textContent = t('files.sessionNoChanges');
+    return;
+  }
+  let add = 0, del = 0;
+  for (const s of _sessionFiles.values()) { add += s.additions; del += s.deletions; }
+  el.innerHTML = `<span class="files-totals-count">${_sessionFiles.size} ${escapeHtml(t('files.filesTouched'))}</span>
+    <span class="chat-change-add">+${add}</span><span class="chat-change-del">-${del}</span>`;
+}
+
+// ── Viewer ───────────────────────────────────────────────────────────────────
+
+function _renderViewerPlaceholder() {
+  const pane = document.getElementById('files-viewer');
+  if (!pane) return;
+  pane.innerHTML = `<div class="files-empty">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+    <p>${escapeHtml(t('files.pickAFile'))}</p>
+  </div>`;
+}
+
+async function openFile(filePath) {
+  const pane = document.getElementById('files-viewer');
+  if (!pane) return;
+  _selectedPath = filePath;
+  const change = getSessionChange(filePath);
+  // A file this session touched opens on its diff: that is what you came for.
+  await FileViewer.render(pane, filePath, {
+    project: _project,
+    change,
+    initialMode: change ? 'diff' : 'content',
+    sessionLabel: _sessionLabel,
+  });
+}
+
+// ── Mount / lifecycle ────────────────────────────────────────────────────────
+
+// Two actions need the host: opening a folder as a terminal, and mentioning a
+// file in the active chat. Everything else the panel handles itself.
+const _hostCallbacks = { onOpenInTerminal: null, onAddToChat: null };
+function setCallbacks(cbs) { Object.assign(_hostCallbacks, cbs); }
+
+function _closeMenus() {
+  const menu = document.getElementById('files-session-menu');
+  if (menu && !menu.hidden) {
+    menu.hidden = true;
+    document.getElementById('files-session-btn')?.setAttribute('aria-expanded', 'false');
+  }
+}
+
+function _wireSessionPicker() {
+  const btn = document.getElementById('files-session-btn');
+  const menu = document.getElementById('files-session-menu');
+  if (!btn || !menu) return;
+
+  btn.onclick = async (e) => {
+    e.stopPropagation();
+    if (!menu.hidden) { menu.hidden = true; btn.setAttribute('aria-expanded', 'false'); return; }
+    menu.hidden = false;
+    btn.setAttribute('aria-expanded', 'true');
+    menu.innerHTML = `<div class="files-picker-loading">${escapeHtml(t('common.loading'))}</div>`;
+    const sessions = await _loadSessions();
+    if (menu.hidden) return;
+    const items = [
+      `<button class="files-picker-item${_sessionId ? '' : ' active'}" data-sid="" role="menuitem">
+        <span class="files-picker-item-text">${escapeHtml(t('files.noSession'))}</span>
+        <span class="files-picker-item-hint">${escapeHtml(t('files.noSessionHint'))}</span>
+      </button>`,
+      '<div class="files-picker-divider"></div>',
+    ];
+    for (const s of sessions) {
+      const text = _sessionText(s);
+      items.push(`<button class="files-picker-item${_sessionId === s.sessionId ? ' active' : ''}" data-sid="${escapeHtml(s.sessionId)}" role="menuitem" title="${escapeHtml(text)}">
+        <span class="files-picker-item-text">${escapeHtml(text)}</span>
+        <span class="files-picker-item-hint">${escapeHtml(_relativeTime(s.modified))}</span>
+      </button>`);
+    }
+    menu.innerHTML = items.join('');
+  };
+
+  menu.onclick = (e) => {
+    const item = e.target.closest('.files-picker-item');
+    if (!item) return;
+    menu.hidden = true;
+    btn.setAttribute('aria-expanded', 'false');
+    selectSession(item.dataset.sid || null, item.querySelector('.files-picker-item-text')?.textContent || '');
+  };
+}
+
+function _wireModifiedFilter() {
+  const btn = document.getElementById('fe-modified-btn');
+  if (!btn) return;
+  btn.onclick = () => {
+    _modifiedOnly = !_modifiedOnly;
+    btn.classList.toggle('active', _modifiedOnly);
+    _pushOverlay();
+    FileExplorer.render();
+  };
+}
+
+function _wireToolbar() {
+  _wireSessionPicker();
+  _wireModifiedFilter();
+}
+
+/**
+ * Switch between the active project's tree and every open project at once.
+ *
+ * Overview drops the session picker rather than disabling it: a session
+ * belongs to one project, so with several on screen the control has no single
+ * answer to give. Any overlay in force is cleared with it.
+ *
+ * @param {'project'|'overview'} scope
+ */
+function setScope(scope) {
+  const next = scope === 'overview' ? 'overview' : 'project';
+  if (next === _scope) return;
+  _scope = next;
+  if (!_mounted) return;
+
+  document.getElementById('files-session')?.toggleAttribute('hidden', _scope === 'overview');
+  if (_scope === 'overview') {
+    // Clearing through selectSession also resets the label, the filter button
+    // and the totals, so nothing stale is left pointing at one project.
+    selectSession(null, '');
+  }
+  _applyRoots();
+  _renderViewerPlaceholder();
+  FileExplorer.render();
+}
+
+/** Point the tree at one project, or at all of the open ones. */
+function _applyRoots() {
+  if (_scope === 'overview') {
+    FileExplorer.setExtraRoots(getOpenProjects().map(p => p.path));
+  } else {
+    FileExplorer.setExtraRoots([]);
+  }
+}
+
+// Dismissing the picker from anywhere, registered once.
+document.addEventListener('click', (e) => {
+  if (e.target.closest('#files-session')) return;
+  _closeMenus();
+});
+
+/**
+ * Build the screen and hand the tree over to FileExplorer. Safe to call on
+ * every activate: it only rebuilds when the project changed.
+ */
+function loadPanel(root, project) {
+  _root = root;
+  const changedProject = !_project || !project || _project.path !== project.path;
+  _project = project || null;
+
+  if (!_project) {
+    root.innerHTML = _noProjectHtml();
+    _mounted = false;
+    return;
+  }
+
+  if (!_mounted || changedProject) {
+    root.innerHTML = _screenHtml();
+    _mounted = true;
+    _wireToolbar();
+    if (changedProject) {
+      _sessionId = null;
+      _sessionLabel = '';
+      _sessionFiles = null;
+      _sessions = null;
+      _modifiedOnly = false;
+      _selectedPath = null;
+    }
+    _renderViewerPlaceholder();
+    // The tree markup exists now, so FileExplorer can bind to it. Clicking a
+    // file lands in this screen's viewer rather than opening a session tab.
+    FileExplorer.setCallbacks({
+      onOpenFile: openFile,
+      onOpenInTerminal: (p) => _hostCallbacks.onOpenInTerminal?.(p),
+      onAddToChat: (rel, full) => _hostCallbacks.onAddToChat?.(rel, full),
+    });
+    FileExplorer.init();
+  }
+
+  const sessionLabel = document.getElementById('files-session-label');
+  if (sessionLabel) sessionLabel.textContent = _sessionId ? _sessionLabel : t('files.noSession');
+  document.getElementById('files-session')?.toggleAttribute('hidden', _scope === 'overview');
+
+  _pushOverlay();
+  // _rootPath stays the active project even in Overview: it is what the path
+  // guards and the git poll measure against.
+  FileExplorer.setRootPath(_project.path);
+  _applyRoots();
+  FileExplorer.show();
+  FileExplorer.render();
+}
+
+function onDeactivate() {
+  FileExplorer.hide();
+}
+
+function cleanup() {
+  FileExplorer.hide();
+  _mounted = false;
+}
+
+module.exports = {
+  loadPanel,
+  setCallbacks,
+  setScope,
+  onDeactivate,
+  cleanup,
+  openFile,
+  selectSession,
+  getSessionChange,
+};

--- a/src/renderer/ui/panels/ShortcutsManager.js
+++ b/src/renderer/ui/panels/ShortcutsManager.js
@@ -462,8 +462,13 @@ class ShortcutsManager extends BasePanel {
       }
     }, { global: true });
 
+    // The explorer is a screen now, so this toggles between it and wherever you
+    // were rather than showing and hiding a docked panel.
     registerShortcut(this.getShortcutKey('toggleFileExplorer'), () => {
-      this._ctx.FileExplorer.toggle();
+      const onFiles = document.body.dataset.activeTab === 'files';
+      const target = onFiles ? (this._lastTabBeforeFiles || 'claude') : 'files';
+      if (!onFiles) this._lastTabBeforeFiles = document.body.dataset.activeTab || 'claude';
+      document.querySelector(`.nav-tab[data-tab="${target}"]`)?.click();
     }, { global: true });
   }
 

--- a/src/renderer/ui/panels/index.js
+++ b/src/renderer/ui/panels/index.js
@@ -20,8 +20,10 @@ const SessionReplayPanel = require('./SessionReplayPanel');
 const ParallelTaskPanel = require('./ParallelTaskPanel');
 const WorkspacePanel = require('./WorkspacePanel');
 const ErrorLogPanel = require('./ErrorLogPanel');
+const FilesPanel = require('./FilesPanel');
 
 module.exports = {
+  FilesPanel,
   MemoryEditor,
   GitChangesPanel,
   ShortcutsManager,

--- a/styles/chat.css
+++ b/styles/chat.css
@@ -90,6 +90,11 @@
 .chat-changes-list { display: flex; flex-direction: column; gap: 1px; }
 
 .chat-change-item {
+  border-radius: var(--radius-sm);
+}
+.chat-change-item.expanded { background: var(--bg-secondary); }
+
+.chat-change-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -99,12 +104,74 @@
   cursor: pointer;
   transition: background 0.1s ease;
 }
-.chat-change-item:hover { background: var(--bg-hover); }
+.chat-change-row:hover { background: var(--bg-hover); }
+.chat-change-row:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: -1px;
+}
 
+.chat-change-chevron {
+  width: 12px;
+  height: 12px;
+  flex-shrink: 0;
+  color: var(--text-muted);
+  transition: transform 0.12s ease;
+}
+.chat-change-item.expanded .chat-change-chevron { transform: rotate(90deg); }
+
+.chat-change-open,
+.chat-change-current {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.1s ease, color 0.1s ease;
+}
+.chat-change-open svg,
+.chat-change-current svg { width: 13px; height: 13px; }
+.chat-change-row:hover .chat-change-open,
+.chat-change-row:hover .chat-change-current { opacity: 1; }
+.chat-change-open:hover,
+.chat-change-current:hover { color: var(--text-primary); background: var(--bg-active); }
+.chat-change-open:focus-visible,
+.chat-change-current:focus-visible { opacity: 1; outline: 1px solid var(--accent); }
+.chat-change-item.expanded[data-diff-mode="current"] .chat-change-current {
+  opacity: 1;
+  color: var(--accent);
+}
+
+/* Diff body, mounted only while the file is expanded. */
+.chat-change-diff {
+  padding: 2px 10px 10px 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.chat-change-diff[hidden] { display: none; }
+.chat-change-diff .chat-diff-viewer { margin: 0; }
+
+.chat-change-note {
+  padding: 6px 8px;
+  color: var(--text-muted);
+  font-size: var(--font-xs);
+  font-style: italic;
+}
+
+/* Takes the row's slack so the name starts at the left edge. Without flex:1 the
+   row's space-between centres this block between the chevron and the stats. */
 .chat-change-file {
   display: flex;
   align-items: baseline;
   gap: 8px;
+  flex: 1;
   min-width: 0;
   overflow: hidden;
 }
@@ -1658,6 +1725,15 @@ mark.chat-search-hit.current {
   word-break: break-all;
   padding-right: 4px;
 }
+
+/* Hunk headers in a raw unified diff (the "compare with disk" view) */
+.diff-line.diff-hunk .diff-text {
+  color: var(--info);
+  opacity: 0.85;
+}
+
+/* A raw diff carries its own +/- column, so it needs no gutter */
+.chat-diff-viewer--raw .diff-line { padding-left: 10px; }
 
 /* Added lines */
 .diff-line.diff-add {

--- a/styles/diff.css
+++ b/styles/diff.css
@@ -1,0 +1,106 @@
+/* ==========================================================================
+   Diff renderer — GitHub-shaped: two gutters, hunk headers, word-level marks.
+   Shared by the Files screen viewer and the session Changes tab.
+   ========================================================================== */
+
+.dr-diff {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: var(--font-xs);
+  line-height: 1.55;
+  tab-size: 2;
+}
+
+.dr-row {
+  display: flex;
+  align-items: flex-start;
+  min-height: 19px;
+}
+.dr-row:hover { background: rgba(255, 255, 255, 0.03); }
+
+/* Two gutters: old line, new line. A row only fills the one it belongs to,
+   which is what makes an add or a delete readable at a glance. */
+.dr-ln {
+  flex-shrink: 0;
+  width: 46px;
+  padding: 0 8px;
+  text-align: right;
+  color: var(--text-muted);
+  opacity: 0.45;
+  user-select: none;
+}
+.dr-ln-new { border-right: 1px solid var(--border-color); }
+
+.dr-sign {
+  flex-shrink: 0;
+  width: 18px;
+  text-align: center;
+  user-select: none;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.dr-code {
+  flex: 1;
+  min-width: 0;
+  padding: 0 12px 0 4px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* ── Hunk header ── */
+.dr-row.dr-hunk {
+  background: rgba(59, 130, 246, 0.07);
+  border-top: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-color);
+}
+.dr-row.dr-hunk:first-child { border-top: none; }
+.dr-row.dr-hunk .dr-code {
+  color: var(--info);
+  opacity: 0.85;
+  user-select: none;
+}
+
+/* ── Added / removed ── */
+.dr-row.dr-add { background: rgba(34, 197, 94, 0.08); }
+.dr-row.dr-add .dr-sign { color: #4ade80; }
+.dr-row.dr-add .dr-ln { color: rgba(74, 222, 128, 0.5); }
+
+.dr-row.dr-del { background: rgba(239, 68, 68, 0.08); }
+.dr-row.dr-del .dr-sign { color: #f87171; }
+.dr-row.dr-del .dr-ln { color: rgba(248, 113, 113, 0.5); }
+
+/* Word-level marks: the part of the line that actually moved. This is the cue
+   that turns "these two lines differ" into "this token changed". */
+.dr-word {
+  background: rgba(34, 197, 94, 0.28);
+  color: inherit;
+  border-radius: 2px;
+  padding: 0 1px;
+}
+.dr-row.dr-del .dr-word { background: rgba(239, 68, 68, 0.3); }
+
+/* ── Split view ── */
+.dr-diff--split .dr-row.dr-split { align-items: stretch; }
+.dr-side {
+  display: flex;
+  align-items: flex-start;
+  width: 50%;
+  min-width: 0;
+}
+.dr-side + .dr-side { border-left: 1px solid var(--border-color); }
+.dr-side.dr-add { background: rgba(34, 197, 94, 0.08); }
+.dr-side.dr-del { background: rgba(239, 68, 68, 0.08); }
+.dr-side.dr-empty { background: rgba(255, 255, 255, 0.015); }
+.dr-side .dr-ln {
+  width: 46px;
+  border-right: 1px solid var(--border-color);
+}
+.dr-diff--split .dr-row.dr-hunk .dr-code { width: 100%; }
+
+.dr-truncated,
+.dr-empty {
+  padding: 10px 12px;
+  color: var(--text-muted);
+  font-size: var(--font-xs);
+  font-style: italic;
+}

--- a/styles/files.css
+++ b/styles/files.css
@@ -1,0 +1,393 @@
+/* ==========================================================================
+   Files screen — project tree on the left, the file it selects on the right.
+   Replaces the explorer column that used to be docked into the Claude layout.
+   ========================================================================== */
+
+#tab-files.active {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.files-screen {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  background: var(--bg-primary);
+}
+
+/* ── Toolbar ── */
+.files-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-secondary);
+  flex-shrink: 0;
+}
+.files-toolbar-spacer { flex: 1; }
+
+/* ── Session picker ──
+   Deliberately chunky: it drives everything below it, and the first version was
+   a grey chip nobody could find. The project is chosen in the project bar above
+   this screen, shared with the rest of the Project group. */
+.files-picker { position: relative; }
+.files-picker-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 420px;
+  padding: 5px 10px;
+  border: 1px solid var(--border-color);
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-sm);
+  cursor: pointer;
+  transition: border-color 0.12s ease, background 0.12s ease;
+}
+.files-picker-btn:hover { background: var(--bg-hover); border-color: var(--text-muted); }
+.files-picker-icon { display: flex; flex-shrink: 0; color: var(--text-muted); }
+.files-picker-icon svg { width: 14px; height: 14px; }
+.files-picker-caption {
+  color: var(--text-muted);
+  font-size: var(--font-xs);
+  flex-shrink: 0;
+}
+.files-picker-value {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 500;
+}
+.files-picker-arrow { display: flex; flex-shrink: 0; color: var(--text-muted); }
+.files-picker-arrow svg { width: 12px; height: 12px; }
+
+/* A session is driving the tree — say so loudly. */
+.files-picker--session.active .files-picker-btn {
+  border-color: var(--accent);
+  background: var(--accent-dim);
+}
+.files-picker--session.active .files-picker-icon,
+.files-picker--session.active .files-picker-value { color: var(--accent); }
+
+.files-picker-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 40;
+  min-width: 280px;
+  max-width: 560px;
+  max-height: 360px;
+  overflow-y: auto;
+  padding: 4px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+}
+.files-picker-menu--wide { min-width: 420px; }
+.files-picker-menu[hidden] { display: none; }
+
+.files-picker-item {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  width: 100%;
+  padding: 7px 9px;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-xs);
+  text-align: left;
+  cursor: pointer;
+}
+.files-picker-item:hover { background: var(--bg-hover); color: var(--text-primary); }
+.files-picker-item.active { color: var(--accent); }
+.files-picker-item-text {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.files-picker-item-hint {
+  flex-shrink: 0;
+  max-width: 45%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-muted);
+  font-size: var(--font-2xs);
+  direction: rtl;
+  text-align: right;
+}
+.files-picker-divider {
+  height: 1px;
+  margin: 4px 6px;
+  background: var(--border-color);
+}
+.files-picker-loading { padding: 8px; color: var(--text-muted); font-size: var(--font-xs); }
+
+/* "Only modified files", sitting with the other tree filters in the search row. */
+.fe-modified-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.fe-modified-btn[hidden] { display: none; }
+.fe-modified-btn svg { width: 12px; height: 12px; }
+.fe-modified-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
+.fe-modified-btn.active { background: var(--accent-dim); color: var(--accent); }
+
+.files-session-totals {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-muted);
+  font-size: var(--font-xs);
+  font-variant-numeric: tabular-nums;
+}
+.files-totals-count { color: var(--text-secondary); }
+
+/* ── Body: two panes ── */
+.files-body {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+}
+
+.files-tree-pane {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: 320px;
+  min-width: 180px;
+  max-width: 60%;
+  flex-shrink: 0;
+  border-right: 1px solid var(--border-color);
+  background: var(--bg-secondary);
+}
+.files-tree-pane .file-explorer-tree {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 4px 0 20px;
+}
+
+.files-viewer-pane {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.files-empty {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 40px 20px;
+  color: var(--text-muted);
+  font-size: var(--font-sm);
+  text-align: center;
+}
+.files-empty svg { width: 40px; height: 40px; opacity: 0.35; }
+
+/* A project as a root row in the Overview tree — heavier than a folder, so the
+   boundary between two projects is obvious while scrolling. */
+.fe-node.fe-root {
+  font-weight: 600;
+  color: var(--text-primary);
+  border-top: 1px solid var(--border-color);
+  margin-top: 2px;
+  padding-top: 3px;
+  padding-bottom: 3px;
+}
+.fe-node.fe-root:first-child { border-top: none; margin-top: 0; }
+
+/* ── Session overlay badges in the tree ── */
+.fe-session-badge {
+  display: inline-flex;
+  gap: 4px;
+  margin-left: auto;
+  padding-left: 6px;
+  font-size: var(--font-2xs);
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+.fe-session-add { color: #4ade80; }
+.fe-session-del { color: #f87171; }
+.fe-session-badge--dir {
+  min-width: 16px;
+  justify-content: center;
+  color: var(--text-muted);
+  background: var(--bg-active);
+  border-radius: 8px;
+  padding: 0 5px;
+}
+.fe-node.fe-session-touched .fe-node-name { color: var(--text-primary); }
+.fe-node.fe-session-touched::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 4px;
+  bottom: 4px;
+  width: 2px;
+  background: var(--accent);
+  border-radius: 0 2px 2px 0;
+}
+.fe-node.fe-session-touched { position: relative; }
+
+/* ==========================================================================
+   File viewer
+   ========================================================================== */
+
+.fv-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 12px;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-secondary);
+  flex-shrink: 0;
+}
+.fv-icon { display: flex; flex-shrink: 0; }
+.fv-icon svg, .fv-icon img { width: 15px; height: 15px; }
+
+.fv-path {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+  overflow: hidden;
+}
+.fv-base { color: var(--text-primary); font-size: var(--font-base); white-space: nowrap; }
+.fv-dir {
+  color: var(--text-muted);
+  font-size: var(--font-xs);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  direction: rtl;
+  text-align: left;
+}
+
+.fv-stats, .fv-meta {
+  display: inline-flex;
+  gap: 8px;
+  margin-left: auto;
+  font-size: var(--font-sm);
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+.fv-meta { color: var(--text-muted); }
+
+.fv-modes {
+  display: inline-flex;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  flex-shrink: 0;
+}
+.fv-mode {
+  padding: 3px 10px;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: var(--font-xs);
+  cursor: pointer;
+}
+.fv-mode:hover { background: var(--bg-hover); color: var(--text-primary); }
+.fv-mode.active { background: var(--accent-dim); color: var(--accent); }
+
+.fv-action {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.fv-action svg { width: 14px; height: 14px; }
+.fv-action:hover { background: var(--bg-hover); color: var(--text-primary); }
+
+.fv-body {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+}
+
+.fv-code {
+  display: flex;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: var(--font-xs);
+  line-height: 1.55;
+}
+.fv-lines {
+  display: flex;
+  flex-direction: column;
+  padding: 8px 8px 8px 12px;
+  text-align: right;
+  color: var(--text-muted);
+  opacity: 0.4;
+  user-select: none;
+  flex-shrink: 0;
+  border-right: 1px solid var(--border-color);
+}
+.fv-ln { display: block; }
+.fv-pre {
+  flex: 1;
+  margin: 0;
+  padding: 8px 12px;
+  overflow-x: auto;
+  white-space: pre;
+}
+.fv-truncated, .fv-error {
+  padding: 8px 12px;
+  color: var(--text-muted);
+  font-size: var(--font-xs);
+  font-style: italic;
+}
+.fv-markdown { padding: 16px 24px; max-width: 900px; }
+.fv-media {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  min-height: 100%;
+}
+.fv-media img { max-width: 100%; max-height: 80vh; object-fit: contain; }
+.fv-handoff {
+  padding: 6px 14px;
+  border: 1px solid var(--border-color);
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-xs);
+  cursor: pointer;
+}
+.fv-handoff:hover { background: var(--bg-hover); border-color: var(--accent); }

--- a/styles/index.css
+++ b/styles/index.css
@@ -11,6 +11,8 @@
 @import './fivem.css';
 @import './memory.css';
 @import './git.css';
+@import './diff.css';
+@import './files.css';
 @import './time-tracking.css';
 @import './skills.css';
 @import './chat.css';

--- a/styles/projects.css
+++ b/styles/projects.css
@@ -43,6 +43,7 @@
 }
 
 body[data-active-tab="claude"] .project-bar,
+body[data-active-tab="files"] .project-bar,
 body[data-active-tab="git"] .project-bar,
 body[data-active-tab="dashboard"] .project-bar,
 body[data-active-tab="session-replay"] .project-bar,
@@ -114,7 +115,7 @@ body[data-active-tab="tasks"] .project-bar {
   display: block;
 }
 
-body:not([data-active-tab="dashboard"]) .project-tab--overview {
+body:not([data-active-tab="dashboard"]):not([data-active-tab="files"]) .project-tab--overview {
   display: none;
 }
 

--- a/styles/terminal.css
+++ b/styles/terminal.css
@@ -110,31 +110,6 @@
   background: var(--border-color);
 }
 
-.btn-toggle-explorer {
-  width: 26px;
-  height: 26px;
-  padding: 4px;
-  border: none;
-  background: transparent;
-  color: var(--text-secondary);
-  border-radius: 4px;
-  cursor: pointer;
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.btn-toggle-explorer:hover {
-  background: var(--bg-hover);
-  color: var(--text-primary);
-}
-
-.btn-toggle-explorer svg {
-  width: 16px;
-  height: 16px;
-}
-
 /* Project tools inside the project bar (right side) */
 .terminals-filter {
   display: flex;

--- a/tests/ipc/claudeSessionChanges.test.js
+++ b/tests/ipc/claudeSessionChanges.test.js
@@ -1,0 +1,297 @@
+// parseSessionFileChanges: reconstruct a session's file edits from its transcript.
+//
+// Claude Code writes the patch it applied next to every edit, as
+// `toolUseResult.structuredPatch` — real hunks with exact line numbers. So the
+// parser's job is to pair each call with its result and add the numbers up, not
+// to re-derive a diff. These tests pin that pairing, the counting, and the
+// id-based dedupe that stops a subagent edit landing twice.
+
+const realOs = require('os');
+const fs = require('fs');
+const path = require('path');
+
+const TMP_HOME = fs.mkdtempSync(path.join(realOs.tmpdir(), 'ct-session-changes-'));
+
+jest.mock('electron', () => ({
+  ipcMain: { handle: jest.fn(), removeHandler: jest.fn() }
+}));
+
+jest.mock('os', () => ({
+  ...jest.requireActual('os'),
+  homedir: () => global.__CT_TMP_HOME__
+}));
+
+global.__CT_TMP_HOME__ = TMP_HOME;
+
+const { parseSessionFileChanges } = require('../../src/main/ipc/claude.ipc');
+
+const PROJECT_PATH = '/tmp/changes-project';
+const SESSION_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const FILE_A = '/tmp/changes-project/a.js';
+
+function sessionsDir() {
+  return path.join(TMP_HOME, '.claude', 'projects', PROJECT_PATH.replace(/[^a-zA-Z0-9]/g, '-'));
+}
+
+/** A hunk in structuredPatch shape. `lines` carry their own +/-/space prefix. */
+function hunk(oldStart, lines, newStart = oldStart) {
+  return {
+    oldStart,
+    oldLines: lines.filter(l => l[0] !== '+').length,
+    newStart,
+    newLines: lines.filter(l => l[0] !== '-').length,
+    lines,
+  };
+}
+
+/**
+ * Write a transcript. Each edit becomes two lines: the assistant's tool_use,
+ * then the user line carrying the tool_result and its toolUseResult sibling —
+ * which is exactly how Claude Code lays it out.
+ */
+function writeSession(edits, { sessionId = SESSION_ID } = {}) {
+  const dir = sessionsDir();
+  fs.mkdirSync(dir, { recursive: true });
+  const lines = [];
+
+  edits.forEach((e, i) => {
+    const id = e.id || `t-${i}`;
+    lines.push(JSON.stringify({
+      type: 'assistant',
+      sessionId,
+      timestamp: `2026-01-0${(i % 9) + 1}T00:00:00.000Z`,
+      ...(e.isSidechain ? { isSidechain: true } : {}),
+      message: {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id, name: e.name, input: e.input }],
+      },
+    }));
+    if (e.patch === null) return; // an edit whose result never landed
+    lines.push(JSON.stringify({
+      type: 'user',
+      sessionId,
+      message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: id, content: 'ok' }] },
+      toolUseResult: {
+        filePath: e.input.file_path || e.input.notebook_path,
+        structuredPatch: e.patch,
+        ...(e.resultType ? { type: e.resultType } : {}),
+        ...(e.resultContent !== undefined ? { content: e.resultContent } : {}),
+      },
+    }));
+  });
+
+  fs.writeFileSync(path.join(dir, `${sessionId}.jsonl`), lines.join('\n') + '\n');
+}
+
+// maxRetries because Windows will not unlink a file whose handle has just been
+// released — the parser destroys its stream, but the OS can lag a tick behind.
+const rmDir = (dir) => fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+
+afterEach(() => rmDir(sessionsDir()));
+afterAll(() => rmDir(TMP_HOME));
+
+describe('parseSessionFileChanges', () => {
+  test('returns an empty result when the session file is missing', async () => {
+    const res = await parseSessionFileChanges(PROJECT_PATH, 'no-such-session');
+    expect(res.files).toEqual([]);
+    expect(res.totals.files).toBe(0);
+  });
+
+  test('keeps the tool\'s own hunks, line numbers included', async () => {
+    writeSession([{
+      name: 'Edit',
+      input: { file_path: FILE_A, old_string: 'x', new_string: 'y' },
+      patch: [hunk(633, ['   const options = {', '-  maxTurns: 100,', '+  ...(maxTurns ? { maxTurns } : {}),', '   includePartial: true,'])],
+    }]);
+
+    const res = await parseSessionFileChanges(PROJECT_PATH, SESSION_ID);
+    expect(res.files).toHaveLength(1);
+    expect(res.files[0]).toMatchObject({ path: FILE_A, additions: 1, deletions: 1, edits: 1 });
+    // Exactly what the tool reported — nothing recomputed.
+    expect(res.files[0].hunks[0]).toEqual({
+      oldStart: 633, oldLines: 3, newStart: 633, newLines: 3,
+      lines: ['   const options = {', '-  maxTurns: 100,', '+  ...(maxTurns ? { maxTurns } : {}),', '   includePartial: true,'],
+    });
+  });
+
+  test('counts additions and deletions across several hunks', async () => {
+    writeSession([{
+      name: 'Edit',
+      input: { file_path: FILE_A, old_string: 'x', new_string: 'y' },
+      patch: [
+        hunk(10, ['-a', '-b', '+c']),
+        hunk(40, [' keep', '+d', '+e']),
+      ],
+    }]);
+
+    const res = await parseSessionFileChanges(PROJECT_PATH, SESSION_ID);
+    expect(res.files[0]).toMatchObject({ additions: 3, deletions: 2 });
+    expect(res.files[0].hunks).toHaveLength(2);
+  });
+
+  test('accumulates several edits to the same file', async () => {
+    writeSession([
+      { name: 'Edit', input: { file_path: FILE_A, old_string: 'a', new_string: 'A' }, patch: [hunk(1, ['-a', '+A'])] },
+      { name: 'Edit', input: { file_path: FILE_A, old_string: 'b', new_string: 'B' }, patch: [hunk(9, ['-b', '+B'])] },
+    ]);
+
+    const res = await parseSessionFileChanges(PROJECT_PATH, SESSION_ID);
+    expect(res.files).toHaveLength(1);
+    expect(res.files[0]).toMatchObject({ edits: 2, additions: 2, deletions: 2 });
+    expect(res.files[0].hunks).toHaveLength(2);
+  });
+
+  test('treats a Write that rewrites a file as an ordinary patch', async () => {
+    writeSession([{
+      name: 'Write',
+      resultType: 'update',
+      input: { file_path: '/tmp/changes-project/new.txt', content: 'one\ntwo\nthree' },
+      patch: [hunk(1, ['+one', '+two', '+three'])],
+    }]);
+
+    const res = await parseSessionFileChanges(PROJECT_PATH, SESSION_ID);
+    expect(res.files[0]).toMatchObject({ additions: 3, deletions: 0, edits: 1 });
+  });
+
+  test('builds the patch for a created file from its content', async () => {
+    // A Write that creates a file reports type:"create" with an EMPTY
+    // structuredPatch — there was no previous version to diff. Taking that
+    // literally showed "+0 -0, no diff available" on every file a session
+    // added, which is exactly the file you want to look at.
+    writeSession([{
+      name: 'Write',
+      resultType: 'create',
+      resultContent: 'line one\nline two\nline three',
+      input: { file_path: '/tmp/changes-project/created.js', content: 'line one\nline two\nline three' },
+      patch: [],
+    }]);
+
+    const res = await parseSessionFileChanges(PROJECT_PATH, SESSION_ID);
+    expect(res.files[0]).toMatchObject({ additions: 3, deletions: 0, edits: 1 });
+    expect(res.files[0].hunks).toEqual([{
+      oldStart: 0, oldLines: 0, newStart: 1, newLines: 3,
+      lines: ['+line one', '+line two', '+line three'],
+    }]);
+  });
+
+  test('an empty created file yields no hunk', async () => {
+    writeSession([{
+      name: 'Write',
+      resultType: 'create',
+      resultContent: '',
+      input: { file_path: '/tmp/changes-project/empty.txt', content: '' },
+      patch: [],
+    }]);
+
+    const res = await parseSessionFileChanges(PROJECT_PATH, SESSION_ID);
+    expect(res.files[0]).toMatchObject({ additions: 0, deletions: 0, edits: 1 });
+    expect(res.files[0].hunks).toEqual([]);
+  });
+
+  test('caps a created file that is enormous', async () => {
+    const content = Array.from({ length: 3500 }, (_, i) => `line ${i}`).join('\n');
+    writeSession([{
+      name: 'Write',
+      resultType: 'create',
+      resultContent: content,
+      input: { file_path: '/tmp/changes-project/huge.txt', content },
+      patch: [],
+    }]);
+
+    const res = await parseSessionFileChanges(PROJECT_PATH, SESSION_ID);
+    expect(res.files[0].hunks[0].lines).toHaveLength(3000);
+  });
+
+  test('ignores tools that do not write files', async () => {
+    writeSession([
+      { name: 'Bash', input: { command: 'ls' }, patch: [hunk(1, ['+nope'])] },
+      { name: 'Read', input: { file_path: FILE_A }, patch: [hunk(1, ['+nope'])] },
+    ]);
+
+    const res = await parseSessionFileChanges(PROJECT_PATH, SESSION_ID);
+    expect(res.files).toEqual([]);
+  });
+
+  test('counts a repeated tool_use id once', async () => {
+    // A subagent edit reaches the transcript twice: streamed, then in the full
+    // assistant message. Without the id guard the edit count doubles.
+    const input = { file_path: '/tmp/changes-project/dup.js', old_string: 'o', new_string: 'n' };
+    writeSession([
+      { name: 'Edit', id: 'same-id', input, patch: null },
+      { name: 'Edit', id: 'same-id', input, patch: [hunk(1, ['-o', '+n'])] },
+    ]);
+
+    const res = await parseSessionFileChanges(PROJECT_PATH, SESSION_ID);
+    expect(res.files[0].edits).toBe(1);
+    expect(res.files[0].hunks).toHaveLength(1);
+  });
+
+  test('keeps a file whose result never arrived, with zeroed counters', async () => {
+    // Session cut mid-call: the file was still touched, so it must not vanish.
+    writeSession([{
+      name: 'Edit',
+      input: { file_path: FILE_A, old_string: 'a', new_string: 'b' },
+      patch: null,
+    }]);
+
+    const res = await parseSessionFileChanges(PROJECT_PATH, SESSION_ID);
+    expect(res.files).toHaveLength(1);
+    expect(res.files[0]).toMatchObject({ edits: 1, additions: 0, deletions: 0 });
+    expect(res.files[0].hunks).toEqual([]);
+  });
+
+  test('flags subagent edits and keeps the last timestamp', async () => {
+    writeSession([{
+      name: 'Edit',
+      isSidechain: true,
+      input: { file_path: '/tmp/changes-project/sub.js', old_string: 'x', new_string: 'y' },
+      patch: [hunk(1, ['-x', '+y'])],
+    }]);
+
+    const res = await parseSessionFileChanges(PROJECT_PATH, SESSION_ID);
+    expect(res.files[0].viaSubagent).toBe(true);
+    expect(res.files[0].lastEditedAt).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  test('statsOnly keeps the counters and drops the hunks', async () => {
+    writeSession([{
+      name: 'Edit',
+      input: { file_path: FILE_A, old_string: 'a', new_string: 'b' },
+      patch: [hunk(5, ['-a', '+b'])],
+    }]);
+
+    const res = await parseSessionFileChanges(PROJECT_PATH, SESSION_ID, { statsOnly: true });
+    expect(res.files[0]).toMatchObject({ additions: 1, deletions: 1 });
+    expect(res.files[0].hunks).toEqual([]);
+  });
+
+  test('sorts files by churn and totals them', async () => {
+    writeSession([
+      { name: 'Write', input: { file_path: '/tmp/changes-project/small.txt', content: 'a' }, patch: [hunk(1, ['+a'])] },
+      { name: 'Write', input: { file_path: '/tmp/changes-project/big.txt', content: 'a\nb\nc\nd' }, patch: [hunk(1, ['+a', '+b', '+c', '+d'])] },
+    ]);
+
+    const res = await parseSessionFileChanges(PROJECT_PATH, SESSION_ID);
+    expect(res.files.map(f => f.path)).toEqual([
+      '/tmp/changes-project/big.txt',
+      '/tmp/changes-project/small.txt',
+    ]);
+    expect(res.totals).toMatchObject({ files: 2, additions: 5, deletions: 0, edits: 2 });
+  });
+
+  test('ignores a patch whose editing call was never seen', async () => {
+    // Only a result line, with no tool_use to tie it to. Trusting the result's
+    // own filePath here is what let a Read's patch into the list.
+    const dir = sessionsDir();
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, `${SESSION_ID}.jsonl`), JSON.stringify({
+      type: 'user',
+      sessionId: SESSION_ID,
+      message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'orphan', content: 'ok' }] },
+      toolUseResult: { filePath: FILE_A, structuredPatch: [hunk(3, ['-a', '+b'])] },
+    }) + '\n');
+
+    const res = await parseSessionFileChanges(PROJECT_PATH, SESSION_ID);
+    expect(res.files).toEqual([]);
+  });
+});

--- a/tests/services/DiffRenderer.test.js
+++ b/tests/services/DiffRenderer.test.js
@@ -1,0 +1,129 @@
+// DiffRenderer turns a structuredPatch into GitHub-shaped rows.
+//
+// The line numbers come from the patch, so what these tests really pin is the
+// arithmetic that walks them: a deletion advances only the old gutter, an
+// addition only the new one. Getting that wrong is invisible on a one-line
+// change and badly wrong on a long hunk.
+
+const DiffRenderer = require('../../src/renderer/services/DiffRenderer');
+
+function hunk(oldStart, newStart, lines) {
+  return {
+    oldStart,
+    oldLines: lines.filter(l => l[0] !== '+').length,
+    newStart,
+    newLines: lines.filter(l => l[0] !== '-').length,
+    lines,
+  };
+}
+
+/** Rows as [oldNo, newNo, sign, text], with HTML stripped. */
+function rows(html) {
+  return [...html.matchAll(/<div class="dr-row([^"]*)">(.*?)<\/div>(?=<div class="dr-row|<div class="dr-truncated|$)/gs)]
+    .map(m => {
+      const body = m[2];
+      const cells = [...body.matchAll(/<span class="dr-(?:ln[^"]*|sign|code)">(.*?)<\/span>/gs)].map(c => c[1]);
+      return { cls: m[1].trim(), cells };
+    });
+}
+
+describe('DiffRenderer.renderPatch', () => {
+  test('reports nothing to draw for an empty patch', () => {
+    expect(DiffRenderer.renderPatch([])).toContain('dr-empty');
+    expect(DiffRenderer.renderPatch(null)).toContain('dr-empty');
+  });
+
+  test('emits a hunk header with the patch coordinates', () => {
+    const html = DiffRenderer.renderPatch([hunk(633, 633, [' a', '-b', '+c'])]);
+    expect(html).toContain('@@ -633,2 +633,2 @@');
+    expect(html).toContain('dr-hunk');
+  });
+
+  test('advances the old gutter on deletions and the new one on additions', () => {
+    // 10: context, 11: deleted, then two added lines, then context.
+    const html = DiffRenderer.renderPatch([hunk(10, 10, [' keep', '-gone', '+one', '+two', ' tail'])]);
+    const body = rows(html).filter(r => !r.cls.includes('dr-hunk'));
+
+    // [oldNo, newNo, sign, code]
+    expect(body.map(r => [r.cells[0], r.cells[1], r.cells[2]])).toEqual([
+      ['10', '10', ' '],   // context advances both
+      ['11', '', '-'],     // deletion: old only
+      ['', '11', '+'],     // additions: new only
+      ['', '12', '+'],
+      ['12', '13', ' '],   // context resumes, gutters now offset by one
+    ]);
+  });
+
+  test('honours a newStart that differs from oldStart', () => {
+    const html = DiffRenderer.renderPatch([hunk(5, 40, [' a', '+b'])]);
+    const body = rows(html).filter(r => !r.cls.includes('dr-hunk'));
+    expect(body[0].cells.slice(0, 2)).toEqual(['5', '40']);
+    expect(body[1].cells.slice(0, 2)).toEqual(['', '41']);
+  });
+
+  test('marks the changed words of a rewritten line', () => {
+    const html = DiffRenderer.renderPatch([hunk(1, 1, ['-const a = 1;', '+const a = 2;'])]);
+    // Only the token that moved is wrapped, not the whole line.
+    expect(html).toContain('<mark class="dr-word">');
+    expect(html).toMatch(/<mark class="dr-word">1<\/mark>/);
+    expect(html).toMatch(/<mark class="dr-word">2<\/mark>/);
+  });
+
+  test('leaves a pure addition unmarked', () => {
+    // Nothing was replaced, so there is no "what changed within the line".
+    const html = DiffRenderer.renderPatch([hunk(1, 1, [' ctx', '+brand new'])]);
+    expect(html).not.toContain('dr-word');
+  });
+
+  test('does not pair an unbalanced run', () => {
+    // 3 lines replaced by 1 has no line-to-line story to tell.
+    const html = DiffRenderer.renderPatch([hunk(1, 1, ['-a', '-b', '-c', '+z'])]);
+    expect(html).not.toContain('dr-word');
+  });
+
+  test('escapes code so a diff cannot inject markup', () => {
+    const html = DiffRenderer.renderPatch([hunk(1, 1, ['-<img src=x onerror=alert(1)>', '+<b>ok</b>'])]);
+    // The payload must survive as text — that is the point of a diff viewer —
+    // while the only real tags are the ones the renderer emits itself. A word
+    // mark can land between "&lt;" and the tag name, so assert on tags rather
+    // than on any particular escaped string.
+    const tags = [...html.matchAll(/<([a-zA-Z][\w-]*)/g)].map(m => m[1]);
+    expect(new Set(tags)).toEqual(new Set(['div', 'span', 'mark']));
+  });
+
+  test('split mode pairs the two columns', () => {
+    const html = DiffRenderer.renderPatch([hunk(1, 1, [' a', '-b', '+c'])], { mode: 'split' });
+    expect(html).toContain('dr-diff--split');
+    expect(html).toContain('dr-side');
+  });
+
+  test('split mode leaves a blank cell opposite an unmatched line', () => {
+    const html = DiffRenderer.renderPatch([hunk(1, 1, ['+only an addition'])], { mode: 'split' });
+    expect(html).toContain('dr-empty');
+  });
+
+  test('truncates beyond the row cap and says so', () => {
+    const lines = Array.from({ length: DiffRenderer.MAX_LINES_RENDERED + 50 }, (_, i) => `+line ${i}`);
+    const html = DiffRenderer.renderPatch([hunk(1, 1, lines)]);
+    expect(html).toContain('dr-truncated');
+  });
+
+  test('skips malformed hunks instead of throwing', () => {
+    const html = DiffRenderer.renderPatch([null, { lines: null }, hunk(1, 1, ['+ok'])]);
+    expect(html).toContain('dr-row');
+    expect(html).not.toContain('dr-empty');
+  });
+});
+
+describe('DiffRenderer.countPatch', () => {
+  test('counts additions and deletions across hunks', () => {
+    expect(DiffRenderer.countPatch([
+      hunk(1, 1, ['-a', '+b', '+c']),
+      hunk(9, 9, [' x', '-y']),
+    ])).toEqual({ additions: 2, deletions: 2 });
+  });
+
+  test('is zero for nothing', () => {
+    expect(DiffRenderer.countPatch(null)).toEqual({ additions: 0, deletions: 0 });
+  });
+});


### PR DESCRIPTION
The file explorer was a column docked into the Claude layout, opened by an unlabelled side-panel glyph. It read as a folder button and nothing said it toggled a tree. This turns it into a screen of its own, and hangs two things off it: browsing what any past session changed, and a diff view that looks like a diff.

## Files is a screen

`#file-explorer-panel` is gone from the Claude layout. Files is a screen (`data-tab="files"`), so it inherits scroll restore, active-tab persistence, pinning and `ui_navigate` for free. It sits in the Project group under Dashboard, and is reached from the project menu, the nav, or `Ctrl+E`.

Two panes: the project tree, and the file it selects.

![Files entry in the project menu](https://raw.githubusercontent.com/bleleve/claude-terminal/assets/files-screen/shots/01-project-menu-files.png)

![The Files screen](https://raw.githubusercontent.com/bleleve/claude-terminal/assets/files-screen/shots/02-files-screen.png)

`FileExplorer` keeps the tree. Ignore patterns, git badges, content search, rename, drag & drop are 60 KB of working behaviour, and it binds to fixed ids, so `FilesPanel` renders that markup and hands over. `FileViewer` draws the right pane; PDF, 3D, audio and video hand off to `openFileTab` rather than duplicate its bootstrapping.

## Pick a session, and the tree shows what it changed

![Session picker](https://raw.githubusercontent.com/bleleve/claude-terminal/assets/files-screen/shots/03-session-picker.png)

Touched files get `+n −m`, folders get a rolled-up count, and the path down to each one is expanded on load — badges buried in collapsed directories help nobody. A filter in the search row narrows the tree to just those files, keeping the hierarchy.

![Modified only](https://raw.githubusercontent.com/bleleve/claude-terminal/assets/files-screen/shots/06-modified-only.png)

Selecting a touched file opens its diff instead of its contents.

## structuredPatch, not a reconstruction

The transcript does not only hold `old_string`/`new_string`: Claude Code attaches the patch it applied, as `toolUseResult.structuredPatch` — real hunks with exact `oldStart`/`newStart`. Measured across six real sessions: present on 100% of edits, about 52 KB for 59 edits, a 16 MB transcript parsed in ~20 ms.

So the parser reads that instead of re-deriving a diff, and `DiffRenderer` draws it the way GitHub does: two gutters, hunk headers, syntax highlighting inside the code, word-level marks on rewritten lines, unified or side by side.

![Session diff](https://raw.githubusercontent.com/bleleve/claude-terminal/assets/files-screen/shots/04-session-diff.png)

![Side by side](https://raw.githubusercontent.com/bleleve/claude-terminal/assets/files-screen/shots/05-diff-split.png)

Three things fall out of using the tool's own patch: the gutter is exact, so the best-effort anchor hunt and the blank line numbers it produced are gone; the three in-memory budgets are gone, because 52 KB read from disk beats 4 MB retained; and a patch is only counted when it pairs with a file-editing call we saw, since trusting the result's own `filePath` let a `Read`'s patch into the list.

One case needed care. A `Write` that **creates** a file reports `type: "create"` with an **empty** `structuredPatch` — there was no previous version to diff — and puts the whole file in `content`. Taken literally that showed "+0 −0, no diff available" on exactly the files a session added. The patch is built from `content` for creates, capped at 3000 lines.

## The Changes tab is rebuilt on the same two pieces

Same parser, same renderer, so the two views cannot disagree.

![Changes tab](https://raw.githubusercontent.com/bleleve/claude-terminal/assets/files-screen/shots/08-changes-tab.png)

## Overview, as on the Dashboard

The Overview tab appears on Files too and means the same thing: every open project becomes a collapsible root in one tree. The session picker is hidden rather than disabled while it shows — a session belongs to one project, so with several on screen the control has no single answer to give.

![Overview](https://raw.githubusercontent.com/bleleve/claude-terminal/assets/files-screen/shots/07-overview.png)

Only the rendering is multi-root. `_rootPath` stays the active project, so the path guards, the git poll and search keep one unambiguous scope: browsing another root works, writing into one is refused by the same `isPathSafe` check as before.

## Two bugs found on the way, both outside the feature

**`0 files` in git-commit blocks.** A `git-commit` markdown block written with `stats: +203` and no file count rendered "0 files +203". It now counts the files it was given, and drops the chip when there are none.

**Re-selecting the active project did nothing during an Overview.** `ProjectBar` treats it as a no-op, but that tab is how you get back to a single project. It now goes through while an Overview is up, on Dashboard as well as Files.

## `acceptFirstMouse`

Set on the main window. macOS spends the first click on an unfocused window focusing it, so every action cost two clicks after switching apps. The tradeoff is real — a click meant only to raise the window now also lands on whatever is under the cursor — and for an app you switch into constantly it seems worth it. Easy to drop if you disagree.

## Verification

2283 unit tests pass, including 15 on the transcript parser (counting, budgets, id dedupe, created files) and 14 on the renderer's gutter arithmetic.

Driven in the running app throughout, against real transcripts on an isolated `HOME`: 28/28 checks on the Files screen, 12/12 on the Changes tab, and the sidebar table above. The screenshots here are from a synthetic project and synthetic sessions — no real paths, prompts or project names.

The column-navigation rework this uncovered lives in its own PR, stacked on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


