### PR TITLE
fix(chat): restore legible contrast in the chat input footer

### DIFF
--- a/styles/chat.css
+++ b/styles/chat.css
@@ -252,7 +252,7 @@ mark.chat-search-hit.current {
 }
 
 .chat-input-footer:hover .chat-search-btn {
-  opacity: 0.5;
+  opacity: 1;
 }
 
 .chat-search-btn:hover {
@@ -2060,7 +2060,7 @@ hr.chat-plan-separator {
 }
 
 .chat-input-footer:hover .chat-export-btn {
-  opacity: 0.5;
+  opacity: 1;
 }
 
 .chat-export-btn:hover {
@@ -3606,30 +3606,33 @@ hr.chat-plan-separator {
   margin-right: 4px;
 }
 
+/* The footer carries the model, the context gauge and the running cost — the
+   things you check before spending a turn. It stays on the AA text ramp: no
+   opacity multiplier on top of the tokens, hierarchy comes from the ramp step. */
 .chat-status-text {
-  font-size: 11px;
-  color: var(--text-tertiary);
-  opacity: 0.6;
+  font-size: var(--font-xs);
+  color: var(--text-muted);
 }
 
 .chat-status-tokens,
 .chat-status-cost {
-  font-size: 10px;
-  color: var(--text-tertiary);
+  font-size: var(--font-2xs);
+  color: var(--text-muted);
   font-family: 'Cascadia Code', 'Fira Code', monospace;
-  opacity: 0.4;
 }
 
+/* No opacity here: this is the popover's offset parent, and group opacity on
+   the parent would dim .chat-context-popover along with it. */
 .chat-status-tokens {
   position: relative;
   cursor: help;
   outline: none;
-  transition: opacity 0.15s;
+  transition: color 0.15s;
 }
 
 .chat-status-tokens:hover,
 .chat-status-tokens:focus-visible {
-  opacity: 0.85;
+  color: var(--text-primary);
 }
 
 /* ── Context window breakdown popover (SDK 0.2.86+ getContextUsage) ── */
@@ -3747,23 +3750,21 @@ hr.chat-plan-separator {
   padding: 2px 6px;
   cursor: pointer;
   font-family: 'Cascadia Code', 'Fira Code', monospace;
-  font-size: 10px;
+  font-size: var(--font-2xs);
   color: var(--accent-color, #d97706);
-  opacity: 0.6;
-  transition: opacity 0.15s;
+  transition: background 0.15s;
 }
 
 .chat-model-btn:hover {
-  opacity: 1;
+  background: var(--bg-hover);
 }
 
 .chat-model-btn.locked {
   cursor: default;
-  opacity: 0.3;
 }
 
 .chat-model-btn.locked:hover {
-  opacity: 0.3;
+  background: none;
 }
 
 .chat-model-btn.locked .chat-model-arrow {
@@ -3772,7 +3773,7 @@ hr.chat-plan-separator {
 
 .chat-model-arrow {
   font-size: 0.5625rem;
-  opacity: 0.5;
+  opacity: 0.75;
 }
 
 .chat-model-dropdown {
@@ -3824,9 +3825,8 @@ hr.chat-plan-separator {
 }
 
 .chat-model-option-desc {
-  font-size: 10px;
-  color: var(--text-tertiary);
-  opacity: 0.5;
+  font-size: var(--font-2xs);
+  color: var(--text-muted);
 }
 
 .chat-model-check {
@@ -3851,23 +3851,21 @@ hr.chat-plan-separator {
   padding: 2px 6px;
   cursor: pointer;
   font-family: 'Cascadia Code', 'Fira Code', monospace;
-  font-size: 10px;
+  font-size: var(--font-2xs);
   color: var(--text-secondary, #888);
-  opacity: 0.6;
-  transition: opacity 0.15s;
+  transition: background 0.15s;
 }
 
 .chat-effort-btn:hover {
-  opacity: 1;
+  background: var(--bg-hover);
 }
 
 .chat-effort-btn.locked {
   cursor: default;
-  opacity: 0.3;
 }
 
 .chat-effort-btn.locked:hover {
-  opacity: 0.3;
+  background: none;
 }
 
 .chat-effort-btn.locked .chat-effort-arrow {
@@ -3876,7 +3874,7 @@ hr.chat-plan-separator {
 
 .chat-effort-arrow {
   font-size: 0.5625rem;
-  opacity: 0.5;
+  opacity: 0.75;
 }
 
 .chat-effort-dropdown {
@@ -3928,9 +3926,8 @@ hr.chat-plan-separator {
 }
 
 .chat-effort-option-desc {
-  font-size: 10px;
-  color: var(--text-tertiary);
-  opacity: 0.5;
+  font-size: var(--font-2xs);
+  color: var(--text-muted);
 }
 
 .chat-effort-check {
@@ -4095,17 +4092,22 @@ hr.chat-plan-separator {
   50% { opacity: 0.5; background: rgba(217, 119, 6, 0.08); }
 }
 
-/* Fix #7: Disabled model/effort buttons during streaming */
+/* Fix #7: Disabled model/effort buttons during streaming.
+   Locked and disabled mean "you can't change this", not "you can't read this" —
+   streaming is exactly when you want to confirm which model is billing. The
+   state is signalled by dropping off the accent onto the muted ramp step (still
+   AA) plus cursor and the hidden arrow, never by fading the label out. */
+.chat-model-btn.locked,
+.chat-model-btn.disabled,
+.chat-effort-btn.locked,
+.chat-effort-btn.disabled {
+  color: var(--text-muted);
+}
+
 .chat-model-btn.disabled,
 .chat-effort-btn.disabled {
   cursor: not-allowed;
-  opacity: 0.3;
   pointer-events: none;
-}
-
-.chat-model-btn.disabled:hover,
-.chat-effort-btn.disabled:hover {
-  opacity: 0.3;
 }
 
 .chat-model-btn.disabled .chat-model-arrow,


### PR DESCRIPTION
Fixes #108.

## Problem

The status row under the chat composer carries the model, the effort, the context gauge and the running cost. Every element in it layered an `opacity` multiplier on top of the text ramp that `base.css` had deliberately tuned for WCAG AA, which collapsed the whole row to between **1.55:1 and 3.56:1**.

That row is where you confirm which model is about to bill you, so an unreadable one is a real cost hazard, not just an aesthetic one.

The worst case: `ChatView.js` toggles `.disabled` on the model button for the whole duration of a stream, and `.disabled` set `opacity: 0.3`. The model label fell to **1.55:1 exactly while a turn was streaming**. `.locked` behaved the same way, even though a model you cannot change is one you have more reason to read, not less.

## Fix

Drop the opacity multipliers from that row and let the ramp steps carry the hierarchy, which is what the ramp was tuned for.

- `.chat-status-text`, `.chat-status-tokens`, `.chat-status-cost` go to `--text-muted` at full opacity.
- `.chat-model-btn` keeps `--accent`, `.chat-effort-btn` keeps `--text-secondary`, both undimmed. Hover moves to a `background` change, so the affordance survives without touching text contrast.
- `.locked` and `.disabled` now signal non-interactive by stepping off the accent onto `--text-muted`, alongside the cursor change and the already-hidden chevron. "You cannot change this" no longer also means "you cannot read this".
- Chevrons go from `0.5` to `0.75`, clearing the 3:1 non-text bar.
- The hover-revealed search and export buttons go to full opacity once revealed.
- Model and effort dropdown descriptions lose their `0.5` multiplier; the labels above them are already `--text-primary`, so weight and ramp step keep the hierarchy readable.

Also removes `opacity` from `.chat-status-tokens` specifically because it is the offset parent of `.chat-context-popover`. Opacity below 1 creates a group, so the context breakdown popover was being dimmed along with its trigger and could not opt out with its own `opacity: 1`.

The hard-coded `10px` / `11px` sizes in the touched rules move to the existing rem-based `--font-2xs` / `--font-xs` tokens, so the footer scales with the root font size.

## Result

| Element | Before | After |
|---|---:|---:|
| context gauge / cost | 1.99:1 | **5.27:1** |
| model label | 2.86:1 | **6.10:1** |
| status text | 3.05:1 | **5.27:1** |
| effort label | 3.56:1 | **8.08:1** |
| locked / disabled model + effort | 1.55:1 | **5.27:1** |
| dropdown chevron | 1.55:1 | **3.86:1** |
| search / export (revealed) | 2.16:1 | **5.27:1** |
| dropdown option descriptions | 2.50:1 | **5.27:1** |

Ratios are against `--bg-primary` `#0d0d0d`; every value also clears AA against `--bg-secondary` `#151515` (4.95:1 or better). Chevrons are non-text UI, so they are held to 3:1 rather than 4.5:1.

## Scope and testing

CSS only, one file. No layout change, no markup change, no behaviour change: `.locked` / `.disabled` still hide the chevron and still block interaction via `cursor` and `pointer-events`.

`npm test` on this branch: **83 suites, 2254 tests, all passing**. `npm run build:renderer` regenerates `dist/styles.bundle.css` cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
