### PR TITLE
fix(chat): read the task id TaskCreate reports so the todo bar advances

### DIFF
--- a/src/renderer/ui/components/ChatView.js
+++ b/src/renderer/ui/components/ChatView.js
@@ -64,6 +64,20 @@ function parseResultJson(text) {
   try { return JSON.parse(trimmed); } catch (_) { return null; }
 }
 
+// TaskCreate answers with a plain sentence — "Task #3 created successfully: <subject>" —
+// not JSON. The id it hands back is the one every later TaskUpdate addresses, so failing
+// to read it leaves the task filed under its tool_use_id and freezes the bar at 0/N.
+const TASK_CREATED_RE = /task\s*#?\s*([A-Za-z0-9_-]+)\s+created/i;
+
+/** @returns {string|null} The task id a TaskCreate result reports, JSON or prose. */
+function parseCreatedTaskId(text) {
+  const parsed = parseResultJson(text);
+  const jsonId = parsed?.task?.id ?? parsed?.taskId ?? parsed?.id;
+  if (jsonId != null) return String(jsonId);
+  const match = TASK_CREATED_RE.exec(text || '');
+  return match ? match[1] : null;
+}
+
 // ── Wakeup countdown ticker (module-level, single global interval) ──
 // Runs only while a wakeup card is actually on screen. The first version armed
 // the interval on the first ScheduleWakeup of the session and then ticked for
@@ -415,7 +429,10 @@ class ChatView extends BaseComponent {
   // ── Task tool accumulator (SDK 0.3+ TaskCreate / TaskUpdate / TaskList) ──
   const tasksMap = new Map(); // taskId -> { id, subject, description, activeForm, status, order }
   const pendingCreateByUseId = new Map(); // tool_use_id -> { subject, description, activeForm, order }
+  const taskIdByUseId = new Map(); // tool_use_id -> real task id, once the result promoted it
+  const pendingTaskUpdates = new Map(); // task id -> patch held until its create is promoted
   let taskOrderCounter = 0;
+  let taskRenderSuspended = false; // batches the widget render during a history replay
   let slashCommands = []; // populated from system/init message
   let slashSelectedIndex = -1; // currently highlighted item in slash dropdown
   // Accumulates messages for CLAUDE.md analysis (role: 'user'|'assistant', content: string)
@@ -4638,36 +4655,52 @@ class ChatView extends BaseComponent {
 
   function applyTaskCreate(input, toolUseId) {
     if (!input || !input.subject) return;
-    pendingCreateByUseId.set(toolUseId, {
-      subject: input.subject,
-      description: input.description || '',
-      activeForm: input.activeForm || '',
-      order: ++taskOrderCounter,
-    });
+    // Every TaskCreate is seen twice — once from the stream (content_block_stop) and
+    // once from the full assistant message. Keying off the tool_use_id (or the real id
+    // it was promoted to) makes the second pass an update, not a duplicate row with a
+    // second slot in the ordering.
+    const key = taskIdByUseId.get(toolUseId) || toolUseId;
+    const existing = tasksMap.get(key);
+    const order = existing ? existing.order : ++taskOrderCounter;
+    if (!taskIdByUseId.has(toolUseId)) {
+      pendingCreateByUseId.set(toolUseId, {
+        subject: input.subject,
+        description: input.description || '',
+        activeForm: input.activeForm || '',
+        order,
+      });
+    }
     // Optimistic render with temp id (tool_use_id) so the widget updates immediately;
     // it'll be replaced with the real task id when the tool_result arrives.
-    tasksMap.set(toolUseId, {
-      id: toolUseId,
+    tasksMap.set(key, {
+      id: key,
       subject: input.subject,
       description: input.description || '',
       activeForm: input.activeForm || '',
-      status: 'pending',
-      order: taskOrderCounter,
-      _temp: true,
+      status: existing?.status || 'pending',
+      order,
+      _temp: key === toolUseId,
     });
     renderTasksWidget();
   }
 
   function applyTaskUpdate(input) {
-    if (!input || !input.taskId) return;
-    const task = tasksMap.get(input.taskId);
-    if (!task) return;
+    if (!input || input.taskId == null) return;
+    const id = String(input.taskId);
+    const task = tasksMap.get(id);
+    if (!task) {
+      // The matching create hasn't been promoted to its real id yet (its tool_result is
+      // still in flight, or arrived in a shape we couldn't read). Hold the patch and
+      // replay it on promotion — dropping it is what left the bar stuck at 0/N.
+      pendingTaskUpdates.set(id, { ...(pendingTaskUpdates.get(id) || {}), ...input });
+      return;
+    }
     if (input.subject != null) task.subject = input.subject;
     if (input.description != null) task.description = input.description;
     if (input.activeForm != null) task.activeForm = input.activeForm;
     if (input.status != null) {
       if (input.status === 'deleted') {
-        tasksMap.delete(input.taskId);
+        tasksMap.delete(id);
       } else {
         task.status = input.status;
       }
@@ -4677,16 +4710,18 @@ class ChatView extends BaseComponent {
 
   function promoteTaskCreateResult(toolUseId, taskId) {
     if (!toolUseId || !taskId) return;
+    const id = String(taskId);
     const pending = pendingCreateByUseId.get(toolUseId);
     pendingCreateByUseId.delete(toolUseId);
+    taskIdByUseId.set(toolUseId, id);
     // Move from temp tool_use_id key to real task id key
     const existing = tasksMap.get(toolUseId);
     if (existing) {
       tasksMap.delete(toolUseId);
-      tasksMap.set(taskId, { ...existing, id: taskId, _temp: false });
+      tasksMap.set(id, { ...existing, id, _temp: false });
     } else if (pending) {
-      tasksMap.set(taskId, {
-        id: taskId,
+      tasksMap.set(id, {
+        id,
         subject: pending.subject,
         description: pending.description,
         activeForm: pending.activeForm,
@@ -4694,12 +4729,27 @@ class ChatView extends BaseComponent {
         order: pending.order,
       });
     }
+    const held = pendingTaskUpdates.get(id);
+    if (held) {
+      pendingTaskUpdates.delete(id);
+      applyTaskUpdate(held); // renders
+      return;
+    }
     renderTasksWidget();
   }
 
   function renderTasksWidget() {
+    if (taskRenderSuspended) return;
     const tasks = getOrderedTasks();
-    if (!tasks.length) return;
+    if (!tasks.length) {
+      // Every task deleted — drop the bar rather than leave the last count standing
+      if (todoWidgetEl) {
+        todoWidgetEl.remove();
+        todoWidgetEl = null;
+        todoAllDone = false;
+      }
+      return;
+    }
 
     const completed = tasks.filter(td => td.status === 'completed').length;
     const active = tasks.find(td => td.status === 'in_progress');
@@ -4762,6 +4812,8 @@ class ChatView extends BaseComponent {
     if (!Array.isArray(todos) || !todos.length) return;
     tasksMap.clear();
     pendingCreateByUseId.clear();
+    taskIdByUseId.clear();
+    pendingTaskUpdates.clear();
     todos.forEach((todo, i) => {
       const id = `todo-${i}`;
       tasksMap.set(id, {
@@ -4774,6 +4826,35 @@ class ChatView extends BaseComponent {
       });
     });
     taskOrderCounter = Math.max(taskOrderCounter, todos.length);
+    renderTasksWidget();
+  }
+
+  /**
+   * Replay the Task tools of a resumed session so the bar opens on the plan the
+   * conversation left off at, instead of staying blank until the next TaskCreate.
+   * The history carries each create's result text, so ids promote exactly as live.
+   * @param {Array} messages One page of history, oldest first.
+   */
+  function hydrateTasksFromHistory(messages) {
+    taskRenderSuspended = true;
+    try {
+      for (const msg of messages) {
+        if (msg.role === 'assistant' && msg.type === 'tool_use') {
+          if (msg.toolName === 'TodoWrite' && msg.toolInput?.todos) {
+            updateTodoWidget(msg.toolInput.todos);
+          } else if (msg.toolName === 'TaskCreate' && msg.toolInput) {
+            applyTaskCreate(msg.toolInput, msg.toolUseId);
+          } else if (msg.toolName === 'TaskUpdate' && msg.toolInput) {
+            applyTaskUpdate(msg.toolInput);
+          }
+        } else if (msg.role === 'tool_result' && pendingCreateByUseId.has(msg.toolUseId)) {
+          const taskId = parseCreatedTaskId(msg.output || '');
+          if (taskId) promoteTaskCreateResult(msg.toolUseId, taskId);
+        }
+      }
+    } finally {
+      taskRenderSuspended = false;
+    }
     renderTasksWidget();
   }
 
@@ -5847,8 +5928,7 @@ class ChatView extends BaseComponent {
     if (block.tool_use_id && pendingCreateByUseId.has(block.tool_use_id)) {
       const raw = typeof block.content === 'string' ? block.content
         : Array.isArray(block.content) ? block.content.map(b => b.text || '').join('\n') : '';
-      const parsed = parseResultJson(raw);
-      const taskId = parsed?.task?.id;
+      const taskId = parseCreatedTaskId(raw);
       if (taskId) promoteTaskCreateResult(block.tool_use_id, taskId);
       return;
     }
@@ -6671,6 +6751,10 @@ class ChatView extends BaseComponent {
         return;
       }
 
+      // Only this first page seeds the bar: later pages are prepended *older*
+      // messages, whose creates and updates would land out of order.
+      hydrateTasksFromHistory(msgs);
+
       renderHistoryMessages(msgs, {
         onComplete: () => {
           syncHistoryTop(result, msgs.length);
@@ -7018,6 +7102,10 @@ class ChatView extends BaseComponent {
       toolInputBuffers.clear();
       todoToolIndices.clear();
       taskToolIndices.clear();
+      tasksMap.clear();
+      pendingCreateByUseId.clear();
+      taskIdByUseId.clear();
+      pendingTaskUpdates.clear();
       // Clean up parallel run widgets
       for (const [, w] of parallelRunWidgets) {
         if (typeof w.cleanup === 'function') w.cleanup();

--- a/tests/ui/chatTaskWidget.test.js
+++ b/tests/ui/chatTaskWidget.test.js
@@ -1,0 +1,139 @@
+/**
+ * Task bar (chat todo widget) — the SDK's TaskCreate/TaskUpdate accumulator.
+ *
+ * TaskCreate answers in prose ("Task #1 created successfully: ..."), so the id every
+ * later TaskUpdate addresses is only available there. Reading it wrong leaves the task
+ * filed under its tool_use_id and the bar frozen at 0/N for the whole session.
+ */
+
+/** api mock: `on*` captures its callback, everything else resolves to a bare success. */
+function makeApiMock(listeners) {
+  const ns = () => new Proxy({}, {
+    get: (_t, method) => (...args) => {
+      if (typeof method === 'string' && method.startsWith('on')) {
+        listeners[method] = args[0];
+        return () => {};
+      }
+      return Promise.resolve({ success: true, messages: [] });
+    }
+  });
+  return new Proxy({}, { get: () => ns() });
+}
+
+// jsdom ships no crypto.randomUUID; the send path tags each user message with one.
+let uuidSeq = 0;
+Object.defineProperty(global, 'crypto', {
+  value: { ...(global.crypto || {}), randomUUID: () => `uuid-${++uuidSeq}` },
+  configurable: true,
+});
+
+describe('chat task bar', () => {
+  let listeners, wrapper, view, sessionId;
+
+  /** Feed one SDK message through the same path the main process uses. */
+  const emit = (message) => listeners.onMessage({ sessionId, message });
+
+  const assistant = (content) => emit({ type: 'assistant', message: { role: 'assistant', content } });
+  const toolResult = (toolUseId, text) => emit({
+    type: 'user',
+    message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: toolUseId, content: text }] }
+  });
+
+  const createTask = (toolUseId, subject, id) => {
+    assistant([{ type: 'tool_use', id: toolUseId, name: 'TaskCreate', input: { subject } }]);
+    toolResult(toolUseId, `Task #${id} created successfully: ${subject}`);
+  };
+
+  const count = () => wrapper.querySelector('.chat-todo .td-count')?.textContent;
+  const rows = () => Array.from(wrapper.querySelectorAll('.chat-todo .td-row'));
+
+  beforeEach(async () => {
+    jest.resetModules();
+    listeners = {};
+    window.electron_api = makeApiMock(listeners);
+    document.body.innerHTML = '';
+    wrapper = document.createElement('div');
+    document.body.appendChild(wrapper);
+    const { createChatView } = require('../../src/renderer/ui/components/ChatView');
+    view = createChatView(wrapper, { id: 'p1', name: 'Test', path: '/tmp/test' });
+    // A real send opens the session, so the messages below carry the id the
+    // component filters on instead of bypassing that guard.
+    view.sendMessage('go');
+    await new Promise(r => setTimeout(r, 0));
+    sessionId = view.getSessionId();
+    expect(sessionId).toBeTruthy();
+  });
+
+  afterEach(() => {
+    try { view?.destroy?.(); } catch (_) { /* teardown is best effort */ }
+  });
+
+  it('ticks a task off when TaskUpdate completes it', () => {
+    createTask('toolu_a', 'First task', 1);
+    createTask('toolu_b', 'Second task', 2);
+    expect(count()).toBe('0/2');
+
+    assistant([{ type: 'tool_use', id: 'toolu_u1', name: 'TaskUpdate', input: { taskId: '1', status: 'completed' } }]);
+
+    expect(count()).toBe('1/2');
+    expect(rows()[0].classList.contains('td-completed')).toBe(true);
+  });
+
+  it('shows the active task while it runs', () => {
+    createTask('toolu_a', 'Build the thing', 1);
+    assistant([{ type: 'tool_use', id: 'toolu_u1', name: 'TaskUpdate', input: { taskId: '1', status: 'in_progress' } }]);
+
+    expect(rows()[0].classList.contains('td-in_progress')).toBe(true);
+  });
+
+  it('keeps one row per task when the create is seen twice', () => {
+    // The stream reports a tool_use at content_block_stop and the assistant message
+    // repeats it — the second pass must update the row, not add another one.
+    const block = { type: 'tool_use', id: 'toolu_a', name: 'TaskCreate', input: { subject: 'Only once' } };
+    assistant([block]);
+    assistant([block]);
+    toolResult('toolu_a', 'Task #1 created successfully: Only once');
+
+    expect(rows()).toHaveLength(1);
+    expect(count()).toBe('0/1');
+  });
+
+  it('replays an update that arrives before the create is promoted', () => {
+    // Out-of-order delivery: the update lands while the create's result is in flight.
+    assistant([{ type: 'tool_use', id: 'toolu_a', name: 'TaskCreate', input: { subject: 'Racy task' } }]);
+    assistant([{ type: 'tool_use', id: 'toolu_u1', name: 'TaskUpdate', input: { taskId: '7', status: 'completed' } }]);
+    expect(count()).toBe('0/1');
+
+    toolResult('toolu_a', 'Task #7 created successfully: Racy task');
+
+    expect(count()).toBe('1/1');
+  });
+
+  it('still promotes when the result comes back as JSON', () => {
+    assistant([{ type: 'tool_use', id: 'toolu_a', name: 'TaskCreate', input: { subject: 'JSON task' } }]);
+    toolResult('toolu_a', JSON.stringify({ task: { id: 42 } }));
+    assistant([{ type: 'tool_use', id: 'toolu_u1', name: 'TaskUpdate', input: { taskId: 42, status: 'completed' } }]);
+
+    expect(count()).toBe('1/1');
+  });
+
+  it('drops the bar once every task is deleted', () => {
+    createTask('toolu_a', 'Doomed', 1);
+    assistant([{ type: 'tool_use', id: 'toolu_u1', name: 'TaskUpdate', input: { taskId: '1', status: 'deleted' } }]);
+
+    expect(wrapper.querySelector('.chat-todo')).toBeNull();
+  });
+
+  it('renders a TodoWrite snapshot', () => {
+    assistant([{
+      type: 'tool_use', id: 'toolu_t', name: 'TodoWrite',
+      input: { todos: [
+        { content: 'One', status: 'completed' },
+        { content: 'Two', status: 'in_progress', activeForm: 'Doing two' },
+      ] }
+    }]);
+
+    expect(count()).toBe('1/2');
+    expect(rows()[1].textContent).toContain('Doing two');
+  });
+});


### PR DESCRIPTION
Fixes #113.

## The bug

The task bar above the composer showed the plan once and then sat at `0/N` for the whole session, while the agent worked through the tasks.

`TaskCreate` is rendered optimistically under its `tool_use_id`, and `promoteTaskCreateResult()` re-keys it onto the real task id when the result arrives. That promotion only read JSON:

```js
const parsed = parseResultJson(raw);
const taskId = parsed?.task?.id;
```

but the tool answers in prose — `Task #1 created successfully: <subject>` — so `parseResultJson()` bails on the first character and the id is always `undefined`. The task stays keyed by `toolu_01…`, and every later `TaskUpdate` (which addresses it as `"1"`) hits `if (!task) return;` and is dropped. Nothing ever changes status.

## The fix

`parseCreatedTaskId()` reads both shapes — the sentence and the JSON the old code expected — so the promotion runs and updates land.

Four related weaknesses in the same accumulator, each one a way for the bar to go stale again:

- **Updates were lost, not deferred.** A patch for a task that is not promoted yet is now held and replayed on promotion, instead of being dropped on the floor.
- **Each create was applied twice** (once from the stream, once from the full assistant message) and took a second slot in the ordering each time. The second pass now updates its row, keyed off the `tool_use_id`.
- **An emptied list left a stale bar.** Deleting the last task now removes the widget instead of leaving the previous count up.
- **A resumed session never rebuilt the bar.** The first page of history now replays its Task tools, so reopening a conversation opens on the plan it left off at. Only the first page: later pages are prepended *older* messages, whose creates and updates would land out of order.

## Tests

`tests/ui/chatTaskWidget.test.js` drives real SDK messages through the component's own `onMessage` path — a real send opens the session, so the messages carry the id the component filters on — and asserts on the rendered bar. Four of the seven fail on `main` with exactly the reported symptom.

```
✓ ticks a task off when TaskUpdate completes it
✓ shows the active task while it runs
✓ keeps one row per task when the create is seen twice
✓ replays an update that arrives before the create is promoted
✓ still promotes when the result comes back as JSON
✓ drops the bar once every task is deleted
✓ renders a TodoWrite snapshot
```

Full suite: 84 suites / 2261 tests green, `npm run build:renderer` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
