### PR TITLE
fix(events): route hook events by session id, not by project

### DIFF
--- a/src/renderer/events/ClaudeEventBus.js
+++ b/src/renderer/events/ClaudeEventBus.js
@@ -46,7 +46,7 @@ class ClaudeEventBus {
    * Emit a normalized event to all listeners.
    * @param {string} type - Event type from EVENT_TYPES
    * @param {Object} data - Event-specific data
-   * @param {Object} meta - { projectId, projectPath, source }
+   * @param {Object} meta - { projectId, projectPath, sessionId, source }
    */
   emit(type, data = {}, meta = {}) {
     const envelope = {
@@ -54,6 +54,10 @@ class ClaudeEventBus {
       timestamp: Date.now(),
       projectId: meta.projectId || null,
       projectPath: meta.projectPath || null,
+      // Which Claude produced this, not just where it ran. Several sessions share
+      // a project - a chat tab, a PTY tab, a workflow node, a `claude` outside the
+      // app - and only this tells them apart. See SessionRouter.
+      sessionId: meta.sessionId || null,
       source: meta.source || 'unknown',
       data
     };

--- a/src/renderer/events/HooksProvider.js
+++ b/src/renderer/events/HooksProvider.js
@@ -26,25 +26,33 @@ function normalizePath(p) {
 
 /**
  * Resolve projectId from a cwd path by matching against known projects.
+ *
+ * The match is on whole path segments, so `/w/api` no longer captures the events
+ * of `/w/api-legacy`, and the deepest match wins so a project nested inside
+ * another gets its own events rather than its parent's.
+ *
  * @param {string} cwd
  * @returns {{ projectId: string|null, projectPath: string }}
  */
 function resolveProject(cwd) {
   if (!cwd) return { projectId: null, projectPath: '' };
   const normalized = normalizePath(cwd);
+  let best = null;
   try {
     const { projectsState } = require('../state/projects.state');
     const projects = projectsState.get().projects || [];
     for (const p of projects) {
       const pPath = normalizePath(p.path);
-      if (pPath && normalized.startsWith(pPath)) {
-        return { projectId: p.id, projectPath: pPath };
+      if (!pPath) continue;
+      if (normalized !== pPath && !normalized.startsWith(pPath + '/')) continue;
+      if (!best || pPath.length > best.projectPath.length) {
+        best = { projectId: p.id, projectPath: pPath };
       }
     }
   } catch (e) {
     console.error('[HooksProvider] Failed to resolve project — hook events may be lost:', e);
   }
-  return { projectId: null, projectPath: normalized };
+  return best || { projectId: null, projectPath: normalized };
 }
 
 /**
@@ -55,7 +63,7 @@ function ensureSession(cwd, meta) {
   const key = normalizePath(cwd);
   if (!sessions.has(key)) {
     sessions.set(key, { active: true, startTime: Date.now() });
-    eventBus.emit(EVENT_TYPES.SESSION_START, { sessionId: null, model: null, synthetic: true }, meta);
+    eventBus.emit(EVENT_TYPES.SESSION_START, { sessionId: meta.sessionId || null, model: null, synthetic: true }, meta);
   }
 }
 
@@ -84,7 +92,9 @@ function handleHookEvent(raw) {
   const hookName = raw.hook;
   const stdin = raw.stdin || {};
   const cwd = raw.cwd || stdin.cwd || null;
-  const meta = { ...resolveProject(cwd), source: 'hooks' };
+  // session_id is what makes an event routable to one tab; cwd only narrows it to
+  // a project, which several unrelated Claudes can share at once.
+  const meta = { ...resolveProject(cwd), sessionId: stdin.session_id || null, source: 'hooks' };
 
   // Skip events from non-project sessions (e.g. /usage monitor, home dir)
   if (!meta.projectId) {

--- a/src/renderer/events/SessionRouter.js
+++ b/src/renderer/events/SessionRouter.js
@@ -1,0 +1,140 @@
+/**
+ * SessionRouter - maps a Claude session id onto the tab that owns it.
+ *
+ * A hook event carries a cwd and a session id, nothing else. Resolving it by cwd
+ * alone lands every event of a project on one arbitrary tab, so an idle tab lights
+ * up whenever anything else runs in the same folder: a chat tab (the Agent SDK
+ * loads the same ~/.claude/settings.json hooks), a workflow node, a `claude`
+ * started outside the app, a worktree checked out under the project.
+ *
+ * So routing goes through the session id instead:
+ *
+ *   1. a tab already carrying that id wins. Chat tabs get theirs from the SDK
+ *      `init` message and resumed terminal tabs at creation, so this is a fact,
+ *      not a guess - and it repairs a binding adopted earlier by mistake.
+ *   2. otherwise the live binding, if its tab is still open.
+ *   3. otherwise adopt, but only an unambiguous candidate, and only when the
+ *      caller allows it.
+ *
+ * When none of the three answers, the event is dropped. A tab badge that lies
+ * about what the app is doing is worse than a badge that misses one event.
+ */
+
+// sessionId -> terminal id. One entry per *live* session, released when that
+// session ends. Deliberately not the same thing as `td.claudeSessionId`, which is
+// a durable "resume this conversation" pointer and outlives the process that
+// wrote it - a tab keeps it long after its Claude exited.
+const bindings = new Map();
+
+/**
+ * @returns {Map<any, Object>} live terminal entries, keyed by tab id
+ */
+function terminals() {
+  try {
+    return require('../state/terminals.state').terminalsState.get().terminals;
+  } catch (e) {
+    return new Map();
+  }
+}
+
+/**
+ * The tab that already advertises this session id, if any.
+ * @param {string} sessionId
+ * @returns {any|null} terminal id
+ */
+function tabCarrying(sessionId) {
+  for (const [id, td] of terminals()) {
+    if (td && td.claudeSessionId === sessionId) return id;
+  }
+  return null;
+}
+
+/**
+ * Claude terminal tabs of a project that no live session has claimed yet.
+ *
+ * Chat tabs are excluded on purpose: the SDK hands them their session id, so they
+ * are always found by rule 1 and must never be adopted on a hunch. That exclusion
+ * is also what used to misroute them - it is only safe now that failing to adopt
+ * means "drop the event" rather than "fall back to a terminal tab".
+ *
+ * @param {string} projectId
+ * @returns {any[]} terminal ids
+ */
+function adoptable(projectId) {
+  const taken = new Set(bindings.values());
+  const out = [];
+  for (const [id, td] of terminals()) {
+    if (!td || td.project?.id !== projectId) continue;
+    if (td.mode !== 'terminal' || td.isBasic) continue;
+    if (taken.has(id)) continue;
+    out.push(id);
+  }
+  return out;
+}
+
+/**
+ * Forget bindings whose tab has been closed.
+ */
+function pruneClosed() {
+  const live = terminals();
+  for (const [sessionId, terminalId] of bindings) {
+    if (!live.has(terminalId)) bindings.delete(sessionId);
+  }
+}
+
+/**
+ * Resolve a session id to the tab that owns it.
+ *
+ * @param {string} sessionId - Claude session id from the hook payload
+ * @param {Object} [opts]
+ * @param {string} [opts.projectId] - required for adoption
+ * @param {boolean} [opts.adopt=false] - allow claiming an unbound tab
+ * @param {any} [opts.prefer] - tab to favour when several are adoptable
+ *   (the last-focused one: the tab the user just launched `claude` in)
+ * @returns {any|null} terminal id, or null when it cannot be known
+ */
+function resolve(sessionId, { projectId = null, adopt = false, prefer = null } = {}) {
+  if (!sessionId) return null;
+
+  const carrier = tabCarrying(sessionId);
+  if (carrier !== null) {
+    bindings.set(sessionId, carrier);
+    return carrier;
+  }
+
+  if (bindings.has(sessionId)) {
+    const bound = bindings.get(sessionId);
+    if (terminals().has(bound)) return bound;
+    bindings.delete(sessionId);
+  }
+
+  if (!adopt || !projectId) return null;
+
+  pruneClosed();
+  const candidates = adoptable(projectId);
+  // Several candidates and no hint: refuse. Picking one is precisely the bug.
+  const picked = (prefer !== null && candidates.includes(prefer))
+    ? prefer
+    : (candidates.length === 1 ? candidates[0] : null);
+  if (picked === null) return null;
+
+  bindings.set(sessionId, picked);
+  return picked;
+}
+
+/**
+ * Release a session that has ended, so its tab can host the next one.
+ * @param {string} sessionId
+ */
+function release(sessionId) {
+  if (sessionId) bindings.delete(sessionId);
+}
+
+/**
+ * Drop all bindings (provider switch, tests).
+ */
+function reset() {
+  bindings.clear();
+}
+
+module.exports = { resolve, release, reset };

--- a/src/renderer/events/index.js
+++ b/src/renderer/events/index.js
@@ -7,6 +7,7 @@
 const { eventBus, EVENT_TYPES } = require('./ClaudeEventBus');
 const HooksProvider = require('./HooksProvider');
 const ScrapingProvider = require('./ScrapingProvider');
+const SessionRouter = require('./SessionRouter');
 
 let activeProvider = null; // 'hooks' | 'scraping'
 let consumerUnsubscribers = [];
@@ -33,6 +34,33 @@ const SESSION_END_DEDUP_MS = 4000;
 // ── Last-active Claude tab tracking (for multi-tab session ID capture) ──
 // projectId -> terminalId (the tab that was most recently focused)
 const lastActiveClaudeTab = new Map();
+
+// ── Stuck-'working' watchdog (hooks-only) ──
+// The badge only drops back to 'ready' on Stop/SessionEnd. A Claude killed with
+// SIGKILL, a worktree removed mid-run, or a machine put to sleep never sends one,
+// and the tab pulses for the rest of the app's life. Any further hook traffic on
+// the session rearms this, so a single tool call running for half an hour is safe.
+const HOOK_IDLE_TIMEOUT_MS = 10 * 60 * 1000;
+const idleWatchdogs = new Map(); // terminalId -> timeout handle
+
+function clearIdleWatchdog(terminalId) {
+  const handle = idleWatchdogs.get(terminalId);
+  if (handle) {
+    clearTimeout(handle);
+    idleWatchdogs.delete(terminalId);
+  }
+}
+
+function armIdleWatchdog(terminalId, setStatus) {
+  clearIdleWatchdog(terminalId);
+  idleWatchdogs.set(terminalId, setTimeout(() => {
+    idleWatchdogs.delete(terminalId);
+    try {
+      const { getTerminal } = require('../state/terminals.state');
+      if (getTerminal(terminalId)?.status === 'working') setStatus(terminalId, 'ready');
+    } catch (e) { /* state not ready */ }
+  }, HOOK_IDLE_TIMEOUT_MS));
+}
 
 // ── Consumer: Time Tracking (hooks-only — scraping uses existing direct calls in TerminalManager) ──
 function wireTimeTrackingConsumer() {
@@ -121,7 +149,7 @@ function wireNotificationConsumer() {
       // never accumulates stale data across sessions (bounded to one entry per project).
       const ctx = sessionContext.get(e.projectId);
 
-      const terminalId = resolveTerminalId(e.projectId);
+      const terminalId = resolveTerminalId(e.projectId, e.sessionId);
       const projectName = resolveProjectName(e.projectId);
 
       const body = (ctx && ctx.toolCount > 0)
@@ -152,7 +180,7 @@ function wireNotificationConsumer() {
       const title = e.data?.title || 'Claude';
       const body = e.data?.message || '';
       if (!body) return;
-      const terminalId = resolveTerminalId(e.projectId);
+      const terminalId = resolveTerminalId(e.projectId, e.sessionId);
       if (notificationFn) {
         notificationFn('info', title, body, terminalId);
       }
@@ -198,9 +226,19 @@ function resolveProjectName(projectId) {
 }
 
 /**
- * Try to find an active terminal for a project so notification click can switch to it.
+ * Best tab to focus when the notification for an event is clicked.
+ *
+ * Exact when the session is known. Otherwise any tab of the project, which is a
+ * small miss: a notification landing on a neighbouring tab of the same project
+ * is a navigation shortcut that fell short, not a claim about what that tab is
+ * doing. Status has no such licence — see wireTerminalStatusConsumer.
+ *
+ * @param {string} projectId
+ * @param {string|null} [sessionId]
  */
-function resolveTerminalId(projectId) {
+function resolveTerminalId(projectId, sessionId = null) {
+  const exact = sessionId ? SessionRouter.resolve(sessionId, { projectId }) : null;
+  if (exact !== null) return exact;
   if (!projectId) return null;
   // Prefer the most recent real Claude terminal (same heuristic as session-id capture),
   // so a notification click lands on the tab that actually finished — not an old/basic one.
@@ -295,7 +333,7 @@ function wireAttentionConsumer() {
       if (!shouldNotify(e.projectId)) return;
 
       const projectName = resolveProjectName(e.projectId);
-      const terminalId = resolveTerminalId(e.projectId);
+      const terminalId = resolveTerminalId(e.projectId, e.sessionId);
 
       // AskUserQuestion: build interactive answer buttons from Claude's options
       // SDK structure: toolInput.questions[0].question + toolInput.questions[0].options[].label
@@ -349,7 +387,7 @@ function wireAttentionConsumer() {
       }
 
       const projectName = resolveProjectName(e.projectId);
-      const terminalId = resolveTerminalId(e.projectId);
+      const terminalId = resolveTerminalId(e.projectId, e.sessionId);
       const tool = e.data?.tool || null;
 
       const body = tool
@@ -391,28 +429,65 @@ function wireAttentionConsumer() {
 // ── Consumer: Terminal Tab Status (hooks-only — forces tab status from hook events) ──
 // When hooks are active, the scraping-based status detection may be slow (debounce).
 // This consumer provides instant tab status updates from hooks.
+//
+// Routing is by session id, never by project. Resolving by project put every event
+// of a folder on one arbitrary tab, so an idle tab started pulsing whenever
+// anything else ran there — a chat tab, a workflow node, a `claude` outside the
+// app. An event whose session cannot be tied to a tab is dropped instead.
 function wireTerminalStatusConsumer() {
+  const setStatus = (terminalId, status) => {
+    try {
+      const TerminalManager = require('../ui/components/TerminalManager');
+      TerminalManager.updateTerminalStatus(terminalId, status);
+    } catch (err) { /* TerminalManager not ready */ }
+  };
+
+  /**
+   * The PTY tab this event belongs to, or null if that cannot be established.
+   * Chat tabs are filtered out: they drive their badge from the SDK stream
+   * (ChatView.onStatusChange), which is finer-grained than the hooks and already
+   * distinguishes thinking from tool calls.
+   */
+  const terminalTab = (e, { adopt }) => {
+    if (e.source !== 'hooks' || !e.projectId || !e.sessionId) return null;
+    const terminalId = SessionRouter.resolve(e.sessionId, {
+      projectId: e.projectId,
+      adopt,
+      prefer: lastActiveClaudeTab.get(e.projectId) ?? null
+    });
+    if (terminalId === null) return null;
+    try {
+      const { getTerminal } = require('../state/terminals.state');
+      const td = getTerminal(terminalId);
+      return td && td.mode === 'terminal' ? terminalId : null;
+    } catch (err) { return null; }
+  };
+
   consumerUnsubscribers.push(
     // Claude working → set tab to 'working'
     eventBus.on(EVENT_TYPES.CLAUDE_WORKING, (e) => {
-      if (e.source !== 'hooks' || !e.projectId) return;
-      const terminalId = resolveTerminalId(e.projectId);
-      if (!terminalId) return;
-      try {
-        const TerminalManager = require('../ui/components/TerminalManager');
-        TerminalManager.updateTerminalStatus(terminalId, 'working');
-      } catch (err) { /* TerminalManager not ready */ }
+      const terminalId = terminalTab(e, { adopt: true });
+      if (terminalId === null) return;
+      setStatus(terminalId, 'working');
+      armIdleWatchdog(terminalId, setStatus);
+    }),
+
+    // Still alive: one tool call can run for minutes without another status event,
+    // so its completion is what keeps the watchdog from firing mid-work.
+    eventBus.on(EVENT_TYPES.TOOL_END, (e) => {
+      const terminalId = terminalTab(e, { adopt: false });
+      if (terminalId !== null && idleWatchdogs.has(terminalId)) armIdleWatchdog(terminalId, setStatus);
     }),
 
     // Session end (Stop/SessionEnd) → set tab to 'ready'
     eventBus.on(EVENT_TYPES.SESSION_END, (e) => {
-      if (e.source !== 'hooks' || !e.projectId) return;
-      const terminalId = resolveTerminalId(e.projectId);
-      if (!terminalId) return;
-      try {
-        const TerminalManager = require('../ui/components/TerminalManager');
-        TerminalManager.updateTerminalStatus(terminalId, 'ready');
-      } catch (err) { /* TerminalManager not ready */ }
+      const terminalId = terminalTab(e, { adopt: false });
+      // 'stop' fires after every turn; only 'end' means the process is gone and
+      // its tab is free to host the next session.
+      if (e.sessionId && e.data?.reason === 'end') SessionRouter.release(e.sessionId);
+      if (terminalId === null) return;
+      clearIdleWatchdog(terminalId);
+      setStatus(terminalId, 'ready');
     }),
 
     // PreCompact → show compacting notification for terminal-mode projects
@@ -421,7 +496,7 @@ function wireTerminalStatusConsumer() {
       const projectName = resolveProjectName(e.projectId);
       if (notificationFn) {
         const { t } = require('../i18n');
-        notificationFn('info', projectName || 'Claude Terminal', t('chat.compacting') || 'Compacting conversation...', resolveTerminalId(e.projectId));
+        notificationFn('info', projectName || 'Claude Terminal', t('chat.compacting') || 'Compacting conversation...', resolveTerminalId(e.projectId, e.sessionId));
       }
     })
   );
@@ -452,7 +527,10 @@ function wireTabRenameConsumer() {
       if (!prompt || !prompt.trimStart().startsWith('/')) return;
       const { getSetting } = require('../state/settings.state');
       if (!getSetting('tabRenameOnSlashCommand')) return;
-      const terminalId = lastActiveClaudeTab.get(e.projectId) ?? findClaudeTerminalForProject(e.projectId);
+      // Session first: a /command typed in one tab must not rename another.
+      const terminalId = (e.sessionId ? SessionRouter.resolve(e.sessionId, { projectId: e.projectId }) : null)
+        ?? lastActiveClaudeTab.get(e.projectId)
+        ?? findClaudeTerminalForProject(e.projectId);
       if (!terminalId) return;
       const name = prompt.length > MAX_TAB_NAME_LEN
         ? prompt.slice(0, MAX_TAB_NAME_LEN - 1) + '\u2026'
@@ -666,6 +744,9 @@ function activateProvider(mode) {
 function deactivateProvider() {
   if (activeProvider === 'hooks') {
     HooksProvider.stop();
+    // No more hook traffic to rearm them, and no more Stop to clear them.
+    for (const terminalId of [...idleWatchdogs.keys()]) clearIdleWatchdog(terminalId);
+    SessionRouter.reset();
   } else if (activeProvider === 'scraping') {
     ScrapingProvider.stop();
   }
@@ -673,19 +754,33 @@ function deactivateProvider() {
 }
 
 // ── Consumer: Session ID Capture (hooks-only — captures Claude session IDs for resume) ──
+// A PTY tab has no way to learn the id of the `claude` it launched, so it is
+// adopted from the SessionStart hook. Deferred by a beat because the SDK announces
+// a chat session's id on its own `init` message: if that lands first the session is
+// already spoken for, and no PTY tab should claim it. Only the resume pointer is
+// delayed here, nothing the user can see.
+const SESSION_ADOPT_DELAY_MS = 1200;
+
 function wireSessionIdCapture() {
   consumerUnsubscribers.push(
     eventBus.on(EVENT_TYPES.SESSION_START, (e) => {
       if (e.source !== 'hooks') return;
-      if (!e.data?.sessionId) return;
-      if (!e.projectId) return;
-      const terminalId = findClaudeTerminalForProject(e.projectId);
-      if (!terminalId) return;
-      const { updateTerminal } = require('../state/terminals.state');
-      updateTerminal(terminalId, { claudeSessionId: e.data.sessionId });
-      const TerminalSessionService = require('../services/TerminalSessionService');
-      TerminalSessionService.saveTerminalSessions();
-      console.debug(`[Events] Captured session ID ${e.data.sessionId} for terminal ${terminalId}`);
+      const sessionId = e.data?.sessionId || e.sessionId;
+      if (!sessionId || !e.projectId) return;
+      const prefer = lastActiveClaudeTab.get(e.projectId) ?? null;
+      setTimeout(() => {
+        const terminalId = SessionRouter.resolve(sessionId, { projectId: e.projectId, adopt: true, prefer });
+        if (terminalId === null) return;
+        const { getTerminal, updateTerminal } = require('../state/terminals.state');
+        const td = getTerminal(terminalId);
+        // Never write over a chat tab: its id comes from the SDK, and repointing it
+        // would aim that tab's Resume at somebody else's conversation.
+        if (!td || td.mode !== 'terminal' || td.claudeSessionId === sessionId) return;
+        updateTerminal(terminalId, { claudeSessionId: sessionId });
+        const TerminalSessionService = require('../services/TerminalSessionService');
+        TerminalSessionService.saveTerminalSessions();
+        console.debug(`[Events] Captured session ID ${sessionId} for terminal ${terminalId}`);
+      }, SESSION_ADOPT_DELAY_MS);
     })
   );
 }

--- a/tests/events/hookSessionRouting.test.js
+++ b/tests/events/hookSessionRouting.test.js
@@ -1,0 +1,166 @@
+/**
+ * Hook events must reach the tab that produced them.
+ *
+ * A hook payload only says *where* Claude ran (cwd) and *which* Claude it was
+ * (session_id). Routing on cwd alone made every session of a project land on one
+ * arbitrary tab, so an idle tab pulsed 'working' whenever a chat tab, a workflow
+ * node or a `claude` outside the app touched the same folder.
+ */
+
+const SessionRouter = require('../../src/renderer/events/SessionRouter');
+const HooksProvider = require('../../src/renderer/events/HooksProvider');
+const { eventBus, EVENT_TYPES } = require('../../src/renderer/events/ClaudeEventBus');
+const { addTerminal, clearAllTerminals } = require('../../src/renderer/state/terminals.state');
+const { projectsState } = require('../../src/renderer/state/projects.state');
+
+function tab(id, { projectId, mode = 'terminal', claudeSessionId = null, isBasic = false } = {}) {
+  return {
+    id,
+    tabId: `tab_${id}`,
+    project: { id: projectId, name: projectId, path: `/w/${projectId}` },
+    mode,
+    isBasic,
+    status: 'ready',
+    claudeSessionId
+  };
+}
+
+function setProjects(projects) {
+  projectsState.set({ ...projectsState.get(), projects });
+}
+
+describe('SessionRouter', () => {
+  beforeEach(() => {
+    clearAllTerminals();
+    SessionRouter.reset();
+  });
+
+  it('gives the session to the tab that carries its id, chat tabs included', () => {
+    addTerminal(1, tab(1, { projectId: 'p1' }));
+    addTerminal(2, tab(2, { projectId: 'p1', mode: 'chat', claudeSessionId: 'sess-chat' }));
+
+    expect(SessionRouter.resolve('sess-chat', { projectId: 'p1', adopt: true })).toBe(2);
+  });
+
+  it('refuses to adopt when several terminal tabs could be the one', () => {
+    addTerminal(1, tab(1, { projectId: 'p1' }));
+    addTerminal(2, tab(2, { projectId: 'p1' }));
+
+    expect(SessionRouter.resolve('sess-unknown', { projectId: 'p1', adopt: true })).toBeNull();
+  });
+
+  it('adopts the last-focused tab when one is nominated', () => {
+    addTerminal(1, tab(1, { projectId: 'p1' }));
+    addTerminal(2, tab(2, { projectId: 'p1' }));
+
+    expect(SessionRouter.resolve('sess-a', { projectId: 'p1', adopt: true, prefer: 1 })).toBe(1);
+    // and stays there without the hint on later events
+    expect(SessionRouter.resolve('sess-a', { projectId: 'p1' })).toBe(1);
+  });
+
+  it('adopts the only candidate, and never that same tab twice', () => {
+    addTerminal(1, tab(1, { projectId: 'p1' }));
+
+    expect(SessionRouter.resolve('sess-a', { projectId: 'p1', adopt: true })).toBe(1);
+    // A second Claude in the same folder — a workflow node, an external CLI —
+    // must not inherit the tab that is already busy with someone else.
+    expect(SessionRouter.resolve('sess-b', { projectId: 'p1', adopt: true })).toBeNull();
+  });
+
+  it('frees the tab once its session ends', () => {
+    addTerminal(1, tab(1, { projectId: 'p1' }));
+
+    expect(SessionRouter.resolve('sess-a', { projectId: 'p1', adopt: true })).toBe(1);
+    SessionRouter.release('sess-a');
+    expect(SessionRouter.resolve('sess-b', { projectId: 'p1', adopt: true })).toBe(1);
+  });
+
+  it('drops an unknown session rather than guessing', () => {
+    addTerminal(1, tab(1, { projectId: 'p1' }));
+
+    expect(SessionRouter.resolve('sess-unknown', { projectId: 'p1' })).toBeNull();
+  });
+
+  it('ignores basic shell tabs and other projects', () => {
+    addTerminal(1, tab(1, { projectId: 'p1', isBasic: true }));
+    addTerminal(2, tab(2, { projectId: 'p2' }));
+
+    expect(SessionRouter.resolve('sess-a', { projectId: 'p1', adopt: true })).toBeNull();
+  });
+
+  it('repairs a binding once the real owner announces itself', () => {
+    addTerminal(1, tab(1, { projectId: 'p1' }));
+    expect(SessionRouter.resolve('sess-a', { projectId: 'p1', adopt: true })).toBe(1);
+
+    // The SDK hands the chat tab its id a beat later.
+    addTerminal(2, tab(2, { projectId: 'p1', mode: 'chat', claudeSessionId: 'sess-a' }));
+    expect(SessionRouter.resolve('sess-a', { projectId: 'p1' })).toBe(2);
+  });
+});
+
+describe('HooksProvider event routing', () => {
+  let emit;
+  let seen;
+
+  beforeEach(() => {
+    clearAllTerminals();
+    SessionRouter.reset();
+    seen = [];
+    emit = eventBus.on('*', (e) => seen.push(e));
+
+    window.electron_api.hooks = {
+      onEvent: (cb) => { window.__hookCb = cb; return () => {}; }
+    };
+    HooksProvider.start();
+  });
+
+  afterEach(() => {
+    emit();
+    HooksProvider.stop();
+    delete window.__hookCb;
+  });
+
+  function fire(raw) {
+    window.__hookCb(raw);
+  }
+
+  it('carries the session id through to consumers', () => {
+    setProjects([{ id: 'p1', name: 'p1', path: '/w/api' }]);
+    addTerminal(1, tab(1, { projectId: 'p1' }));
+
+    fire({ hook: 'PreToolUse', stdin: { session_id: 'sess-a', tool_name: 'Bash' }, cwd: '/w/api' });
+
+    const working = seen.find(e => e.type === EVENT_TYPES.CLAUDE_WORKING);
+    expect(working).toBeDefined();
+    expect(working.sessionId).toBe('sess-a');
+    expect(working.projectId).toBe('p1');
+  });
+
+  it('matches on whole path segments, not on a shared prefix', () => {
+    setProjects([
+      { id: 'api', name: 'api', path: '/w/api' },
+      { id: 'api-legacy', name: 'api-legacy', path: '/w/api-legacy' }
+    ]);
+    addTerminal(1, tab(1, { projectId: 'api' }));
+    addTerminal(2, tab(2, { projectId: 'api-legacy' }));
+
+    fire({ hook: 'PreToolUse', stdin: { session_id: 'sess-a', tool_name: 'Bash' }, cwd: '/w/api-legacy/src' });
+
+    const working = seen.find(e => e.type === EVENT_TYPES.CLAUDE_WORKING);
+    expect(working.projectId).toBe('api-legacy');
+  });
+
+  it('gives a nested project its own events instead of its parent\'s', () => {
+    setProjects([
+      { id: 'mono', name: 'mono', path: '/w/mono' },
+      { id: 'pkg', name: 'pkg', path: '/w/mono/packages/ui' }
+    ]);
+    addTerminal(1, tab(1, { projectId: 'mono' }));
+    addTerminal(2, tab(2, { projectId: 'pkg' }));
+
+    fire({ hook: 'PreToolUse', stdin: { session_id: 'sess-a', tool_name: 'Read' }, cwd: '/w/mono/packages/ui' });
+
+    const working = seen.find(e => e.type === EVENT_TYPES.CLAUDE_WORKING);
+    expect(working.projectId).toBe('pkg');
+  });
+});


### PR DESCRIPTION
Fixes #110.

An idle tab starts pulsing orange while nothing runs in it — most visibly while you work in a chat tab of the same project.

## What was wrong

A hook payload says **where** Claude ran (`cwd`) and **which** Claude it was (`stdin.session_id`). We dropped the second and resolved on the first, so every event of a project landed on `findClaudeTerminalForProject()` — the highest-numbered non-basic terminal tab, whatever it happened to be doing.

Everything that runs Claude inside a project folder therefore lit up that one tab:

- a **chat tab** — `ChatService` starts SDK sessions with `settingSources: ['user', 'project', 'local']`, so the same `~/.claude/settings.json` hooks fire, and the consumer bounces them onto a *terminal* tab because chat tabs are excluded from the candidate list;
- a workflow `claude` node, a `claude` started from a shell outside the app, a worktree checked out under the project;
- a second terminal tab of the same project — the older one working lights up the newer one.

## What it does now

New `src/renderer/events/SessionRouter.js` maps a session id onto the tab that owns it:

1. **a tab already carrying that id wins** — chat tabs get theirs from the SDK `init` message, resumed terminal tabs at creation. This is a fact, not a heuristic, and it also repairs a binding adopted earlier by mistake;
2. otherwise the live binding, if its tab is still open;
3. otherwise adopt — but only an unambiguous candidate (the single Claude terminal tab of the project, or the last-focused one).

An event that answers to none of the three is **dropped**. A badge that lies about what a tab is doing is worse than a badge that misses an event. Notifications keep the project-wide fallback on purpose: landing on a neighbouring tab of the same project is a navigation shortcut that fell short, not a false claim.

`ClaudeEventBus` now carries `sessionId` on the envelope; `HooksProvider` fills it from `stdin.session_id`.

## Three more defects on the same path

- **`resolveProject` matched a raw prefix** — project `/w/api` captured the events of `/w/api-legacy`, and the first project in the list won over a nested one. Now matches whole segments, deepest wins.
- **`wireSessionIdCapture` overwrote `claudeSessionId`** on the guessed tab, repointing its Resume at a conversation never held in it. It now adopts through the router, never writes over a chat tab, and defers 1.2 s so the SDK can claim its own session first (only the resume pointer is delayed — nothing user-visible).
- **The badge only fell back to `ready` on `Stop`/`SessionEnd`**, which a SIGKILLed Claude never sends, so the tab pulsed for the rest of the app's life. A 10 min silence watchdog releases it, rearmed by any hook traffic on that session (`TOOL_END` included, so a single long tool call is safe).

## Tests

`tests/events/hookSessionRouting.test.js`, 11 cases: carrier wins over adoption (chat tabs included), adoption refuses an ambiguous project, honours the last-focused hint, never hands the same tab to a second session, releases on session end, ignores basic and foreign-project tabs, repairs a mistaken binding — plus three end-to-end through `HooksProvider` covering the session id reaching consumers, the `api` / `api-legacy` prefix, and a nested project.

Full suite: **84 suites, 2265 tests, all passing**. `npm run build:renderer` clean.

## Verifying by hand

With hooks enabled, open a chat tab and a terminal tab on the same project, then work in the chat. Before: the terminal tab pulses orange on every tool call. After: it stays idle, and the chat tab keeps its own finer-grained badge from the SDK stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
