### PR TITLE
feat(artifacts): artifact library and per-conversation Documents tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,6 +104,14 @@
           </svg>
           <span data-i18n="ui.tabClaude">Claude</span>
         </button>
+        <button class="nav-tab" data-tab="artifacts" title="Artifacts" data-i18n-title="ui.tooltipArtifacts">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M12 2l8 4.5v9L12 20l-8-4.5v-9L12 2z"/>
+            <path d="M4 6.5l8 4.5 8-4.5"/>
+            <path d="M12 11v9"/>
+          </svg>
+          <span data-i18n="artifacts.tabTitle">Artifacts</span>
+        </button>
         <button class="nav-tab" data-tab="dashboard" title="Dashboard" data-i18n-title="ui.tooltipDashboard">
           <svg viewBox="0 0 24 24" fill="currentColor">
             <path d="M3 13h8V3H3v10zm0 8h8v-6H3v6zm10 0h8V11h-8v10zm0-18v6h8V3h-8z"/>
@@ -141,14 +149,6 @@
           <span data-i18n="parallel.tabTitle">Tasks</span>
         </button>
         <div class="nav-separator"><span data-i18n="ui.separatorAllProjects">Tous les projets</span></div>
-        <button class="nav-tab" data-tab="artifacts" title="Artifacts" data-i18n-title="ui.tooltipArtifacts">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M12 2l8 4.5v9L12 20l-8-4.5v-9L12 2z"/>
-            <path d="M4 6.5l8 4.5 8-4.5"/>
-            <path d="M12 11v9"/>
-          </svg>
-          <span data-i18n="artifacts.tabTitle">Artifacts</span>
-        </button>
         <button class="nav-tab" data-tab="control-tower" title="Control Tower" data-i18n-title="ui.tooltipControlTower">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <path d="M12 2L2 7l10 5 10-5-10-5z"/>

--- a/index.html
+++ b/index.html
@@ -141,6 +141,14 @@
           <span data-i18n="parallel.tabTitle">Tasks</span>
         </button>
         <div class="nav-separator"><span data-i18n="ui.separatorAllProjects">Tous les projets</span></div>
+        <button class="nav-tab" data-tab="artifacts" title="Artifacts" data-i18n-title="ui.tooltipArtifacts">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M12 2l8 4.5v9L12 20l-8-4.5v-9L12 2z"/>
+            <path d="M4 6.5l8 4.5 8-4.5"/>
+            <path d="M12 11v9"/>
+          </svg>
+          <span data-i18n="artifacts.tabTitle">Artifacts</span>
+        </button>
         <button class="nav-tab" data-tab="control-tower" title="Control Tower" data-i18n-title="ui.tooltipControlTower">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <path d="M12 2L2 7l10 5 10-5-10-5z"/>
@@ -791,6 +799,11 @@
       <!-- Workspace Tab -->
       <div class="tab-content" id="tab-workspace">
         <div class="workspace-layout" id="workspace-panel-root"></div>
+      </div>
+
+      <!-- Artifacts Tab -->
+      <div class="tab-content" id="tab-artifacts">
+        <div id="artifacts-panel-root"></div>
       </div>
 
       <!-- Error Log Tab -->

--- a/renderer.js
+++ b/renderer.js
@@ -116,7 +116,7 @@ const {
 const registry = require('./src/project-types/registry');
 const { mergeTranslations } = require('./src/renderer/i18n');
 const ModalComponent = require('./src/renderer/ui/components/Modal');
-const { MemoryEditor, GitChangesPanel, ShortcutsManager, SettingsPanel, SkillsAgentsPanel, PluginsPanel, MarketplacePanel, McpPanel, WorkflowPanel, DatabasePanel, CloudPanel, ConnectivityPanel, ControlTowerPanel, SessionReplayPanel, ParallelTaskPanel, WorkspacePanel, ErrorLogPanel, FilesPanel } = require('./src/renderer/ui/panels');
+const { MemoryEditor, GitChangesPanel, ShortcutsManager, SettingsPanel, SkillsAgentsPanel, PluginsPanel, MarketplacePanel, McpPanel, WorkflowPanel, DatabasePanel, CloudPanel, ConnectivityPanel, ControlTowerPanel, SessionReplayPanel, ParallelTaskPanel, WorkspacePanel, ErrorLogPanel, FilesPanel, ArtifactsPanel } = require('./src/renderer/ui/panels');
 // Not re-exported by the panels index: ConnectivityPanel embeds it as a sub-tab,
 // but its polling lifecycle is driven from the tab registry below.
 const RemotePanel = require('./src/renderer/ui/panels/RemotePanel');
@@ -3643,6 +3643,14 @@ const _TAB_LIFECYCLE = {
     },
     deactivate: () => WorkspacePanel.cleanup()
   },
+  artifacts: {
+    activate: () => {
+      const root = document.getElementById('artifacts-panel-root');
+      if (root) ArtifactsPanel.loadPanel(root);
+    },
+    // Releases the artifacts-changed IPC listener registered on activate.
+    deactivate: () => ArtifactsPanel.cleanup()
+  },
   errorlog: {
     activate: () => {
       const root = document.getElementById('errorlog-panel-root');
@@ -3744,7 +3752,7 @@ document.querySelectorAll('.nav-tab[data-tab]').forEach(tab => {
 // ========== PINNED TABS SYSTEM ==========
 // Canonical order — must mirror the grouping in index.html, since the groups
 // carry meaning (whether the project tab drives the screen).
-const _ALL_TABS_ORDER = ['claude', 'dashboard', 'files', 'git', 'session-replay', 'tasks', 'control-tower', 'workspace', 'memory', 'timetracking', 'database', 'skills', 'agents', 'plugins', 'mcp', 'workflows', 'errorlog', 'connectivity'];
+const _ALL_TABS_ORDER = ['claude', 'dashboard', 'files', 'git', 'session-replay', 'tasks', 'artifacts', 'control-tower', 'workspace', 'memory', 'timetracking', 'database', 'skills', 'agents', 'plugins', 'mcp', 'workflows', 'errorlog', 'connectivity'];
 
 function applyPinnedTabs() {
   const pinned = settingsState.get().pinnedTabs || _ALL_TABS_ORDER;

--- a/renderer.js
+++ b/renderer.js
@@ -2812,6 +2812,8 @@ function applyProjectContext(projectIndex) {
     SessionReplayPanel.setProject();
   } else if (activeTab === 'tasks') {
     ParallelTaskPanel.onProjectChanged?.();
+  } else if (activeTab === 'artifacts') {
+    ArtifactsPanel.setProject(project);
   }
 }
 
@@ -3646,7 +3648,9 @@ const _TAB_LIFECYCLE = {
   artifacts: {
     activate: () => {
       const root = document.getElementById('artifacts-panel-root');
-      if (root) ArtifactsPanel.loadPanel(root);
+      // Artifacts belong to a project, so the panel follows the project bar
+      // instead of carrying its own project picker — same as the Git tab.
+      if (root) ArtifactsPanel.loadPanel(root, getCurrentProjectFromBar());
     },
     // Releases the artifacts-changed IPC listener registered on activate.
     deactivate: () => ArtifactsPanel.cleanup()
@@ -3752,7 +3756,7 @@ document.querySelectorAll('.nav-tab[data-tab]').forEach(tab => {
 // ========== PINNED TABS SYSTEM ==========
 // Canonical order — must mirror the grouping in index.html, since the groups
 // carry meaning (whether the project tab drives the screen).
-const _ALL_TABS_ORDER = ['claude', 'dashboard', 'files', 'git', 'session-replay', 'tasks', 'artifacts', 'control-tower', 'workspace', 'memory', 'timetracking', 'database', 'skills', 'agents', 'plugins', 'mcp', 'workflows', 'errorlog', 'connectivity'];
+const _ALL_TABS_ORDER = ['claude', 'artifacts', 'dashboard', 'files', 'git', 'session-replay', 'tasks', 'control-tower', 'workspace', 'memory', 'timetracking', 'database', 'skills', 'agents', 'plugins', 'mcp', 'workflows', 'errorlog', 'connectivity'];
 
 function applyPinnedTabs() {
   const pinned = settingsState.get().pinnedTabs || _ALL_TABS_ORDER;

--- a/resources/mcp-servers/tools/artifacts.js
+++ b/resources/mcp-servers/tools/artifacts.js
@@ -43,7 +43,8 @@ function log(...args) {
 
 // -- Formatting ---------------------------------------------------------------
 
-const KINDS = ['html', 'svg', 'mermaid', 'code', 'file'];
+// Mirrors KINDS in src/shared/artifact-schema.js.
+const KINDS = ['published', 'html', 'svg', 'mermaid', 'code', 'file'];
 
 function formatBytes(bytes) {
   if (!bytes) return '0 B';
@@ -62,8 +63,13 @@ function formatRow(a) {
   const version = (a.version || 1) > 1 ? ` v${a.version}` : '';
   const project = a.projectName ? ` · ${a.projectName}` : '';
   const lang = a.lang ? ` · ${a.lang}` : '';
-  return `- [${a.kind}] ${a.title}${version} — ${a.id}\n`
-    + `  ${a.lines} lines · ${formatBytes(a.bytes)}${lang}${project} · ${formatDate(a.createdAt)}`;
+  const icon = a.favicon ? `${a.favicon} ` : '';
+  // The URL only exists on published artifacts, and it is the single most
+  // useful thing to hand back — it is what the user can actually open or share.
+  const url = a.url ? `\n  ${a.url}` : '';
+  const description = a.description ? `\n  ${a.description}` : '';
+  return `- ${icon}[${a.kind}] ${a.title}${version} — ${a.id}${description}\n`
+    + `  ${a.lines} lines · ${formatBytes(a.bytes)}${lang}${project} · ${formatDate(a.createdAt)}${url}`;
 }
 
 function ok(text) {
@@ -189,15 +195,18 @@ async function handleGet(args) {
   if (!artifact) return fail(`No artifact with id "${args.id}". Use artifact_list to find one.`);
 
   const header = [
-    `# ${artifact.title}`,
+    `# ${artifact.favicon ? `${artifact.favicon} ` : ''}${artifact.title}`,
     '',
+    artifact.description ? `> ${artifact.description}` : null,
+    artifact.description ? '' : null,
     `- id: ${artifact.id}`,
     `- kind: ${artifact.kind}${artifact.lang ? ` (${artifact.lang})` : ''}`,
     `- version: v${artifact.version || 1}`,
     `- size: ${artifact.lines} lines, ${formatBytes(artifact.bytes)}`,
     artifact.projectName ? `- project: ${artifact.projectName}` : null,
+    artifact.url ? `- published at: ${artifact.url}` : null,
     `- created: ${formatDate(artifact.createdAt)}`,
-  ].filter(Boolean).join('\n');
+  ].filter(v => v !== null).join('\n');
 
   if (args.metadataOnly) return ok(header);
   if (!artifact.source) {

--- a/resources/mcp-servers/tools/artifacts.js
+++ b/resources/mcp-servers/tools/artifacts.js
@@ -1,0 +1,281 @@
+'use strict';
+
+/**
+ * Artifacts Tools Module for Claude Terminal MCP
+ *
+ * The artifact library: the self-contained things Claude produced inside past
+ * conversations (an HTML page, an SVG, a Mermaid diagram, a long code block, a
+ * file it wrote), detected by the app and kept on disk.
+ *
+ * These tools let a session reach back into that library — "show me the
+ * dashboard I built last week", "what was in v1 of that page" — without asking
+ * the user to find and paste it.
+ *
+ * Storage is shared with the app, not copied: both sides run
+ * src/shared/artifact-store.js, so a write from either process takes the same
+ * cross-process lock and neither can lose the other's update.
+ */
+
+const path = require('path');
+
+// Resolve the shared store: packaged app (afterPack copy) → dev repo.
+// Same dual-path shape automation.js uses for the task compiler. Without it the
+// module still loads but every tool fails loudly rather than reading a store
+// that does not exist.
+let store = null;
+let storeError = null;
+try {
+  // Packaged app: src/shared/ is copied alongside mcp-servers/
+  store = require(path.join(__dirname, '..', 'shared', 'artifact-store'));
+} catch (_) {
+  try {
+    // Dev environment: src/shared/ relative to the repo root
+    store = require(path.join(__dirname, '..', '..', '..', 'src', 'shared', 'artifact-store'));
+  } catch (e) {
+    storeError = e.message;
+    process.stderr.write(`[ct-mcp:artifacts] artifact-store unavailable, tools disabled: ${e.message}\n`);
+  }
+}
+
+function log(...args) {
+  process.stderr.write(`[ct-mcp:artifacts] ${args.join(' ')}\n`);
+}
+
+// -- Formatting ---------------------------------------------------------------
+
+const KINDS = ['html', 'svg', 'mermaid', 'code', 'file'];
+
+function formatBytes(bytes) {
+  if (!bytes) return '0 B';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatDate(iso) {
+  if (!iso) return 'unknown date';
+  return String(iso).slice(0, 16).replace('T', ' ');
+}
+
+/** One artifact as a compact line for a list. */
+function formatRow(a) {
+  const version = (a.version || 1) > 1 ? ` v${a.version}` : '';
+  const project = a.projectName ? ` · ${a.projectName}` : '';
+  const lang = a.lang ? ` · ${a.lang}` : '';
+  return `- [${a.kind}] ${a.title}${version} — ${a.id}\n`
+    + `  ${a.lines} lines · ${formatBytes(a.bytes)}${lang}${project} · ${formatDate(a.createdAt)}`;
+}
+
+function ok(text) {
+  return { content: [{ type: 'text', text }] };
+}
+
+function fail(text) {
+  return { content: [{ type: 'text', text }], isError: true };
+}
+
+// -- Tool definitions ---------------------------------------------------------
+
+const tools = [
+  {
+    name: 'artifact_list',
+    description:
+      'List artifacts Claude produced in past conversations: HTML pages, SVGs, Mermaid diagrams, '
+      + 'long code blocks, and files written. Newest first. Filter by project, kind, or session. '
+      + 'By default only the latest version of each artifact is listed.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectId: { type: 'string', description: 'Restrict to one project (see project_list)' },
+        sessionId: { type: 'string', description: 'Restrict to one chat session' },
+        kind: { type: 'string', enum: KINDS, description: 'Restrict to one artifact kind' },
+        limit: { type: 'number', description: 'Maximum rows to return (default 30)' },
+        allVersions: {
+          type: 'boolean',
+          description: 'List every version instead of only the newest of each artifact',
+        },
+      },
+    },
+  },
+  {
+    name: 'artifact_get',
+    description:
+      'Read one artifact in full: its metadata and its complete source. Use the id from '
+      + 'artifact_list or artifact_search.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: { type: 'string', description: 'Artifact id, e.g. art-1a2b3c4d5e6f7a8b' },
+        metadataOnly: {
+          type: 'boolean',
+          description: 'Return only the metadata, useful when the source is large',
+        },
+      },
+      required: ['id'],
+    },
+  },
+  {
+    name: 'artifact_search',
+    description:
+      'Find artifacts by title, language or project name. Use this when the user refers to '
+      + 'something they remember producing ("the pricing page", "that sequence diagram") rather '
+      + 'than to a specific id.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Text to match against title, language and project' },
+        kind: { type: 'string', enum: KINDS, description: 'Restrict to one artifact kind' },
+        limit: { type: 'number', description: 'Maximum rows to return (default 20)' },
+      },
+      required: ['query'],
+    },
+  },
+  {
+    name: 'artifact_versions',
+    description:
+      'List every version of one artifact, oldest first. Rewrites of the same thing are grouped, '
+      + 'so this is how to reach an earlier draft of a page or diagram.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: { type: 'string', description: 'Any version of the artifact' },
+      },
+      required: ['id'],
+    },
+  },
+  {
+    name: 'artifact_delete',
+    description:
+      'Delete one artifact and its stored source. Irreversible. Prefer letting the user do this '
+      + 'from the Artifacts panel unless they explicitly asked you to clean up.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: { type: 'string', description: 'Artifact id to delete' },
+      },
+      required: ['id'],
+    },
+  },
+  {
+    name: 'artifact_stats',
+    description: 'Counts, total size on disk and per-kind breakdown of the artifact library.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+];
+
+// -- Handlers -----------------------------------------------------------------
+
+async function handleList(args) {
+  const limit = Math.max(1, Math.min(200, args.limit || 30));
+  const { artifacts, total } = await store.listArtifacts({
+    projectId: args.projectId,
+    sessionId: args.sessionId,
+    kind: args.kind,
+    latestOnly: !args.allVersions,
+    limit,
+  });
+
+  if (!artifacts.length) {
+    return ok('No artifacts match. The library fills up as Claude produces HTML pages, diagrams, '
+      + 'SVGs, long code blocks or writes files in the app.');
+  }
+
+  const shown = artifacts.length < total ? ` (showing ${artifacts.length})` : '';
+  return ok(`${total} artifact(s)${shown}:\n\n${artifacts.map(formatRow).join('\n')}`);
+}
+
+async function handleGet(args) {
+  const artifact = await store.getArtifact(args.id);
+  if (!artifact) return fail(`No artifact with id "${args.id}". Use artifact_list to find one.`);
+
+  const header = [
+    `# ${artifact.title}`,
+    '',
+    `- id: ${artifact.id}`,
+    `- kind: ${artifact.kind}${artifact.lang ? ` (${artifact.lang})` : ''}`,
+    `- version: v${artifact.version || 1}`,
+    `- size: ${artifact.lines} lines, ${formatBytes(artifact.bytes)}`,
+    artifact.projectName ? `- project: ${artifact.projectName}` : null,
+    `- created: ${formatDate(artifact.createdAt)}`,
+  ].filter(Boolean).join('\n');
+
+  if (args.metadataOnly) return ok(header);
+  if (!artifact.source) {
+    return ok(`${header}\n\nThe stored source for this artifact is missing from disk; only its metadata survives.`);
+  }
+  return ok(`${header}\n\n## Source\n\n${artifact.source}`);
+}
+
+async function handleSearch(args) {
+  const limit = Math.max(1, Math.min(200, args.limit || 20));
+  const { artifacts, total } = await store.listArtifacts({
+    query: args.query,
+    kind: args.kind,
+    latestOnly: true,
+    limit,
+  });
+
+  if (!artifacts.length) return ok(`No artifact matches "${args.query}".`);
+  const shown = artifacts.length < total ? ` (showing ${artifacts.length})` : '';
+  return ok(`${total} match(es) for "${args.query}"${shown}:\n\n${artifacts.map(formatRow).join('\n')}`);
+}
+
+async function handleVersions(args) {
+  const artifact = await store.getArtifact(args.id);
+  if (!artifact) return fail(`No artifact with id "${args.id}".`);
+
+  const versions = await store.getVersions(artifact.groupKey);
+  if (versions.length < 2) return ok(`"${artifact.title}" has a single version (${artifact.id}).`);
+
+  return ok(`${versions.length} versions of "${artifact.title}":\n\n${versions.map(formatRow).join('\n')}`);
+}
+
+async function handleDelete(args) {
+  const deleted = await store.deleteArtifact(args.id);
+  if (!deleted) return fail(`No artifact with id "${args.id}".`);
+  return ok(`Deleted artifact ${args.id}.`);
+}
+
+async function handleStats() {
+  const stats = await store.getStats();
+  const breakdown = Object.entries(stats.byKind)
+    .filter(([, count]) => count > 0)
+    .map(([kind, count]) => `- ${kind}: ${count}`)
+    .join('\n') || '- (none)';
+
+  return ok(`Artifact library:\n\n`
+    + `- total: ${stats.total}\n`
+    + `- on disk: ${formatBytes(stats.bytes)}\n`
+    + `- projects: ${stats.projects}\n\n`
+    + `By kind:\n${breakdown}`);
+}
+
+const HANDLERS = {
+  artifact_list: handleList,
+  artifact_get: handleGet,
+  artifact_search: handleSearch,
+  artifact_versions: handleVersions,
+  artifact_delete: handleDelete,
+  artifact_stats: handleStats,
+};
+
+async function handle(toolName, args = {}) {
+  if (!store) {
+    return fail(`Artifact store unavailable: ${storeError || 'module not found'}`);
+  }
+  const handler = HANDLERS[toolName];
+  if (!handler) return fail(`Unknown tool: ${toolName}`);
+
+  try {
+    return await handler(args);
+  } catch (e) {
+    log(`${toolName} failed: ${e.message}`);
+    return fail(`${toolName} failed: ${e.message}`);
+  }
+}
+
+async function cleanup() {
+  // No handles held: every call reads and releases the index.
+}
+
+module.exports = { tools, handle, cleanup };

--- a/resources/mcp-servers/tools/sidebar.js
+++ b/resources/mcp-servers/tools/sidebar.js
@@ -46,7 +46,7 @@ function saveSettings(settings) {
 const ALL_TABS = [
   'claude', 'git', 'database', 'mcp', 'plugins', 'skills',
   'agents', 'workflows', 'tasks', 'control-tower', 'dashboard', 'timetracking',
-  'session-replay', 'memory', 'workspace', 'errorlog', 'connectivity',
+  'session-replay', 'memory', 'workspace', 'artifacts', 'errorlog', 'connectivity',
 ];
 
 const TAB_LABELS = {
@@ -65,6 +65,7 @@ const TAB_LABELS = {
   'session-replay': 'Session replay',
   memory: 'Memory editor (MEMORY.md)',
   workspace: 'Workspace knowledge base',
+  artifacts: 'Artifact library (HTML, SVG, diagrams, code)',
   errorlog: 'Error log',
   connectivity: 'Connectivity (local Wi-Fi + cloud relay)',
 };

--- a/src/main/ipc/artifacts.ipc.js
+++ b/src/main/ipc/artifacts.ipc.js
@@ -1,0 +1,99 @@
+'use strict';
+
+/**
+ * Artifacts IPC Handlers
+ * Library of artifacts produced by Claude across every session and project.
+ */
+
+const { ipcMain } = require('electron');
+const ArtifactService = require('../services/ArtifactService');
+
+function registerArtifactHandlers() {
+  // The MCP tools write index.json from another process; watching it is how the
+  // library panel learns about those writes.
+  ArtifactService.startWatching();
+
+  ipcMain.handle('artifacts-list', async (_event, options) => {
+    try {
+      const { artifacts, total } = await ArtifactService.listArtifacts(options || {});
+      return { success: true, artifacts, total };
+    } catch (e) {
+      console.error('[Artifacts IPC] List error:', e);
+      return { success: false, error: e.message };
+    }
+  });
+
+  ipcMain.handle('artifacts-get', async (_event, { id }) => {
+    try {
+      const artifact = await ArtifactService.getArtifact(id);
+      if (!artifact) return { success: false, error: 'Artifact not found' };
+      return { success: true, artifact };
+    } catch (e) {
+      console.error('[Artifacts IPC] Get error:', e);
+      return { success: false, error: e.message };
+    }
+  });
+
+  ipcMain.handle('artifacts-versions', async (_event, { groupKey }) => {
+    try {
+      const versions = await ArtifactService.getVersions(groupKey);
+      return { success: true, versions };
+    } catch (e) {
+      console.error('[Artifacts IPC] Versions error:', e);
+      return { success: false, error: e.message };
+    }
+  });
+
+  ipcMain.handle('artifacts-save', async (_event, artifact) => {
+    try {
+      const result = await ArtifactService.saveArtifact(artifact || {});
+      return { success: true, ...result };
+    } catch (e) {
+      console.error('[Artifacts IPC] Save error:', e);
+      return { success: false, error: e.message };
+    }
+  });
+
+  // Batch entry point used by the renderer's harvest pass.
+  ipcMain.handle('artifacts-save-many', async (_event, { artifacts }) => {
+    try {
+      const result = await ArtifactService.saveMany(artifacts || []);
+      return { success: true, created: result.created, skipped: result.skipped };
+    } catch (e) {
+      console.error('[Artifacts IPC] Save many error:', e);
+      return { success: false, error: e.message };
+    }
+  });
+
+  ipcMain.handle('artifacts-delete', async (_event, { id }) => {
+    try {
+      const deleted = await ArtifactService.deleteArtifact(id);
+      return { success: true, deleted };
+    } catch (e) {
+      console.error('[Artifacts IPC] Delete error:', e);
+      return { success: false, error: e.message };
+    }
+  });
+
+  ipcMain.handle('artifacts-delete-where', async (_event, filter) => {
+    try {
+      const count = await ArtifactService.deleteWhere(filter || {});
+      return { success: true, count };
+    } catch (e) {
+      console.error('[Artifacts IPC] Delete where error:', e);
+      return { success: false, error: e.message };
+    }
+  });
+
+  ipcMain.handle('artifacts-stats', async () => {
+    try {
+      const stats = await ArtifactService.getStats();
+      return { success: true, stats };
+    } catch (e) {
+      console.error('[Artifacts IPC] Stats error:', e);
+      return { success: false, error: e.message };
+    }
+  });
+}
+
+module.exports = { registerArtifactHandlers };

--- a/src/main/ipc/index.js
+++ b/src/main/ipc/index.js
@@ -35,6 +35,7 @@ const { registerVoiceHandlers } = require('./voice.ipc');
 const { registerParallelHandlers } = require('./parallel.ipc');
 const { registerWorkspaceHandlers } = require('./workspace.ipc');
 const { registerKnowledgeHandlers } = require('./knowledge.ipc');
+const { registerArtifactHandlers } = require('./artifacts.ipc');
 const { registerErrorLogHandlers } = require('./errorLog.ipc');
 const { registerAccountsHandlers } = require('./accounts.ipc');
 const { registerDiscordRpcHandlers } = require('./discord-rpc.ipc');
@@ -84,6 +85,7 @@ function registerAllHandlers(mainWindow) {
   registerParallelHandlers(mainWindow);
   registerWorkspaceHandlers();
   registerKnowledgeHandlers();
+  registerArtifactHandlers();
   registerErrorLogHandlers();
   registerAccountsHandlers();
   registerDiscordRpcHandlers();

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -530,6 +530,24 @@ contextBridge.exposeInMainWorld('electron_api', {
     sync: () => ipcRenderer.invoke('knowledge-sync'),
   },
 
+  // ==================== ARTIFACTS ====================
+  artifacts: {
+    list: (options) => ipcRenderer.invoke('artifacts-list', options || {}),
+    get: (id) => ipcRenderer.invoke('artifacts-get', { id }),
+    versions: (groupKey) => ipcRenderer.invoke('artifacts-versions', { groupKey }),
+    save: (artifact) => ipcRenderer.invoke('artifacts-save', artifact),
+    saveMany: (artifacts) => ipcRenderer.invoke('artifacts-save-many', { artifacts }),
+    delete: (id) => ipcRenderer.invoke('artifacts-delete', { id }),
+    deleteWhere: (filter) => ipcRenderer.invoke('artifacts-delete-where', filter),
+    stats: () => ipcRenderer.invoke('artifacts-stats'),
+    // Fired after any mutation, including ones made by the MCP tools.
+    onChanged: (callback) => {
+      const handler = (_event, payload) => callback(payload);
+      ipcRenderer.on('artifacts-changed', handler);
+      return () => ipcRenderer.removeListener('artifacts-changed', handler);
+    },
+  },
+
   // ==================== PROJECT ====================
   project: {
     scanTodos: (projectPath) => ipcRenderer.invoke('scan-todos', projectPath),

--- a/src/main/services/ArtifactService.js
+++ b/src/main/services/ArtifactService.js
@@ -1,0 +1,109 @@
+'use strict';
+
+/**
+ * ArtifactService
+ *
+ * Main-process facade over the artifact store. The store itself lives in
+ * src/shared/artifact-store.js because the MCP server process needs the exact
+ * same code (see the header there); this file adds the two things only the main
+ * process can do:
+ *
+ *   1. Broadcast `artifacts-changed` to every window after a mutation, so the
+ *      library panel refreshes when an artifact is deleted from somewhere else.
+ *   2. Poll for out-of-process writes. The MCP tools mutate index.json directly
+ *      and have no way to reach a BrowserWindow, so the app watches the file and
+ *      broadcasts on its behalf.
+ */
+
+const fs = require('fs');
+const { BrowserWindow } = require('electron');
+const store = require('../../shared/artifact-store');
+
+let watcher = null;
+let lastSeenMtimeMs = 0;
+
+function broadcast(reason) {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed()) win.webContents.send('artifacts-changed', { reason });
+  }
+}
+
+/**
+ * Watch index.json for writes we did not make ourselves (the MCP process).
+ * fs.watch fires more than once per logical write, so changes are collapsed by
+ * mtime and debounced.
+ */
+function startWatching() {
+  if (watcher) return;
+  try {
+    fs.mkdirSync(store.ARTIFACTS_DIR, { recursive: true });
+    let timer = null;
+    watcher = fs.watch(store.ARTIFACTS_DIR, (_event, filename) => {
+      if (filename && filename !== 'index.json') return;
+      clearTimeout(timer);
+      timer = setTimeout(() => {
+        let mtimeMs = 0;
+        try { mtimeMs = fs.statSync(store.INDEX_FILE).mtimeMs; } catch { return; }
+        if (mtimeMs === lastSeenMtimeMs) return;
+        lastSeenMtimeMs = mtimeMs;
+        broadcast('external');
+      }, 250);
+    });
+  } catch (e) {
+    // A missing watch is a missing refresh, not a broken feature.
+    console.warn('[Artifacts] index watch unavailable:', e.message);
+  }
+}
+
+function stopWatching() {
+  if (!watcher) return;
+  try { watcher.close(); } catch { /* ignore */ }
+  watcher = null;
+}
+
+/** Remember our own write so the watcher does not echo it back as external. */
+function markSelfWrite() {
+  try { lastSeenMtimeMs = fs.statSync(store.INDEX_FILE).mtimeMs; } catch { /* ignore */ }
+}
+
+async function saveArtifact(input) {
+  const result = await store.saveArtifact(input);
+  if (result.created) { markSelfWrite(); broadcast('save'); }
+  return result;
+}
+
+async function saveMany(inputs) {
+  const result = await store.saveMany(inputs);
+  if (result.created.length) { markSelfWrite(); broadcast('save'); }
+  return result;
+}
+
+async function deleteArtifact(id) {
+  const deleted = await store.deleteArtifact(id);
+  if (deleted) { markSelfWrite(); broadcast('delete'); }
+  return deleted;
+}
+
+async function deleteWhere(filter) {
+  const count = await store.deleteWhere(filter);
+  if (count) { markSelfWrite(); broadcast('delete'); }
+  return count;
+}
+
+module.exports = {
+  // reads pass straight through
+  listArtifacts: store.listArtifacts,
+  getArtifact: store.getArtifact,
+  getVersions: store.getVersions,
+  getStats: store.getStats,
+  KINDS: store.KINDS,
+  ARTIFACTS_DIR: store.ARTIFACTS_DIR,
+  // writes broadcast
+  saveArtifact,
+  saveMany,
+  deleteArtifact,
+  deleteWhere,
+  // lifecycle
+  startWatching,
+  stopWatching,
+};

--- a/src/main/services/index.js
+++ b/src/main/services/index.js
@@ -361,6 +361,9 @@ function cleanupServices() {
   discordRpcService.destroy();
   databaseService.disconnectAll().catch(() => {});
   _stopMcpTriggerPolling();
+  // fs.watch on the artifacts index. Required lazily (same pattern as the
+  // explorer watchers below) to keep this module free of an ipc/ dependency.
+  try { require('./ArtifactService').stopWatching(); } catch (_) { /* non-critical */ }
   // File explorer chokidar watchers. Required lazily (same pattern as git below)
   // to keep this module free of an ipc/ dependency at load time. Without this the
   // watchers were only ever released by an explicit renderer IPC call, so a quit

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -1086,7 +1086,7 @@
     "separatorSystem": "System",
     "tabFiles": "Files",
     "tooltipFiles": "Files",
-    "tooltipArtifacts": "Artifacts produced in this project"
+    "tooltipArtifacts": "Artifacts published to claude.ai from this project"
   },
   "memory": {
     "panelDescription": "Configure how Claude behaves in your projects. Global settings apply everywhere, project settings override them.",
@@ -2116,14 +2116,12 @@
     "tabTitle": "Artifacts",
     "libraryTitle": "Artifacts",
     "emptySession": "No documents produced in this conversation yet.",
-    "emptyLibrary": "No artifacts yet. They appear here as Claude produces HTML pages, diagrams, SVGs and code.",
+    "emptyLibrary": "No published artifacts in this project. They appear here when Claude publishes a page with the Artifact tool.",
     "selectPrompt": "Select an artifact to preview it.",
     "lines": "lines",
     "documentsSingular": "document",
     "documentsPlural": "documents",
-    "stored": "stored",
-    "allKinds": "All kinds",
-    "inProject": "in this project",
+    "publishedCount": "published in this project",
     "saveAs": "Save as...",
     "saved": "Artifact saved",
     "openInEditor": "Open in editor",

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -2128,7 +2128,8 @@
     "saved": "Artifact saved",
     "openInEditor": "Open in editor",
     "resizePane": "Resize artifact panel",
-    "jumpToMessage": "Go to message"
+    "jumpToMessage": "Go to message",
+    "openPublished": "Open published page"
   },
   "errorLog": {
     "title": "Error Log",

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -1086,7 +1086,7 @@
     "separatorSystem": "System",
     "tabFiles": "Files",
     "tooltipFiles": "Files",
-    "tooltipArtifacts": "Artifact library: HTML, SVG, diagrams and code"
+    "tooltipArtifacts": "Artifacts produced in this project"
   },
   "memory": {
     "panelDescription": "Configure how Claude behaves in your projects. Global settings apply everywhere, project settings override them.",
@@ -1912,7 +1912,7 @@
     "elicitationDecline": "Decline",
     "elicitationOpen": "Continue",
     "cancel": "Cancel",
-    "tabArtifacts": "Artifacts"
+    "tabExtracts": "Extracts"
   },
   "hooks": {
     "consent": {
@@ -2115,16 +2115,15 @@
   "artifacts": {
     "tabTitle": "Artifacts",
     "libraryTitle": "Artifacts",
-    "emptySession": "No artifacts in this session yet.",
+    "emptySession": "Nothing extracted from this conversation yet.",
     "emptyLibrary": "No artifacts yet. They appear here as Claude produces HTML pages, diagrams, SVGs and code.",
     "selectPrompt": "Select an artifact to preview it.",
     "lines": "lines",
-    "countSingular": "artifact",
-    "countPlural": "artifacts",
+    "extractsSingular": "extract",
+    "extractsPlural": "extracts",
     "stored": "stored",
-    "projects": "projects",
     "allKinds": "All kinds",
-    "allProjects": "All projects",
+    "inProject": "in this project",
     "saveAs": "Save as...",
     "saved": "Artifact saved",
     "openInEditor": "Open in editor",

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -1912,7 +1912,7 @@
     "elicitationDecline": "Decline",
     "elicitationOpen": "Continue",
     "cancel": "Cancel",
-    "tabExtracts": "Extracts"
+    "tabDocuments": "Documents"
   },
   "hooks": {
     "consent": {
@@ -2115,12 +2115,12 @@
   "artifacts": {
     "tabTitle": "Artifacts",
     "libraryTitle": "Artifacts",
-    "emptySession": "Nothing extracted from this conversation yet.",
+    "emptySession": "No documents produced in this conversation yet.",
     "emptyLibrary": "No artifacts yet. They appear here as Claude produces HTML pages, diagrams, SVGs and code.",
     "selectPrompt": "Select an artifact to preview it.",
     "lines": "lines",
-    "extractsSingular": "extract",
-    "extractsPlural": "extracts",
+    "documentsSingular": "document",
+    "documentsPlural": "documents",
     "stored": "stored",
     "allKinds": "All kinds",
     "inProject": "in this project",

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -1085,7 +1085,8 @@
     "separatorCapabilities": "Capabilities",
     "separatorSystem": "System",
     "tabFiles": "Files",
-    "tooltipFiles": "Files"
+    "tooltipFiles": "Files",
+    "tooltipArtifacts": "Artifact library: HTML, SVG, diagrams and code"
   },
   "memory": {
     "panelDescription": "Configure how Claude behaves in your projects. Global settings apply everywhere, project settings override them.",
@@ -1910,7 +1911,8 @@
     "elicitationSubmit": "Submit",
     "elicitationDecline": "Decline",
     "elicitationOpen": "Continue",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "tabArtifacts": "Artifacts"
   },
   "hooks": {
     "consent": {
@@ -2109,6 +2111,25 @@
     "analyzeProjectDone": "Doc generated: {title} ({links} link(s))",
     "analyzeProjectError": "Failed to analyze project",
     "badge": "WS"
+  },
+  "artifacts": {
+    "tabTitle": "Artifacts",
+    "libraryTitle": "Artifacts",
+    "emptySession": "No artifacts in this session yet.",
+    "emptyLibrary": "No artifacts yet. They appear here as Claude produces HTML pages, diagrams, SVGs and code.",
+    "selectPrompt": "Select an artifact to preview it.",
+    "lines": "lines",
+    "countSingular": "artifact",
+    "countPlural": "artifacts",
+    "stored": "stored",
+    "projects": "projects",
+    "allKinds": "All kinds",
+    "allProjects": "All projects",
+    "saveAs": "Save as...",
+    "saved": "Artifact saved",
+    "openInEditor": "Open in editor",
+    "resizePane": "Resize artifact panel",
+    "jumpToMessage": "Go to message"
   },
   "errorLog": {
     "title": "Error Log",

--- a/src/renderer/i18n/locales/es.json
+++ b/src/renderer/i18n/locales/es.json
@@ -2125,7 +2125,8 @@
     "saved": "Artefacto guardado",
     "openInEditor": "Abrir en el editor",
     "resizePane": "Redimensionar el panel de artefactos",
-    "jumpToMessage": "Ir al mensaje"
+    "jumpToMessage": "Ir al mensaje",
+    "openPublished": "Abrir la página publicada"
   },
   "errorLog": {
     "title": "Registro de errores",

--- a/src/renderer/i18n/locales/es.json
+++ b/src/renderer/i18n/locales/es.json
@@ -1083,7 +1083,7 @@
     "separatorSystem": "Sistema",
     "tabFiles": "Archivos",
     "tooltipFiles": "Archivos",
-    "tooltipArtifacts": "Artefactos producidos en este proyecto"
+    "tooltipArtifacts": "Artefactos publicados en claude.ai desde este proyecto"
   },
   "memory": {
     "panelDescription": "Configura como Claude se comporta en tus proyectos. Los ajustes globales aplican en todos lados, los de proyecto los reemplazan.",
@@ -2113,14 +2113,12 @@
     "tabTitle": "Artefactos",
     "libraryTitle": "Artefactos",
     "emptySession": "Todavía no se ha producido ningún documento en esta conversación.",
-    "emptyLibrary": "Aún no hay artefactos. Aparecen aquí a medida que Claude produce páginas HTML, diagramas, SVG y código.",
+    "emptyLibrary": "No hay artefactos publicados en este proyecto. Aparecen aquí cuando Claude publica una página con la herramienta Artifact.",
     "selectPrompt": "Selecciona un artefacto para previsualizarlo.",
     "lines": "líneas",
     "documentsSingular": "documento",
     "documentsPlural": "documentos",
-    "stored": "almacenados",
-    "allKinds": "Todos los tipos",
-    "inProject": "en este proyecto",
+    "publishedCount": "publicados en este proyecto",
     "saveAs": "Guardar como...",
     "saved": "Artefacto guardado",
     "openInEditor": "Abrir en el editor",

--- a/src/renderer/i18n/locales/es.json
+++ b/src/renderer/i18n/locales/es.json
@@ -1082,7 +1082,8 @@
     "separatorCapabilities": "Capacidades",
     "separatorSystem": "Sistema",
     "tabFiles": "Archivos",
-    "tooltipFiles": "Archivos"
+    "tooltipFiles": "Archivos",
+    "tooltipArtifacts": "Biblioteca de artefactos: HTML, SVG, diagramas y código"
   },
   "memory": {
     "panelDescription": "Configura como Claude se comporta en tus proyectos. Los ajustes globales aplican en todos lados, los de proyecto los reemplazan.",
@@ -1907,7 +1908,8 @@
     "elicitationSubmit": "Enviar",
     "elicitationDecline": "Rechazar",
     "elicitationOpen": "Continuar",
-    "cancel": "Cancelar"
+    "cancel": "Cancelar",
+    "tabArtifacts": "Artefactos"
   },
   "hooks": {
     "consent": {
@@ -2106,6 +2108,25 @@
     "analyzeProjectDone": "Doc generada: {title} ({links} enlace(s))",
     "analyzeProjectError": "Error al analizar el proyecto",
     "badge": "ET"
+  },
+  "artifacts": {
+    "tabTitle": "Artefactos",
+    "libraryTitle": "Artefactos",
+    "emptySession": "Aún no hay artefactos en esta sesión.",
+    "emptyLibrary": "Aún no hay artefactos. Aparecen aquí a medida que Claude produce páginas HTML, diagramas, SVG y código.",
+    "selectPrompt": "Selecciona un artefacto para previsualizarlo.",
+    "lines": "líneas",
+    "countSingular": "artefacto",
+    "countPlural": "artefactos",
+    "stored": "almacenados",
+    "projects": "proyectos",
+    "allKinds": "Todos los tipos",
+    "allProjects": "Todos los proyectos",
+    "saveAs": "Guardar como...",
+    "saved": "Artefacto guardado",
+    "openInEditor": "Abrir en el editor",
+    "resizePane": "Redimensionar el panel de artefactos",
+    "jumpToMessage": "Ir al mensaje"
   },
   "errorLog": {
     "title": "Registro de errores",

--- a/src/renderer/i18n/locales/es.json
+++ b/src/renderer/i18n/locales/es.json
@@ -1083,7 +1083,7 @@
     "separatorSystem": "Sistema",
     "tabFiles": "Archivos",
     "tooltipFiles": "Archivos",
-    "tooltipArtifacts": "Biblioteca de artefactos: HTML, SVG, diagramas y código"
+    "tooltipArtifacts": "Artefactos producidos en este proyecto"
   },
   "memory": {
     "panelDescription": "Configura como Claude se comporta en tus proyectos. Los ajustes globales aplican en todos lados, los de proyecto los reemplazan.",
@@ -1909,7 +1909,7 @@
     "elicitationDecline": "Rechazar",
     "elicitationOpen": "Continuar",
     "cancel": "Cancelar",
-    "tabArtifacts": "Artefactos"
+    "tabExtracts": "Extractos"
   },
   "hooks": {
     "consent": {
@@ -2112,16 +2112,15 @@
   "artifacts": {
     "tabTitle": "Artefactos",
     "libraryTitle": "Artefactos",
-    "emptySession": "Aún no hay artefactos en esta sesión.",
+    "emptySession": "Nada extraído de esta conversación todavía.",
     "emptyLibrary": "Aún no hay artefactos. Aparecen aquí a medida que Claude produce páginas HTML, diagramas, SVG y código.",
     "selectPrompt": "Selecciona un artefacto para previsualizarlo.",
     "lines": "líneas",
-    "countSingular": "artefacto",
-    "countPlural": "artefactos",
+    "extractsSingular": "extracto",
+    "extractsPlural": "extractos",
     "stored": "almacenados",
-    "projects": "proyectos",
     "allKinds": "Todos los tipos",
-    "allProjects": "Todos los proyectos",
+    "inProject": "en este proyecto",
     "saveAs": "Guardar como...",
     "saved": "Artefacto guardado",
     "openInEditor": "Abrir en el editor",

--- a/src/renderer/i18n/locales/es.json
+++ b/src/renderer/i18n/locales/es.json
@@ -1909,7 +1909,7 @@
     "elicitationDecline": "Rechazar",
     "elicitationOpen": "Continuar",
     "cancel": "Cancelar",
-    "tabExtracts": "Extractos"
+    "tabDocuments": "Documentos"
   },
   "hooks": {
     "consent": {
@@ -2112,12 +2112,12 @@
   "artifacts": {
     "tabTitle": "Artefactos",
     "libraryTitle": "Artefactos",
-    "emptySession": "Nada extraído de esta conversación todavía.",
+    "emptySession": "Todavía no se ha producido ningún documento en esta conversación.",
     "emptyLibrary": "Aún no hay artefactos. Aparecen aquí a medida que Claude produce páginas HTML, diagramas, SVG y código.",
     "selectPrompt": "Selecciona un artefacto para previsualizarlo.",
     "lines": "líneas",
-    "extractsSingular": "extracto",
-    "extractsPlural": "extractos",
+    "documentsSingular": "documento",
+    "documentsPlural": "documentos",
     "stored": "almacenados",
     "allKinds": "Todos los tipos",
     "inProject": "en este proyecto",

--- a/src/renderer/i18n/locales/fr.json
+++ b/src/renderer/i18n/locales/fr.json
@@ -1181,7 +1181,7 @@
     "separatorSystem": "Système",
     "tabFiles": "Fichiers",
     "tooltipFiles": "Fichiers",
-    "tooltipArtifacts": "Bibliothèque d’artefacts : HTML, SVG, diagrammes et code"
+    "tooltipArtifacts": "Artefacts produits dans ce projet"
   },
   "memory": {
     "panelDescription": "Configurez le comportement de Claude dans vos projets. Les reglages globaux s'appliquent partout, les reglages projet les remplacent.",
@@ -1912,7 +1912,7 @@
     "elicitationDecline": "Refuser",
     "elicitationOpen": "Continuer",
     "cancel": "Annuler",
-    "tabArtifacts": "Artefacts"
+    "tabExtracts": "Extraits"
   },
   "hooks": {
     "consent": {
@@ -2115,16 +2115,15 @@
   "artifacts": {
     "tabTitle": "Artefacts",
     "libraryTitle": "Artefacts",
-    "emptySession": "Aucun artefact dans cette session pour l’instant.",
+    "emptySession": "Rien d’extrait de cette conversation pour l’instant.",
     "emptyLibrary": "Aucun artefact. Ils apparaissent ici au fur et à mesure que Claude produit des pages HTML, des diagrammes, des SVG et du code.",
     "selectPrompt": "Sélectionnez un artefact pour l’afficher.",
     "lines": "lignes",
-    "countSingular": "artefact",
-    "countPlural": "artefacts",
+    "extractsSingular": "extrait",
+    "extractsPlural": "extraits",
     "stored": "stockés",
-    "projects": "projets",
     "allKinds": "Tous les types",
-    "allProjects": "Tous les projets",
+    "inProject": "dans ce projet",
     "saveAs": "Enregistrer sous...",
     "saved": "Artefact enregistré",
     "openInEditor": "Ouvrir dans l’éditeur",

--- a/src/renderer/i18n/locales/fr.json
+++ b/src/renderer/i18n/locales/fr.json
@@ -1181,7 +1181,7 @@
     "separatorSystem": "Système",
     "tabFiles": "Fichiers",
     "tooltipFiles": "Fichiers",
-    "tooltipArtifacts": "Artefacts produits dans ce projet"
+    "tooltipArtifacts": "Artefacts publiés sur claude.ai depuis ce projet"
   },
   "memory": {
     "panelDescription": "Configurez le comportement de Claude dans vos projets. Les reglages globaux s'appliquent partout, les reglages projet les remplacent.",
@@ -2116,14 +2116,12 @@
     "tabTitle": "Artefacts",
     "libraryTitle": "Artefacts",
     "emptySession": "Aucun document produit dans cette conversation pour l’instant.",
-    "emptyLibrary": "Aucun artefact. Ils apparaissent ici au fur et à mesure que Claude produit des pages HTML, des diagrammes, des SVG et du code.",
+    "emptyLibrary": "Aucun artefact publié dans ce projet. Ils apparaissent ici quand Claude publie une page avec l’outil Artifact.",
     "selectPrompt": "Sélectionnez un artefact pour l’afficher.",
     "lines": "lignes",
     "documentsSingular": "document",
     "documentsPlural": "documents",
-    "stored": "stockés",
-    "allKinds": "Tous les types",
-    "inProject": "dans ce projet",
+    "publishedCount": "publiés dans ce projet",
     "saveAs": "Enregistrer sous...",
     "saved": "Artefact enregistré",
     "openInEditor": "Ouvrir dans l’éditeur",

--- a/src/renderer/i18n/locales/fr.json
+++ b/src/renderer/i18n/locales/fr.json
@@ -1180,7 +1180,8 @@
     "separatorCapabilities": "Capacités",
     "separatorSystem": "Système",
     "tabFiles": "Fichiers",
-    "tooltipFiles": "Fichiers"
+    "tooltipFiles": "Fichiers",
+    "tooltipArtifacts": "Bibliothèque d’artefacts : HTML, SVG, diagrammes et code"
   },
   "memory": {
     "panelDescription": "Configurez le comportement de Claude dans vos projets. Les reglages globaux s'appliquent partout, les reglages projet les remplacent.",
@@ -1910,7 +1911,8 @@
     "elicitationSubmit": "Envoyer",
     "elicitationDecline": "Refuser",
     "elicitationOpen": "Continuer",
-    "cancel": "Annuler"
+    "cancel": "Annuler",
+    "tabArtifacts": "Artefacts"
   },
   "hooks": {
     "consent": {
@@ -2109,6 +2111,25 @@
     "analyzeProjectDone": "Doc generee : {title} ({links} lien(s))",
     "analyzeProjectError": "Echec de l'analyse du projet",
     "badge": "WS"
+  },
+  "artifacts": {
+    "tabTitle": "Artefacts",
+    "libraryTitle": "Artefacts",
+    "emptySession": "Aucun artefact dans cette session pour l’instant.",
+    "emptyLibrary": "Aucun artefact. Ils apparaissent ici au fur et à mesure que Claude produit des pages HTML, des diagrammes, des SVG et du code.",
+    "selectPrompt": "Sélectionnez un artefact pour l’afficher.",
+    "lines": "lignes",
+    "countSingular": "artefact",
+    "countPlural": "artefacts",
+    "stored": "stockés",
+    "projects": "projets",
+    "allKinds": "Tous les types",
+    "allProjects": "Tous les projets",
+    "saveAs": "Enregistrer sous...",
+    "saved": "Artefact enregistré",
+    "openInEditor": "Ouvrir dans l’éditeur",
+    "resizePane": "Redimensionner le panneau d’artefact",
+    "jumpToMessage": "Aller au message"
   },
   "errorLog": {
     "title": "Journal d'erreurs",

--- a/src/renderer/i18n/locales/fr.json
+++ b/src/renderer/i18n/locales/fr.json
@@ -1912,7 +1912,7 @@
     "elicitationDecline": "Refuser",
     "elicitationOpen": "Continuer",
     "cancel": "Annuler",
-    "tabExtracts": "Extraits"
+    "tabDocuments": "Documents"
   },
   "hooks": {
     "consent": {
@@ -2115,12 +2115,12 @@
   "artifacts": {
     "tabTitle": "Artefacts",
     "libraryTitle": "Artefacts",
-    "emptySession": "Rien d’extrait de cette conversation pour l’instant.",
+    "emptySession": "Aucun document produit dans cette conversation pour l’instant.",
     "emptyLibrary": "Aucun artefact. Ils apparaissent ici au fur et à mesure que Claude produit des pages HTML, des diagrammes, des SVG et du code.",
     "selectPrompt": "Sélectionnez un artefact pour l’afficher.",
     "lines": "lignes",
-    "extractsSingular": "extrait",
-    "extractsPlural": "extraits",
+    "documentsSingular": "document",
+    "documentsPlural": "documents",
     "stored": "stockés",
     "allKinds": "Tous les types",
     "inProject": "dans ce projet",

--- a/src/renderer/i18n/locales/fr.json
+++ b/src/renderer/i18n/locales/fr.json
@@ -2128,7 +2128,8 @@
     "saved": "Artefact enregistré",
     "openInEditor": "Ouvrir dans l’éditeur",
     "resizePane": "Redimensionner le panneau d’artefact",
-    "jumpToMessage": "Aller au message"
+    "jumpToMessage": "Aller au message",
+    "openPublished": "Ouvrir la page publiée"
   },
   "errorLog": {
     "title": "Journal d'erreurs",

--- a/src/renderer/i18n/locales/id.json
+++ b/src/renderer/i18n/locales/id.json
@@ -1086,7 +1086,7 @@
     "separatorSystem": "Sistem",
     "tabFiles": "Berkas",
     "tooltipFiles": "Berkas",
-    "tooltipArtifacts": "Artefak yang dibuat di proyek ini"
+    "tooltipArtifacts": "Artefak yang diterbitkan ke claude.ai dari proyek ini"
   },
   "memory": {
     "panelDescription": "Atur bagaimana Claude berperilaku dalam proyek Anda. Pengaturan global berlaku di mana saja, pengaturan proyek akan menimpanya.",
@@ -2116,14 +2116,12 @@
     "tabTitle": "Artefak",
     "libraryTitle": "Artefak",
     "emptySession": "Belum ada dokumen yang dibuat dalam percakapan ini.",
-    "emptyLibrary": "Belum ada artefak. Artefak muncul di sini saat Claude membuat halaman HTML, diagram, SVG, dan kode.",
+    "emptyLibrary": "Belum ada artefak yang diterbitkan di proyek ini. Artefak muncul di sini saat Claude menerbitkan halaman dengan alat Artifact.",
     "selectPrompt": "Pilih artefak untuk melihat pratinjaunya.",
     "lines": "baris",
     "documentsSingular": "dokumen",
     "documentsPlural": "dokumen",
-    "stored": "tersimpan",
-    "allKinds": "Semua jenis",
-    "inProject": "di proyek ini",
+    "publishedCount": "diterbitkan di proyek ini",
     "saveAs": "Simpan sebagai...",
     "saved": "Artefak disimpan",
     "openInEditor": "Buka di editor",

--- a/src/renderer/i18n/locales/id.json
+++ b/src/renderer/i18n/locales/id.json
@@ -1086,7 +1086,7 @@
     "separatorSystem": "Sistem",
     "tabFiles": "Berkas",
     "tooltipFiles": "Berkas",
-    "tooltipArtifacts": "Pustaka artefak: HTML, SVG, diagram, dan kode"
+    "tooltipArtifacts": "Artefak yang dibuat di proyek ini"
   },
   "memory": {
     "panelDescription": "Atur bagaimana Claude berperilaku dalam proyek Anda. Pengaturan global berlaku di mana saja, pengaturan proyek akan menimpanya.",
@@ -1912,7 +1912,7 @@
     "elicitationDecline": "Tolak",
     "elicitationOpen": "Lanjutkan",
     "cancel": "Batal",
-    "tabArtifacts": "Artefak"
+    "tabExtracts": "Ekstrak"
   },
   "hooks": {
     "consent": {
@@ -2115,16 +2115,15 @@
   "artifacts": {
     "tabTitle": "Artefak",
     "libraryTitle": "Artefak",
-    "emptySession": "Belum ada artefak di sesi ini.",
+    "emptySession": "Belum ada yang diekstrak dari percakapan ini.",
     "emptyLibrary": "Belum ada artefak. Artefak muncul di sini saat Claude membuat halaman HTML, diagram, SVG, dan kode.",
     "selectPrompt": "Pilih artefak untuk melihat pratinjaunya.",
     "lines": "baris",
-    "countSingular": "artefak",
-    "countPlural": "artefak",
+    "extractsSingular": "ekstrak",
+    "extractsPlural": "ekstrak",
     "stored": "tersimpan",
-    "projects": "proyek",
     "allKinds": "Semua jenis",
-    "allProjects": "Semua proyek",
+    "inProject": "di proyek ini",
     "saveAs": "Simpan sebagai...",
     "saved": "Artefak disimpan",
     "openInEditor": "Buka di editor",

--- a/src/renderer/i18n/locales/id.json
+++ b/src/renderer/i18n/locales/id.json
@@ -2128,7 +2128,8 @@
     "saved": "Artefak disimpan",
     "openInEditor": "Buka di editor",
     "resizePane": "Ubah ukuran panel artefak",
-    "jumpToMessage": "Ke pesan"
+    "jumpToMessage": "Ke pesan",
+    "openPublished": "Buka halaman terbit"
   },
   "errorLog": {
     "title": "Log Kesalahan",

--- a/src/renderer/i18n/locales/id.json
+++ b/src/renderer/i18n/locales/id.json
@@ -1085,7 +1085,8 @@
     "separatorCapabilities": "Kemampuan",
     "separatorSystem": "Sistem",
     "tabFiles": "Berkas",
-    "tooltipFiles": "Berkas"
+    "tooltipFiles": "Berkas",
+    "tooltipArtifacts": "Pustaka artefak: HTML, SVG, diagram, dan kode"
   },
   "memory": {
     "panelDescription": "Atur bagaimana Claude berperilaku dalam proyek Anda. Pengaturan global berlaku di mana saja, pengaturan proyek akan menimpanya.",
@@ -1910,7 +1911,8 @@
     "elicitationSubmit": "Kirim",
     "elicitationDecline": "Tolak",
     "elicitationOpen": "Lanjutkan",
-    "cancel": "Batal"
+    "cancel": "Batal",
+    "tabArtifacts": "Artefak"
   },
   "hooks": {
     "consent": {
@@ -2109,6 +2111,25 @@
     "analyzeProjectDone": "Dokumen dibuat: {title} ({links} tautan)",
     "analyzeProjectError": "Gagal menganalisis proyek",
     "badge": "WS"
+  },
+  "artifacts": {
+    "tabTitle": "Artefak",
+    "libraryTitle": "Artefak",
+    "emptySession": "Belum ada artefak di sesi ini.",
+    "emptyLibrary": "Belum ada artefak. Artefak muncul di sini saat Claude membuat halaman HTML, diagram, SVG, dan kode.",
+    "selectPrompt": "Pilih artefak untuk melihat pratinjaunya.",
+    "lines": "baris",
+    "countSingular": "artefak",
+    "countPlural": "artefak",
+    "stored": "tersimpan",
+    "projects": "proyek",
+    "allKinds": "Semua jenis",
+    "allProjects": "Semua proyek",
+    "saveAs": "Simpan sebagai...",
+    "saved": "Artefak disimpan",
+    "openInEditor": "Buka di editor",
+    "resizePane": "Ubah ukuran panel artefak",
+    "jumpToMessage": "Ke pesan"
   },
   "errorLog": {
     "title": "Log Kesalahan",

--- a/src/renderer/i18n/locales/id.json
+++ b/src/renderer/i18n/locales/id.json
@@ -1912,7 +1912,7 @@
     "elicitationDecline": "Tolak",
     "elicitationOpen": "Lanjutkan",
     "cancel": "Batal",
-    "tabExtracts": "Ekstrak"
+    "tabDocuments": "Dokumen"
   },
   "hooks": {
     "consent": {
@@ -2115,12 +2115,12 @@
   "artifacts": {
     "tabTitle": "Artefak",
     "libraryTitle": "Artefak",
-    "emptySession": "Belum ada yang diekstrak dari percakapan ini.",
+    "emptySession": "Belum ada dokumen yang dibuat dalam percakapan ini.",
     "emptyLibrary": "Belum ada artefak. Artefak muncul di sini saat Claude membuat halaman HTML, diagram, SVG, dan kode.",
     "selectPrompt": "Pilih artefak untuk melihat pratinjaunya.",
     "lines": "baris",
-    "extractsSingular": "ekstrak",
-    "extractsPlural": "ekstrak",
+    "documentsSingular": "dokumen",
+    "documentsPlural": "dokumen",
     "stored": "tersimpan",
     "allKinds": "Semua jenis",
     "inProject": "di proyek ini",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -1086,7 +1086,7 @@
     "separatorSystem": "系统",
     "tabFiles": "文件",
     "tooltipFiles": "文件",
-    "tooltipArtifacts": "产物库：HTML、SVG、图表和代码"
+    "tooltipArtifacts": "在此项目中生成的产物"
   },
   "memory": {
     "panelDescription": "配置 Claude 在您的项目中的行为方式。全局设置适用于所有地方，项目设置会覆盖它们。",
@@ -1912,7 +1912,7 @@
     "elicitationDecline": "拒绝",
     "elicitationOpen": "继续",
     "cancel": "取消",
-    "tabArtifacts": "产物"
+    "tabExtracts": "摘录"
   },
   "hooks": {
     "consent": {
@@ -2115,16 +2115,15 @@
   "artifacts": {
     "tabTitle": "产物",
     "libraryTitle": "产物",
-    "emptySession": "本会话尚无产物。",
+    "emptySession": "尚未从此对话中提取任何内容。",
     "emptyLibrary": "尚无产物。当 Claude 生成 HTML 页面、图表、SVG 和代码时，它们会显示在这里。",
     "selectPrompt": "选择一个产物以预览。",
     "lines": "行",
-    "countSingular": "个产物",
-    "countPlural": "个产物",
+    "extractsSingular": "条摘录",
+    "extractsPlural": "条摘录",
     "stored": "已存储",
-    "projects": "个项目",
     "allKinds": "所有类型",
-    "allProjects": "所有项目",
+    "inProject": "在此项目中",
     "saveAs": "另存为...",
     "saved": "产物已保存",
     "openInEditor": "在编辑器中打开",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -1912,7 +1912,7 @@
     "elicitationDecline": "拒绝",
     "elicitationOpen": "继续",
     "cancel": "取消",
-    "tabExtracts": "摘录"
+    "tabDocuments": "文档"
   },
   "hooks": {
     "consent": {
@@ -2115,12 +2115,12 @@
   "artifacts": {
     "tabTitle": "产物",
     "libraryTitle": "产物",
-    "emptySession": "尚未从此对话中提取任何内容。",
+    "emptySession": "此对话尚未生成任何文档。",
     "emptyLibrary": "尚无产物。当 Claude 生成 HTML 页面、图表、SVG 和代码时，它们会显示在这里。",
     "selectPrompt": "选择一个产物以预览。",
     "lines": "行",
-    "extractsSingular": "条摘录",
-    "extractsPlural": "条摘录",
+    "documentsSingular": "个文档",
+    "documentsPlural": "个文档",
     "stored": "已存储",
     "allKinds": "所有类型",
     "inProject": "在此项目中",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -1086,7 +1086,7 @@
     "separatorSystem": "系统",
     "tabFiles": "文件",
     "tooltipFiles": "文件",
-    "tooltipArtifacts": "在此项目中生成的产物"
+    "tooltipArtifacts": "从此项目发布到 claude.ai 的产物"
   },
   "memory": {
     "panelDescription": "配置 Claude 在您的项目中的行为方式。全局设置适用于所有地方，项目设置会覆盖它们。",
@@ -2116,14 +2116,12 @@
     "tabTitle": "产物",
     "libraryTitle": "产物",
     "emptySession": "此对话尚未生成任何文档。",
-    "emptyLibrary": "尚无产物。当 Claude 生成 HTML 页面、图表、SVG 和代码时，它们会显示在这里。",
+    "emptyLibrary": "此项目还没有已发布的产物。当 Claude 使用 Artifact 工具发布页面时，它们会显示在这里。",
     "selectPrompt": "选择一个产物以预览。",
     "lines": "行",
     "documentsSingular": "个文档",
     "documentsPlural": "个文档",
-    "stored": "已存储",
-    "allKinds": "所有类型",
-    "inProject": "在此项目中",
+    "publishedCount": "个已发布于此项目",
     "saveAs": "另存为...",
     "saved": "产物已保存",
     "openInEditor": "在编辑器中打开",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -1085,7 +1085,8 @@
     "separatorCapabilities": "能力",
     "separatorSystem": "系统",
     "tabFiles": "文件",
-    "tooltipFiles": "文件"
+    "tooltipFiles": "文件",
+    "tooltipArtifacts": "产物库：HTML、SVG、图表和代码"
   },
   "memory": {
     "panelDescription": "配置 Claude 在您的项目中的行为方式。全局设置适用于所有地方，项目设置会覆盖它们。",
@@ -1910,7 +1911,8 @@
     "elicitationSubmit": "提交",
     "elicitationDecline": "拒绝",
     "elicitationOpen": "继续",
-    "cancel": "取消"
+    "cancel": "取消",
+    "tabArtifacts": "产物"
   },
   "hooks": {
     "consent": {
@@ -2109,6 +2111,25 @@
     "analyzeProjectDone": "生成的文档：{title}（{links} 链接）",
     "analyzeProjectError": "无法分析项目",
     "badge": "WS"
+  },
+  "artifacts": {
+    "tabTitle": "产物",
+    "libraryTitle": "产物",
+    "emptySession": "本会话尚无产物。",
+    "emptyLibrary": "尚无产物。当 Claude 生成 HTML 页面、图表、SVG 和代码时，它们会显示在这里。",
+    "selectPrompt": "选择一个产物以预览。",
+    "lines": "行",
+    "countSingular": "个产物",
+    "countPlural": "个产物",
+    "stored": "已存储",
+    "projects": "个项目",
+    "allKinds": "所有类型",
+    "allProjects": "所有项目",
+    "saveAs": "另存为...",
+    "saved": "产物已保存",
+    "openInEditor": "在编辑器中打开",
+    "resizePane": "调整产物面板大小",
+    "jumpToMessage": "跳转到消息"
   },
   "errorLog": {
     "title": "错误日志",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -2128,7 +2128,8 @@
     "saved": "产物已保存",
     "openInEditor": "在编辑器中打开",
     "resizePane": "调整产物面板大小",
-    "jumpToMessage": "跳转到消息"
+    "jumpToMessage": "跳转到消息",
+    "openPublished": "打开已发布页面"
   },
   "errorLog": {
     "title": "错误日志",

--- a/src/renderer/services/ArtifactService.js
+++ b/src/renderer/services/ArtifactService.js
@@ -224,6 +224,55 @@ function fromFileTool(toolName, input) {
   return null;
 }
 
+// ── Published artifacts (the Agent SDK `Artifact` tool) ──────────────────────
+
+/**
+ * Is this tool call a publish worth capturing?
+ *
+ * The tool has two actions: `publish` (the default) uploads a file, and `list`
+ * merely enumerates the gallery. Only the former produces anything.
+ */
+function isArtifactPublish(toolName, input) {
+  return toolName === 'Artifact'
+    && !!input
+    && input.action !== 'list'
+    && !!input.file_path;
+}
+
+/**
+ * Build a `published` artifact from an `Artifact` tool call.
+ *
+ * The tool takes a path, never inline content ("Content always comes from
+ * file_path — there is no inline content parameter"), so the caller reads the
+ * file and passes it in. `url` arrives later, with the tool result, and is
+ * optional: an artifact captured from replayed history has no result to wait
+ * for and is still worth keeping.
+ *
+ * Titles follow the tool's own rule: HTML prefers its <title>, Markdown pages
+ * "keep their filename identity".
+ */
+function fromArtifactTool(input, source, url = null) {
+  if (!input?.file_path) return null;
+  const filename = String(input.file_path).split(/[\\/]/).pop();
+  const isMarkdown = /\.md$/i.test(filename);
+
+  const title = isMarkdown
+    ? filename
+    : (firstMatch(source, /<title[^>]*>([^<]+)<\/title>/i) || input.title || filename);
+
+  return {
+    kind: 'published',
+    lang: isMarkdown ? 'markdown' : 'html',
+    source,
+    title,
+    path: input.file_path,
+    url: url || null,
+    description: input.description || null,
+    favicon: input.favicon || null,
+    id: computeId('published', source),
+  };
+}
+
 // ── Session registry ─────────────────────────────────────────────────────────
 
 /**
@@ -252,6 +301,12 @@ function createRegistry({ project, getSessionId, onChange } = {}) {
       lang: a.lang,
       source: a.source,
       messageIndex: a.messageIndex,
+      // Named explicitly rather than spread: `node` must never reach the
+      // structured-clone boundary, and a DOM node would throw there.
+      url: a.url || null,
+      description: a.description || null,
+      favicon: a.favicon || null,
+      path: a.path || null,
     }));
     pending = [];
     const api = window.electron_api?.artifacts;
@@ -311,6 +366,8 @@ module.exports = {
   MIN_CODE_LINES,
   detect,
   fromFileTool,
+  fromArtifactTool,
+  isArtifactPublish,
   deriveTitle,
   readCodeSource,
   createRegistry,

--- a/src/renderer/services/ArtifactService.js
+++ b/src/renderer/services/ArtifactService.js
@@ -1,0 +1,317 @@
+/**
+ * ArtifactService (renderer)
+ *
+ * Turns rendered chat markdown into a list of artifacts: the self-contained
+ * things Claude produced in a conversation, worth pulling out of the transcript
+ * and keeping (an HTML page, an SVG, a Mermaid diagram, a substantial code
+ * block, a file it wrote).
+ *
+ * Detection runs on the RENDERED DOM rather than on the markdown source. That
+ * is deliberate: the markdown renderer has already decided what each fenced
+ * block is (`blocks/code.js`), so scanning its output means never
+ * re-implementing that dispatch, and it means anything the renderer learns to
+ * render becomes harvestable by adding one selector below.
+ *
+ * The pass must only ever run on FINALIZED content — never mid-stream, where a
+ * half-written ```html block would be captured as a truncated page. ChatView
+ * calls harvest() right after MarkdownRenderer.postProcess(), which is exactly
+ * the set of moments where content is settled: end of stream, block edit, and
+ * history replay.
+ *
+ * Ids come from a content hash (src/shared/artifact-store.js), so re-harvesting
+ * the same conversation on every session resume is idempotent and needs no
+ * bookkeeping on either side.
+ */
+
+const { computeId } = require('../../shared/artifact-schema');
+
+// A fenced code block becomes an artifact from this many lines up. Below it,
+// a snippet is part of the prose, and promoting it would drown the real
+// artifacts in noise.
+const MIN_CODE_LINES = 20;
+
+// `text` is what the renderer prints when a fence carried no language. Those
+// blocks are usually pasted output, not authored code.
+const IGNORED_LANGS = new Set(['text', '']);
+
+// ── Source recovery ──────────────────────────────────────────────────────────
+
+/**
+ * Recover the source of a standard code block from its highlighted DOM.
+ *
+ * configure.js wraps every line in <span class="code-line"> joined by '\n', and
+ * substitutes a single space for empty lines so they keep their height. Reading
+ * textContent therefore returns the original text with one artefact: blank
+ * lines come back as ' '. Restoring exactly those (a line that is a lone space)
+ * is safe, because a source line of exactly one space is not a thing worth
+ * preserving.
+ */
+function readCodeSource(codeEl) {
+  if (!codeEl) return '';
+  return codeEl.textContent.replace(/^ $/gm, '');
+}
+
+/** Text of the first matching descendant, or ''. */
+function textOf(root, selector) {
+  const el = root.querySelector(selector);
+  return el ? el.textContent : '';
+}
+
+// ── Title derivation ─────────────────────────────────────────────────────────
+
+function firstMatch(source, regex) {
+  const m = String(source).match(regex);
+  return m && m[1] ? m[1].trim() : '';
+}
+
+const MERMAID_KINDS = [
+  [/^\s*(graph|flowchart)\b/i, 'Flowchart'],
+  [/^\s*sequenceDiagram\b/i, 'Sequence diagram'],
+  [/^\s*classDiagram\b/i, 'Class diagram'],
+  [/^\s*stateDiagram/i, 'State diagram'],
+  [/^\s*erDiagram\b/i, 'ER diagram'],
+  [/^\s*gantt\b/i, 'Gantt chart'],
+  [/^\s*pie\b/i, 'Pie chart'],
+  [/^\s*journey\b/i, 'User journey'],
+  [/^\s*mindmap\b/i, 'Mind map'],
+];
+
+/** First non-trivial comment line of a snippet, used as a fallback title. */
+function firstCommentTitle(source) {
+  for (const line of String(source).split('\n', 12)) {
+    const m = line.match(/^\s*(?:\/\/|#|--|\*|<!--)\s*(.{3,80}?)\s*(?:-->)?\s*$/);
+    if (m && !/^[-=*_#\s]+$/.test(m[1])) return m[1];
+  }
+  return '';
+}
+
+/**
+ * A human-readable name for the artifact. This is also what groups versions
+ * together, so it has to be stable across rewrites of the same thing: prefer
+ * an explicit name the author gave (filename, <title>) over anything derived
+ * from the body, which changes on every edit.
+ */
+function deriveTitle(kind, source, hints = {}) {
+  if (hints.filename) return hints.filename;
+
+  switch (kind) {
+    case 'html': {
+      return firstMatch(source, /<title[^>]*>([^<]+)<\/title>/i)
+        || firstMatch(source, /<h1[^>]*>([^<]+)<\/h1>/i)
+        || 'Preview';
+    }
+    case 'svg': {
+      return firstMatch(source, /<title[^>]*>([^<]+)<\/title>/i)
+        || firstMatch(source, /aria-label="([^"]+)"/i)
+        || 'SVG';
+    }
+    case 'mermaid': {
+      const explicit = firstMatch(source, /^\s*title:\s*(.+)$/im);
+      if (explicit) return explicit;
+      const kindMatch = MERMAID_KINDS.find(([re]) => re.test(source));
+      return kindMatch ? kindMatch[1] : 'Diagram';
+    }
+    case 'file':
+      return String(hints.path || '').split(/[\\/]/).pop() || 'File';
+    default: {
+      const comment = firstCommentTitle(source);
+      if (comment) return comment;
+      return hints.lang ? `${hints.lang} snippet` : 'Snippet';
+    }
+  }
+}
+
+// ── Detection ────────────────────────────────────────────────────────────────
+
+/** Extract the artifact carried by one DOM node, or null. */
+function readNode(node) {
+  if (node.classList.contains('chat-preview-container')) {
+    const source = textOf(node, '.chat-preview-source');
+    if (!source.trim()) return null;
+    const filename = node.dataset.filename || '';
+    return { kind: 'html', lang: 'html', source, title: deriveTitle('html', source, { filename }) };
+  }
+
+  if (node.classList.contains('chat-svg-block')) {
+    const source = textOf(node, '.chat-svg-source pre code');
+    if (!source.trim()) return null;
+    return { kind: 'svg', lang: 'svg', source, title: deriveTitle('svg', source) };
+  }
+
+  if (node.classList.contains('chat-mermaid-block')) {
+    const source = textOf(node, '.chat-mermaid-source');
+    if (!source.trim()) return null;
+    return { kind: 'mermaid', lang: 'mermaid', source, title: deriveTitle('mermaid', source) };
+  }
+
+  if (node.classList.contains('chat-code-block')) {
+    // Diff blocks share the class but carry no recoverable source (the +/- are
+    // stripped into separate spans), and they are already a view of a change
+    // rather than a thing in their own right.
+    if (node.classList.contains('chat-diff-block')) return null;
+    const lang = textOf(node, '.chat-code-lang').trim().toLowerCase();
+    if (IGNORED_LANGS.has(lang)) return null;
+    const source = readCodeSource(node.querySelector('pre code'));
+    if (source.split('\n').length < MIN_CODE_LINES) return null;
+    const filename = textOf(node, '.chat-code-filename').trim();
+    return { kind: 'code', lang, source, title: deriveTitle('code', source, { filename, lang }) };
+  }
+
+  return null;
+}
+
+const ARTIFACT_SELECTOR = '.chat-preview-container, .chat-svg-block, .chat-mermaid-block, .chat-code-block';
+
+/**
+ * Scan already-rendered nodes for artifacts.
+ *
+ * @param {Element|Element[]} roots  a message element, or the batch of elements
+ *                                   postProcess() was just handed
+ * @param {{messageIndex?: number}} [context]
+ * @returns {object[]} artifacts in document order, without store metadata
+ */
+function detect(roots, context = {}) {
+  const list = Array.isArray(roots) ? roots : [roots];
+  const found = [];
+
+  for (const root of list) {
+    if (!root || root.nodeType !== 1) continue;
+    const nodes = [];
+    if (root.matches?.(ARTIFACT_SELECTOR)) nodes.push(root);
+    nodes.push(...root.querySelectorAll(ARTIFACT_SELECTOR));
+
+    for (const node of nodes) {
+      // A preview container holds its own code view; a code block nested in one
+      // is a rendering detail, not a second artifact.
+      if (node.classList.contains('chat-code-block') && node.closest('.chat-preview-container')) continue;
+      let artifact;
+      try {
+        artifact = readNode(node);
+      } catch (e) {
+        console.warn('[Artifacts] node read failed:', e.message);
+        continue;
+      }
+      if (!artifact) continue;
+      artifact.id = computeId(artifact.kind, artifact.source);
+      artifact.messageIndex = context.messageIndex ?? null;
+      // Session-only: lets the UI scroll back to where the artifact came from.
+      // Deliberately not persisted — the registry copies named fields into the
+      // store, so a DOM node never reaches the structured-clone boundary.
+      artifact.node = node;
+      found.push(artifact);
+    }
+  }
+  return found;
+}
+
+/**
+ * Artifacts produced by a file-editing tool call. These have no DOM of their
+ * own worth scanning: the interesting content is the tool input.
+ */
+function fromFileTool(toolName, input) {
+  if (!input) return null;
+  if (toolName === 'Write' && input.file_path && input.content) {
+    const source = String(input.content);
+    return {
+      kind: 'file',
+      lang: null,
+      source,
+      title: deriveTitle('file', source, { path: input.file_path }),
+      path: input.file_path,
+      id: computeId('file', source),
+    };
+  }
+  return null;
+}
+
+// ── Session registry ─────────────────────────────────────────────────────────
+
+/**
+ * One registry per ChatView instance. Holds what the current conversation has
+ * produced, in order, deduplicated by content id, and pushes new entries to the
+ * persistent store in batches.
+ */
+function createRegistry({ project, getSessionId, onChange } = {}) {
+  const byId = new Map();
+  // Artifacts seen but not yet persisted. Flushing is debounced because a
+  // history replay calls add() once per batch of messages.
+  let pending = [];
+  let flushTimer = null;
+
+  function flush() {
+    clearTimeout(flushTimer);
+    flushTimer = null;
+    if (!pending.length) return;
+    const batch = pending.map((a) => ({
+      id: a.id,
+      projectId: project?.id || null,
+      projectName: project?.name || null,
+      sessionId: typeof getSessionId === 'function' ? getSessionId() : null,
+      kind: a.kind,
+      title: a.title,
+      lang: a.lang,
+      source: a.source,
+      messageIndex: a.messageIndex,
+    }));
+    pending = [];
+    const api = window.electron_api?.artifacts;
+    if (!api) return; // persistence is optional; the session list still works
+    api.saveMany(batch).catch((e) => console.warn('[Artifacts] persist failed:', e.message));
+  }
+
+  function scheduleFlush() {
+    if (flushTimer) return;
+    flushTimer = setTimeout(flush, 500);
+  }
+
+  return {
+    /** @returns {number} how many were new */
+    add(artifacts) {
+      const list = Array.isArray(artifacts) ? artifacts : [artifacts];
+      let added = 0;
+      for (const artifact of list) {
+        if (!artifact || byId.has(artifact.id)) continue;
+        byId.set(artifact.id, { ...artifact, createdAt: new Date().toISOString() });
+        pending.push(artifact);
+        added++;
+      }
+      if (added) {
+        scheduleFlush();
+        onChange?.(added);
+      }
+      return added;
+    },
+
+    /** Everything this session produced, in the order it was produced. */
+    list() {
+      return [...byId.values()];
+    },
+
+    get(id) {
+      return byId.get(id) || null;
+    },
+
+    get size() {
+      return byId.size;
+    },
+
+    clear() {
+      byId.clear();
+      pending = [];
+      clearTimeout(flushTimer);
+      flushTimer = null;
+    },
+
+    /** Persist immediately, e.g. before the view is destroyed. */
+    flush,
+  };
+}
+
+module.exports = {
+  MIN_CODE_LINES,
+  detect,
+  fromFileTool,
+  deriveTitle,
+  readCodeSource,
+  createRegistry,
+};

--- a/src/renderer/services/ArtifactService.js
+++ b/src/renderer/services/ArtifactService.js
@@ -151,7 +151,20 @@ function readNode(node) {
     if (node.classList.contains('chat-diff-block')) return null;
     const lang = textOf(node, '.chat-code-lang').trim().toLowerCase();
     if (IGNORED_LANGS.has(lang)) return null;
-    const source = readCodeSource(node.querySelector('pre code'));
+
+    const codeEl = node.querySelector('pre code');
+    if (!codeEl) return null;
+    // Reject on the line threshold BEFORE serializing the block. The renderer
+    // emits exactly one <span class="code-line"> per line as a direct child of
+    // <code>, so childElementCount is the line count for free — reading
+    // textContent first meant every short snippet in the transcript paid a full
+    // string build only to be thrown away. A live count beats querySelectorAll
+    // here, which walks the whole subtree.
+    const lineCount = codeEl.childElementCount;
+    if (lineCount && lineCount < MIN_CODE_LINES) return null;
+
+    const source = readCodeSource(codeEl);
+    // Fallback for markup without per-line spans, where the count above is 0.
     if (source.split('\n').length < MIN_CODE_LINES) return null;
     const filename = textOf(node, '.chat-code-filename').trim();
     return { kind: 'code', lang, source, title: deriveTitle('code', source, { filename, lang }) };

--- a/src/renderer/services/markdown/blocks/code.js
+++ b/src/renderer/services/markdown/blocks/code.js
@@ -108,7 +108,9 @@ function renderHtmlPreviewBlock(code, filename) {
     + `<button class="chat-preview-btn active" data-action="preview">${escapeHtml(t('chat.preview.title') || 'Preview')}</button>`
     + `<button class="chat-preview-btn" data-action="code">${escapeHtml(t('chat.preview.code') || 'Code')}</button>`
     + `<span class="chat-preview-sep"></span>`
-    + `<button class="chat-preview-btn" data-action="viewport-desktop" title="${t('chat.preview.desktop') || 'Desktop'}"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg></button>`
+    // Desktop is the initial state — the container carries no viewport-* class
+    // until one is picked — so it starts highlighted.
+    + `<button class="chat-preview-btn active" data-action="viewport-desktop" title="${t('chat.preview.desktop') || 'Desktop'}"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg></button>`
     + `<button class="chat-preview-btn" data-action="viewport-tablet" title="${t('chat.preview.tablet') || 'Tablet'}"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="4" y="2" width="16" height="20" rx="2"/><line x1="12" y1="18" x2="12.01" y2="18"/></svg></button>`
     + `<button class="chat-preview-btn" data-action="viewport-mobile" title="${t('chat.preview.mobile') || 'Mobile'}"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="5" y="2" width="14" height="20" rx="2"/><line x1="12" y1="18" x2="12.01" y2="18"/></svg></button>`
     + `<span class="chat-preview-sep"></span>`

--- a/src/renderer/services/markdown/interactivity.js
+++ b/src/renderer/services/markdown/interactivity.js
@@ -423,6 +423,11 @@ function handlePreviewAction(btn) {
     if (viewport !== 'desktop') {
       container.classList.add(`viewport-${viewport}`);
     }
+    // Move the highlight the way the Preview/Code pair does. Without this the
+    // three viewport buttons looked identical whatever was selected, so the
+    // current width was invisible.
+    container.querySelectorAll('.chat-preview-btn[data-action^="viewport-"]')
+      .forEach(b => b.classList.toggle('active', b === btn));
     return;
   }
 }

--- a/src/renderer/state/settings.state.js
+++ b/src/renderer/state/settings.state.js
@@ -70,7 +70,7 @@ const defaultSettings = {
   enhancePrompts: false, // Opt-in: reformulate prompts via Haiku for better prompt engineering before sending
   // Every tab is pinned by default: the grouped sidebar fits without overflow,
   // so the More menu is now opt-in rather than the default state.
-  pinnedTabs: ['claude', 'dashboard', 'files', 'git', 'session-replay', 'tasks', 'control-tower', 'workspace', 'memory', 'timetracking', 'database', 'skills', 'agents', 'plugins', 'mcp', 'workflows', 'errorlog', 'connectivity'],
+  pinnedTabs: ['claude', 'dashboard', 'files', 'git', 'session-replay', 'tasks', 'artifacts', 'control-tower', 'workspace', 'memory', 'timetracking', 'database', 'skills', 'agents', 'plugins', 'mcp', 'workflows', 'errorlog', 'connectivity'],
   activeTab: 'claude', // Last active sidebar tab (restored on restart)
   openProjectIds: [], // Projects with a tab in the project bar, in tab order (restored on restart)
   navigationMode: null, // 'tabs' | 'sidebar' | null = never chosen, ask once on next launch
@@ -146,10 +146,11 @@ function _migrateSettings(saved) {
     saved.activeTab = 'connectivity';
   }
 
-  // Workspaces and Error Log were never in the default pinned set, so nobody
-  // could have deliberately unpinned them. The grouped sidebar has room now.
+  // Workspaces, Error Log and Artifacts were never in the default pinned set,
+  // so nobody could have deliberately unpinned them. The grouped sidebar has
+  // room now.
   if (Array.isArray(saved.pinnedTabs)) {
-    for (const id of ['workspace', 'errorlog']) {
+    for (const id of ['workspace', 'errorlog', 'artifacts']) {
       if (!saved.pinnedTabs.includes(id)) saved.pinnedTabs.push(id);
     }
     // Files is new, so an existing array cannot have deliberately excluded it.

--- a/src/renderer/ui/components/ChatView.js
+++ b/src/renderer/ui/components/ChatView.js
@@ -3952,12 +3952,58 @@ class ChatView extends BaseComponent {
     onChange: () => updateArtifactsTab(),
   });
 
-  function recordFileChange(toolName, input, toolUseId) {
+  // Publishes waiting on their tool result, which is where the URL lives.
+  // Keyed by tool_use_id; entries are consumed by resolveArtifactPublish.
+  const pendingPublishes = new Map();
+
+  /**
+   * Read the file an `Artifact` call published and register it as an extract.
+   * The tool takes a path and never inline content, so the content has to come
+   * off disk here.
+   */
+  async function capturePublishedArtifact(input, url) {
+    const { fsp } = require('../../utils/fs-async');
+    let source;
+    try {
+      source = await fsp.readFile(input.file_path, 'utf8');
+    } catch (e) {
+      // Often a temp file that is already gone. Without content there is
+      // nothing to preview, and a sourceless card would just be dead weight.
+      console.warn('[ChatView] published artifact unreadable:', e.message);
+      return;
+    }
+    artifactRegistry.add(ArtifactService.fromArtifactTool(input, source, url));
+  }
+
+  /** Pair a tool result with its pending publish and capture the artifact. */
+  function resolveArtifactPublish(toolUseId, resultText) {
+    const input = pendingPublishes.get(toolUseId);
+    if (!input) return;
+    pendingPublishes.delete(toolUseId);
+    const parsed = parseResultJson(resultText || '');
+    const url = parsed?.url || (String(resultText || '').match(/https?:\/\/\S+/) || [])[0] || null;
+    capturePublishedArtifact(input, url);
+  }
+
+  function recordFileChange(toolName, input, toolUseId = null) {
     if (!input || !toolName) return;
+    // A subagent tool_use arrives twice, once streamed and once in the full
+    // assistant message — the id keeps publishes and tallies counted once.
     if (toolUseId) {
       if (recordedToolUseIds.has(toolUseId)) return;
       recordedToolUseIds.add(toolUseId);
     }
+
+    // The `Artifact` tool publishes an .html/.md file to claude.ai. Unlike every
+    // other extract this one is explicit, so it is captured from the tool call
+    // rather than inferred from the transcript — and deferred until the result
+    // arrives, both to pick up the published URL and to skip failed publishes.
+    if (ArtifactService.isArtifactPublish(toolName, input)) {
+      if (toolUseId) pendingPublishes.set(toolUseId, input);
+      else capturePublishedArtifact(input, null);
+      return;
+    }
+
     // A `Write` authors a complete file, which is an artifact in its own right.
     // `Edit`/`MultiEdit` only amend an existing one — that is what the Changes
     // tab is for, and mirroring them here would just duplicate it.
@@ -4305,7 +4351,7 @@ class ChatView extends BaseComponent {
   }
 
   const ARTIFACT_KIND_LABEL = {
-    html: 'HTML', svg: 'SVG', mermaid: 'Diagram', code: 'Code', file: 'File',
+    published: 'Published', html: 'HTML', svg: 'SVG', mermaid: 'Diagram', code: 'Code', file: 'File',
   };
 
   /** Cards, newest first, one per artifact. */
@@ -4322,11 +4368,20 @@ class ChatView extends BaseComponent {
       const meta = a.kind === 'code' || a.kind === 'file'
         ? `${a.lines || a.source.split('\n').length} ${escapeHtml(t('artifacts.lines') || 'lines')}`
         : escapeHtml(a.lang || kindLabel);
+      // A published artifact brought its own emoji and subtitle from the
+      // Artifact tool; nothing else has either.
+      const thumb = a.favicon
+        ? `<span class="chat-artifact-favicon">${escapeHtml(a.favicon)}</span>`
+        : artifactGlyph(a.kind);
+      const sub = a.description
+        ? `<span class="chat-artifact-card-desc">${escapeHtml(a.description)}</span>`
+        : '';
       return `
         <button class="chat-artifact-card${a.id === openId ? ' active' : ''}" data-artifact-id="${escapeHtml(a.id)}" title="${escapeHtml(a.title)}">
-          <span class="chat-artifact-thumb" data-kind="${escapeHtml(a.kind)}">${artifactGlyph(a.kind)}</span>
+          <span class="chat-artifact-thumb" data-kind="${escapeHtml(a.kind)}">${thumb}</span>
           <span class="chat-artifact-card-text">
             <span class="chat-artifact-card-title">${escapeHtml(a.title)}</span>
+            ${sub}
             <span class="chat-artifact-card-meta">
               <span class="chat-artifact-kind">${escapeHtml(kindLabel)}</span>
               <span class="chat-artifact-dot">•</span>
@@ -4432,11 +4487,17 @@ class ChatView extends BaseComponent {
         <button class="chat-artifact-action" data-action="copy">${escapeHtml(t('common.copy') || 'Copy')}</button>
         <button class="chat-artifact-action" data-action="save">${escapeHtml(t('artifacts.saveAs') || 'Save as...')}</button>
         ${canOpenInEditor ? `<button class="chat-artifact-action" data-action="edit">${escapeHtml(t('artifacts.openInEditor') || 'Open in editor')}</button>` : ''}
+        ${artifact.url ? `<button class="chat-artifact-action" data-action="open-url">${escapeHtml(t('artifacts.openPublished') || 'Open published page')}</button>` : ''}
         ${artifact.node?.isConnected ? `<button class="chat-artifact-action" data-action="reveal">${escapeHtml(t('artifacts.jumpToMessage') || 'Go to message')}</button>` : ''}
       </div>
     `;
 
-    artifactBodyEl.innerHTML = renderMarkdown(artifactAsMarkdown(artifact));
+    // A published Markdown page IS a document — render it as one rather than
+    // fencing it into a code block showing its own syntax. Everything else goes
+    // through a fence so the renderer picks the right block for it.
+    const isMarkdownDoc = artifact.kind === 'published' && artifact.lang === 'markdown';
+    artifactBodyEl.innerHTML = renderMarkdown(isMarkdownDoc ? artifact.source : artifactAsMarkdown(artifact));
+    artifactBodyEl.classList.toggle('chat-artifact-doc', isMarkdownDoc);
     MarkdownRenderer.postProcess(artifactBodyEl);
   }
 
@@ -4480,6 +4541,9 @@ class ChatView extends BaseComponent {
       }
       case 'edit':
         api.dialog.openInEditor({ editor: getSetting('editor') || 'code', path: artifact.path });
+        break;
+      case 'open-url':
+        if (artifact.url) api.dialog.openExternal(artifact.url);
         break;
       case 'reveal': {
         // The transcript pruner detaches old messages, so the node can be alive
@@ -6413,6 +6477,16 @@ class ChatView extends BaseComponent {
   }
 
   function processToolResultBlock(block) {
+    // Artifact publish — the result is where the claude.ai URL comes from.
+    // Runs before the early returns below so it is never skipped.
+    if (block.tool_use_id && pendingPublishes.has(block.tool_use_id)) {
+      const raw = typeof block.content === 'string' ? block.content
+        : Array.isArray(block.content) ? block.content.map(b => b.text || '').join('\n') : '';
+      // A failed publish produced nothing worth listing; drop it.
+      if (block.is_error) pendingPublishes.delete(block.tool_use_id);
+      else resolveArtifactPublish(block.tool_use_id, raw);
+    }
+
     // TaskCreate result — promote pending temp id to real task id
     if (block.tool_use_id && pendingCreateByUseId.has(block.tool_use_id)) {
       const raw = typeof block.content === 'string' ? block.content
@@ -7468,6 +7542,9 @@ class ChatView extends BaseComponent {
           }
           if (msg.toolUseId && toolResults.has(msg.toolUseId)) {
             el.dataset.toolOutput = toolResults.get(msg.toolUseId);
+            // History carries results too, so a replayed publish recovers its
+            // URL exactly like a live one.
+            resolveArtifactPublish(msg.toolUseId, toolResults.get(msg.toolUseId));
           }
 
           // Group consecutive same-tool cards in history

--- a/src/renderer/ui/components/ChatView.js
+++ b/src/renderer/ui/components/ChatView.js
@@ -140,6 +140,7 @@ const EFFORT_OPTIONS = [
 
 const MarkdownRenderer = require('../../services/MarkdownRenderer');
 const DiffRenderer = require('../../services/DiffRenderer');
+const ArtifactService = require('../../services/ArtifactService');
 
 function renderMarkdown(text) {
   return MarkdownRenderer.render(text);
@@ -454,13 +455,22 @@ class ChatView extends BaseComponent {
 
   // ── Build DOM ──
 
+  // `.chat-view` is a row: the conversation column plus the artifact pane that
+  // slides in beside it. Everything that was in the view before now lives in
+  // `.chat-main`, whose inner indentation is left alone so the diff stays
+  // readable.
   wrapperEl.innerHTML = `
     <div class="chat-view">
+      <div class="chat-main">
       <div class="chat-tabbar" hidden>
         <button class="chat-tab active" data-tab="conversation">${escapeHtml(t('chat.tabConversation') || 'Conversation')}</button>
         <button class="chat-tab" data-tab="changes">
           <span class="chat-tab-label">${escapeHtml(t('chat.tabChanges') || 'Changes')}</span>
-          <span class="chat-tab-badge" hidden>0</span>
+          <span class="chat-tab-badge" data-badge="changes" hidden>0</span>
+        </button>
+        <button class="chat-tab" data-tab="artifacts">
+          <span class="chat-tab-label">${escapeHtml(t('chat.tabArtifacts') || 'Artifacts')}</span>
+          <span class="chat-tab-badge" data-badge="artifacts" hidden>0</span>
         </button>
       </div>
       <div class="chat-search" hidden>
@@ -484,6 +494,7 @@ class ChatView extends BaseComponent {
         </div>
       </div>
       <div class="chat-changes-panel" hidden></div>
+      <div class="chat-artifacts-panel" hidden></div>
       <div class="chat-input-area">
         <div class="chat-mention-dropdown" style="display:none"></div>
         <div class="chat-slash-dropdown" style="display:none"></div>
@@ -533,6 +544,15 @@ class ChatView extends BaseComponent {
           </div>
         </div>
       </div>
+      </div>
+      <aside class="chat-artifact-pane" hidden>
+        <div class="chat-artifact-resizer" role="separator" aria-orientation="vertical" tabindex="0"
+             aria-label="${escapeHtml(t('artifacts.resizePane') || 'Resize artifact panel')}"></div>
+        <div class="chat-artifact-pane-inner">
+          <div class="chat-artifact-head"></div>
+          <div class="chat-artifact-body"></div>
+        </div>
+      </aside>
     </div>
   `;
 
@@ -540,7 +560,12 @@ class ChatView extends BaseComponent {
   const messagesEl = chatView.querySelector('.chat-messages');
   const tabbarEl = chatView.querySelector('.chat-tabbar');
   const changesPanelEl = chatView.querySelector('.chat-changes-panel');
-  const changesBadgeEl = chatView.querySelector('.chat-tab-badge');
+  const artifactsPanelEl = chatView.querySelector('.chat-artifacts-panel');
+  const artifactPaneEl = chatView.querySelector('.chat-artifact-pane');
+  const artifactHeadEl = chatView.querySelector('.chat-artifact-head');
+  const artifactBodyEl = chatView.querySelector('.chat-artifact-body');
+  const changesBadgeEl = chatView.querySelector('.chat-tab-badge[data-badge="changes"]');
+  const artifactsBadgeEl = chatView.querySelector('.chat-tab-badge[data-badge="artifacts"]');
   const inputEl = chatView.querySelector('.chat-input');
   const sendBtn = chatView.querySelector('.chat-send-btn');
   const stopBtn = chatView.querySelector('.chat-stop-btn');
@@ -3777,6 +3802,9 @@ class ChatView extends BaseComponent {
       }
       injectInlineImages(currentStreamEl);
       MarkdownRenderer.postProcess(currentStreamEl);
+      // Finalization is the first moment the block is settled: harvesting any
+      // earlier would capture a truncated ```html page mid-stream.
+      harvestArtifacts(currentStreamEl);
     }
     if (currentStreamText) conversationHistory.push({ role: 'assistant', content: currentStreamText });
     currentStreamEl = null;
@@ -3916,12 +3944,26 @@ class ChatView extends BaseComponent {
   // assistant message, so count it by id.
   const recordedToolUseIds = new Set();
 
+  // Artifacts this session produced. Session-scoped like the tally below, and
+  // fed from the same recordFileChange() the tool stream already drives.
+  const artifactRegistry = ArtifactService.createRegistry({
+    project,
+    getSessionId: () => sessionId,
+    onChange: () => updateArtifactsTab(),
+  });
+
   function recordFileChange(toolName, input, toolUseId) {
     if (!input || !toolName) return;
     if (toolUseId) {
       if (recordedToolUseIds.has(toolUseId)) return;
       recordedToolUseIds.add(toolUseId);
     }
+    // A `Write` authors a complete file, which is an artifact in its own right.
+    // `Edit`/`MultiEdit` only amend an existing one — that is what the Changes
+    // tab is for, and mirroring them here would just duplicate it.
+    const fileArtifact = ArtifactService.fromFileTool(toolName, input);
+    if (fileArtifact) artifactRegistry.add(fileArtifact);
+
     let path = null;
     switch (toolName) {
       case 'Write':
@@ -3970,13 +4012,14 @@ class ChatView extends BaseComponent {
   }
 
   function switchChatTab(tab) {
-    const isChanges = tab === 'changes';
     tabbarEl.querySelectorAll('.chat-tab').forEach((btn) => {
       btn.classList.toggle('active', btn.dataset.tab === tab);
     });
-    messagesEl.hidden = isChanges;
-    changesPanelEl.hidden = !isChanges;
-    if (isChanges) renderChangesPanel();
+    messagesEl.hidden = tab !== 'conversation';
+    changesPanelEl.hidden = tab !== 'changes';
+    artifactsPanelEl.hidden = tab !== 'artifacts';
+    if (tab === 'changes') renderChangesPanel();
+    if (tab === 'artifacts') renderArtifactsPanel();
   }
 
   // ── This session's changes ──
@@ -4222,6 +4265,262 @@ class ChatView extends BaseComponent {
     e.preventDefault();
     toggleFileDiff(row.closest('.chat-change-item'));
   });
+
+  // ── Artifacts tab ──
+  //
+  // Artifacts are the self-contained things Claude produced in this session: an
+  // HTML page, an SVG, a diagram, a long code block, a file it wrote. They are
+  // detected by scanning the rendered markdown (see ArtifactService), so the tab
+  // repopulates itself for free when a session is resumed and the transcript is
+  // replayed.
+
+  /**
+   * Pull artifacts out of freshly rendered nodes.
+   * Only ever called on settled content — never mid-stream, where a half-written
+   * ```html block would be captured as a truncated page.
+   */
+  function harvestArtifacts(nodes) {
+    if (!nodes) return;
+    try {
+      artifactRegistry.add(ArtifactService.detect(nodes, { messageIndex: messagesEl.children.length }));
+    } catch (e) {
+      // Harvesting is an enhancement; it must never break the transcript.
+      console.warn('[ChatView] artifact harvest failed:', e.message);
+    }
+  }
+
+  function updateArtifactsTab() {
+    const count = artifactRegistry.size;
+    if (count > 0 && tabbarEl.hidden) tabbarEl.hidden = false;
+    if (artifactsBadgeEl) {
+      artifactsBadgeEl.textContent = String(count);
+      artifactsBadgeEl.hidden = count === 0;
+    }
+    if (!artifactsPanelEl.hidden) renderArtifactsPanel();
+  }
+
+  const ARTIFACT_KIND_LABEL = {
+    html: 'HTML', svg: 'SVG', mermaid: 'Diagram', code: 'Code', file: 'File',
+  };
+
+  /** Cards, newest first, one per artifact. */
+  function renderArtifactsPanel() {
+    const artifacts = artifactRegistry.list().reverse();
+    if (!artifacts.length) {
+      artifactsPanelEl.innerHTML = `<div class="chat-artifacts-empty">${escapeHtml(t('artifacts.emptySession') || 'No artifacts in this session yet.')}</div>`;
+      return;
+    }
+
+    const openId = artifactPaneEl.dataset.artifactId || '';
+    const cards = artifacts.map((a) => {
+      const kindLabel = ARTIFACT_KIND_LABEL[a.kind] || a.kind;
+      const meta = a.kind === 'code' || a.kind === 'file'
+        ? `${a.lines || a.source.split('\n').length} ${escapeHtml(t('artifacts.lines') || 'lines')}`
+        : escapeHtml(a.lang || kindLabel);
+      return `
+        <button class="chat-artifact-card${a.id === openId ? ' active' : ''}" data-artifact-id="${escapeHtml(a.id)}" title="${escapeHtml(a.title)}">
+          <span class="chat-artifact-thumb" data-kind="${escapeHtml(a.kind)}">${artifactGlyph(a.kind)}</span>
+          <span class="chat-artifact-card-text">
+            <span class="chat-artifact-card-title">${escapeHtml(a.title)}</span>
+            <span class="chat-artifact-card-meta">
+              <span class="chat-artifact-kind">${escapeHtml(kindLabel)}</span>
+              <span class="chat-artifact-dot">•</span>
+              <span>${meta}</span>
+            </span>
+          </span>
+        </button>`;
+    }).join('');
+
+    const label = artifacts.length > 1
+      ? (t('artifacts.countPlural') || 'artifacts')
+      : (t('artifacts.countSingular') || 'artifact');
+    artifactsPanelEl.innerHTML = `
+      <div class="chat-artifacts-summary">
+        <span class="chat-artifacts-count">${artifacts.length} ${escapeHtml(label)}</span>
+      </div>
+      <div class="chat-artifacts-grid">${cards}</div>
+    `;
+  }
+
+  function artifactGlyph(kind) {
+    switch (kind) {
+      case 'html':
+        return '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="M2 9h20"/></svg>';
+      case 'svg':
+        return '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3a15 15 0 010 18a15 15 0 010-18"/></svg>';
+      case 'mermaid':
+        return '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="5" rx="1"/><rect x="14" y="16" width="7" height="5" rx="1"/><path d="M6.5 8v6a2 2 0 002 2h5.5"/></svg>';
+      case 'file':
+        return '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><path d="M14 2v6h6"/></svg>';
+      default:
+        return '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>';
+    }
+  }
+
+  // ── Artifact split-pane ──
+
+  /**
+   * Fence an artifact back into markdown and let the normal renderer display it.
+   *
+   * This is what keeps the viewer small: the HTML preview (with its viewport
+   * toolbar), the Mermaid lazy render, the SVG sanitizer and the syntax
+   * highlighter all already exist as markdown blocks. Re-rendering also
+   * re-registers the ct-preview:// document, which matters because those are
+   * held in a bounded LRU (src/main/ipc/preview.ipc.js) — reusing the iframe
+   * from the transcript would eventually show a blank page.
+   */
+  function artifactAsMarkdown(artifact) {
+    const langByKind = { html: 'html', svg: 'svg', mermaid: 'mermaid' };
+    let lang = langByKind[artifact.kind] || artifact.lang || '';
+    if (artifact.kind === 'file') lang = guessLangFromPath(artifact.title);
+    // A fence has to be longer than the longest backtick run in the body.
+    const longestRun = (artifact.source.match(/`+/g) || []).reduce((max, run) => Math.max(max, run.length), 0);
+    const fence = '`'.repeat(Math.max(3, longestRun + 1));
+    return `${fence}${lang}\n${artifact.source}\n${fence}`;
+  }
+
+  const LANG_BY_EXT = {
+    js: 'javascript', jsx: 'jsx', ts: 'typescript', tsx: 'tsx', py: 'python',
+    rs: 'rust', go: 'go', java: 'java', rb: 'ruby', php: 'php', cs: 'csharp',
+    cpp: 'cpp', c: 'c', lua: 'lua', sql: 'sql', sh: 'bash', json: 'json',
+    yml: 'yaml', yaml: 'yaml', toml: 'toml', xml: 'xml', css: 'css',
+    scss: 'scss', md: 'markdown', html: 'html', svg: 'svg',
+  };
+
+  function guessLangFromPath(name) {
+    const ext = String(name || '').split('.').pop().toLowerCase();
+    return LANG_BY_EXT[ext] || '';
+  }
+
+  function openArtifact(id) {
+    const artifact = artifactRegistry.get(id);
+    if (!artifact) return;
+    artifactPaneEl.dataset.artifactId = id;
+    artifactPaneEl.hidden = false;
+    chatView.classList.add('artifact-open');
+    renderArtifactPane(artifact);
+    // Keep the grid's selection ring in sync when it is the visible tab.
+    if (!artifactsPanelEl.hidden) renderArtifactsPanel();
+  }
+
+  function closeArtifactPane() {
+    artifactPaneEl.hidden = true;
+    delete artifactPaneEl.dataset.artifactId;
+    chatView.classList.remove('artifact-open');
+    artifactBodyEl.innerHTML = '';
+    artifactHeadEl.innerHTML = '';
+    if (!artifactsPanelEl.hidden) renderArtifactsPanel();
+  }
+
+  function renderArtifactPane(artifact) {
+    const kindLabel = ARTIFACT_KIND_LABEL[artifact.kind] || artifact.kind;
+    const canOpenInEditor = artifact.kind === 'file' && artifact.path;
+    artifactHeadEl.innerHTML = `
+      <div class="chat-artifact-title-row">
+        <span class="chat-artifact-kind-badge" data-kind="${escapeHtml(artifact.kind)}">${escapeHtml(kindLabel)}</span>
+        <span class="chat-artifact-title" title="${escapeHtml(artifact.title)}">${escapeHtml(artifact.title)}</span>
+        <button class="chat-artifact-action" data-action="close" title="${escapeHtml(t('common.close') || 'Close')}">
+          <svg viewBox="0 0 12 12"><path d="M1 1l10 10M11 1L1 11" stroke="currentColor" stroke-width="1.5" fill="none"/></svg>
+        </button>
+      </div>
+      <div class="chat-artifact-actions">
+        <button class="chat-artifact-action" data-action="copy">${escapeHtml(t('common.copy') || 'Copy')}</button>
+        <button class="chat-artifact-action" data-action="save">${escapeHtml(t('artifacts.saveAs') || 'Save as...')}</button>
+        ${canOpenInEditor ? `<button class="chat-artifact-action" data-action="edit">${escapeHtml(t('artifacts.openInEditor') || 'Open in editor')}</button>` : ''}
+        ${artifact.node?.isConnected ? `<button class="chat-artifact-action" data-action="reveal">${escapeHtml(t('artifacts.jumpToMessage') || 'Go to message')}</button>` : ''}
+      </div>
+    `;
+
+    artifactBodyEl.innerHTML = renderMarkdown(artifactAsMarkdown(artifact));
+    MarkdownRenderer.postProcess(artifactBodyEl);
+  }
+
+  artifactsPanelEl.addEventListener('click', (e) => {
+    const card = e.target.closest('.chat-artifact-card');
+    if (card?.dataset.artifactId) openArtifact(card.dataset.artifactId);
+  });
+
+  artifactHeadEl.addEventListener('click', async (e) => {
+    const btn = e.target.closest('.chat-artifact-action');
+    if (!btn) return;
+    const artifact = artifactRegistry.get(artifactPaneEl.dataset.artifactId);
+    if (!artifact) return;
+
+    switch (btn.dataset.action) {
+      case 'close':
+        closeArtifactPane();
+        break;
+      case 'copy':
+        try {
+          await navigator.clipboard.writeText(artifact.source);
+          require('./Toast').showToast({ message: t('common.copied') || 'Copied', type: 'success' });
+        } catch (err) {
+          console.warn('[ChatView] artifact copy failed:', err.message);
+        }
+        break;
+      case 'save': {
+        const filePath = await api.dialog.saveFileDialog({
+          title: t('artifacts.saveAs') || 'Save as...',
+          defaultPath: artifact.title,
+        });
+        if (!filePath) break;
+        const { fsp } = require('../../utils/fs-async');
+        try {
+          await fsp.writeFile(filePath, artifact.source, 'utf8');
+          require('./Toast').showToast({ message: t('artifacts.saved') || 'Artifact saved', type: 'success' });
+        } catch (err) {
+          require('./Toast').showToast({ message: err.message, type: 'error' });
+        }
+        break;
+      }
+      case 'edit':
+        api.dialog.openInEditor({ editor: getSetting('editor') || 'code', path: artifact.path });
+        break;
+      case 'reveal': {
+        // The transcript pruner detaches old messages, so the node can be alive
+        // but unmounted. Scrolling to it would silently do nothing.
+        if (!artifact.node?.isConnected) break;
+        switchChatTab('conversation');
+        artifact.node.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        artifact.node.classList.add('chat-artifact-flash');
+        setTimeout(() => artifact.node.classList.remove('chat-artifact-flash'), 1200);
+        break;
+      }
+      default:
+        break;
+    }
+  });
+
+  // Drag the divider between the conversation and the artifact pane.
+  const ARTIFACT_PANE_MIN = 320;
+  (function setupArtifactResizer() {
+    const handle = chatView.querySelector('.chat-artifact-resizer');
+    if (!handle) return;
+    let startX = 0;
+    let startWidth = 0;
+
+    function onMove(e) {
+      // The pane sits on the right, so dragging left widens it.
+      const width = startWidth + (startX - e.clientX);
+      const max = Math.max(ARTIFACT_PANE_MIN, chatView.clientWidth - ARTIFACT_PANE_MIN);
+      artifactPaneEl.style.width = `${Math.min(max, Math.max(ARTIFACT_PANE_MIN, width))}px`;
+    }
+
+    function onUp() {
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+      document.body.classList.remove('resizing-h');
+    }
+
+    handle.addEventListener('mousedown', (e) => {
+      e.preventDefault();
+      startX = e.clientX;
+      startWidth = artifactPaneEl.getBoundingClientRect().width;
+      document.body.classList.add('resizing-h');
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('mouseup', onUp);
+    });
+  })();
 
   // ── Subagent (Task tool) card ──
 
@@ -6327,6 +6626,7 @@ class ChatView extends BaseComponent {
           el.innerHTML = `<div class="chat-msg-content">${renderMarkdown(block.text)}</div>`;
           injectInlineImages(el.querySelector('.chat-msg-content'));
           MarkdownRenderer.postProcess(el.querySelector('.chat-msg-content'));
+          harvestArtifacts(el.querySelector('.chat-msg-content'));
           messagesEl.appendChild(el);
           conversationHistory.push({ role: 'assistant', content: block.text });
           turnHadAssistantContent = true;
@@ -7192,6 +7492,10 @@ class ChatView extends BaseComponent {
       if (anchor) messagesEl.insertBefore(fragment, anchor);
       else messagesEl.appendChild(fragment);
       MarkdownRenderer.postProcess(batchNodes);
+      // Replaying history re-harvests every artifact it contains. Ids are
+      // content hashes, so this repopulates the tab on session resume without
+      // ever duplicating an entry.
+      harvestArtifacts(batchNodes);
 
       if (idx < messages.length) {
         // Keep the view pinned to the newest content while the tail streams in
@@ -7248,6 +7552,8 @@ class ChatView extends BaseComponent {
         } catch (e) { /* events not ready */ }
       }
       if (sessionId) api.chat.close({ sessionId });
+      // Persist whatever the debounce was still holding, before the view goes.
+      artifactRegistry.flush();
       transcriptPruner?.destroy();
       contextSuggestions.reset();
       followupChips.clear();

--- a/src/renderer/ui/components/ChatView.js
+++ b/src/renderer/ui/components/ChatView.js
@@ -864,7 +864,12 @@ class ChatView extends BaseComponent {
   }
 
   // ── Attach interactive markdown block handlers (sort, collapse, preview, etc.) ──
+  // Delegation is per-container and postProcess() does not set it up, so every
+  // container that renders markdown needs its own call. The Documents preview
+  // is a second such container: without this its Preview/Code toggle, viewport
+  // buttons, copy buttons and external links are all inert.
   MarkdownRenderer.attachInteractivity(messagesEl);
+  MarkdownRenderer.attachInteractivity(artifactBodyEl);
 
   // ── Mention state ──
 

--- a/src/renderer/ui/components/ChatView.js
+++ b/src/renderer/ui/components/ChatView.js
@@ -455,13 +455,8 @@ class ChatView extends BaseComponent {
 
   // ── Build DOM ──
 
-  // `.chat-view` is a row: the conversation column plus the artifact pane that
-  // slides in beside it. Everything that was in the view before now lives in
-  // `.chat-main`, whose inner indentation is left alone so the diff stays
-  // readable.
   wrapperEl.innerHTML = `
     <div class="chat-view">
-      <div class="chat-main">
       <div class="chat-tabbar" hidden>
         <button class="chat-tab active" data-tab="conversation">${escapeHtml(t('chat.tabConversation') || 'Conversation')}</button>
         <button class="chat-tab" data-tab="changes">
@@ -469,7 +464,7 @@ class ChatView extends BaseComponent {
           <span class="chat-tab-badge" data-badge="changes" hidden>0</span>
         </button>
         <button class="chat-tab" data-tab="artifacts">
-          <span class="chat-tab-label">${escapeHtml(t('chat.tabExtracts') || 'Extracts')}</span>
+          <span class="chat-tab-label">${escapeHtml(t('chat.tabDocuments') || 'Documents')}</span>
           <span class="chat-tab-badge" data-badge="artifacts" hidden>0</span>
         </button>
       </div>
@@ -494,7 +489,22 @@ class ChatView extends BaseComponent {
         </div>
       </div>
       <div class="chat-changes-panel" hidden></div>
-      <div class="chat-artifacts-panel" hidden></div>
+      <!-- Documents is itself a two-column screen: the list of what this
+           conversation produced on the left, the preview of the selected one on
+           the right. Both live inside the tab, so leaving the tab takes the
+           preview with it. -->
+      <div class="chat-artifacts-panel" hidden>
+        <div class="chat-artifacts-side">
+          <div class="chat-artifacts-summary"></div>
+          <div class="chat-artifacts-list"></div>
+        </div>
+        <div class="chat-artifacts-resizer" role="separator" aria-orientation="vertical" tabindex="0"
+             aria-label="${escapeHtml(t('artifacts.resizePane') || 'Resize artifact panel')}"></div>
+        <div class="chat-artifact-view">
+          <div class="chat-artifact-head"></div>
+          <div class="chat-artifact-body"></div>
+        </div>
+      </div>
       <div class="chat-input-area">
         <div class="chat-mention-dropdown" style="display:none"></div>
         <div class="chat-slash-dropdown" style="display:none"></div>
@@ -544,15 +554,6 @@ class ChatView extends BaseComponent {
           </div>
         </div>
       </div>
-      </div>
-      <aside class="chat-artifact-pane" hidden>
-        <div class="chat-artifact-resizer" role="separator" aria-orientation="vertical" tabindex="0"
-             aria-label="${escapeHtml(t('artifacts.resizePane') || 'Resize artifact panel')}"></div>
-        <div class="chat-artifact-pane-inner">
-          <div class="chat-artifact-head"></div>
-          <div class="chat-artifact-body"></div>
-        </div>
-      </aside>
     </div>
   `;
 
@@ -561,7 +562,10 @@ class ChatView extends BaseComponent {
   const tabbarEl = chatView.querySelector('.chat-tabbar');
   const changesPanelEl = chatView.querySelector('.chat-changes-panel');
   const artifactsPanelEl = chatView.querySelector('.chat-artifacts-panel');
-  const artifactPaneEl = chatView.querySelector('.chat-artifact-pane');
+  const artifactsSideEl = chatView.querySelector('.chat-artifacts-side');
+  const artifactsSummaryEl = chatView.querySelector('.chat-artifacts-summary');
+  const artifactsListEl = chatView.querySelector('.chat-artifacts-list');
+  const artifactViewEl = chatView.querySelector('.chat-artifact-view');
   const artifactHeadEl = chatView.querySelector('.chat-artifact-head');
   const artifactBodyEl = chatView.querySelector('.chat-artifact-body');
   const changesBadgeEl = chatView.querySelector('.chat-tab-badge[data-badge="changes"]');
@@ -4312,7 +4316,7 @@ class ChatView extends BaseComponent {
     toggleFileDiff(row.closest('.chat-change-item'));
   });
 
-  // ── Extracts tab ──
+  // ── Documents tab ──
   //
   // The self-contained things Claude produced in THIS conversation: an HTML
   // page, an SVG, a diagram, a long code block, a file it wrote. Detected by
@@ -4320,7 +4324,7 @@ class ChatView extends BaseComponent {
   // repopulates itself for free when a session is resumed and the transcript is
   // replayed.
   //
-  // Named "Extracts" and not "Artifacts" on purpose: `Artifact` is a distinct
+  // Named "Documents" and not "Artifacts" on purpose: `Artifact` is a distinct
   // Agent SDK tool that publishes an .html/.md file to claude.ai and hands back
   // a shareable URL. Those are remote and explicit; these are local and
   // inferred, and conflating the two in the UI would be misleading.
@@ -4354,20 +4358,21 @@ class ChatView extends BaseComponent {
     published: 'Published', html: 'HTML', svg: 'SVG', mermaid: 'Diagram', code: 'Code', file: 'File',
   };
 
-  /** Cards, newest first, one per artifact. */
+  /** Left column: one row per extract, newest first. */
   function renderArtifactsPanel() {
     const artifacts = artifactRegistry.list().reverse();
+
     if (!artifacts.length) {
-      artifactsPanelEl.innerHTML = `<div class="chat-artifacts-empty">${escapeHtml(t('artifacts.emptySession') || 'Nothing extracted from this conversation yet.')}</div>`;
+      artifactsSummaryEl.innerHTML = '';
+      artifactsListEl.innerHTML = `<div class="chat-artifacts-empty">${escapeHtml(t('artifacts.emptySession') || 'No documents produced in this conversation yet.')}</div>`;
+      renderArtifactPlaceholder();
       return;
     }
 
-    const openId = artifactPaneEl.dataset.artifactId || '';
-    const cards = artifacts.map((a) => {
+    const openId = artifactViewEl.dataset.artifactId || '';
+    artifactsListEl.innerHTML = artifacts.map((a) => {
       const kindLabel = ARTIFACT_KIND_LABEL[a.kind] || a.kind;
-      const meta = a.kind === 'code' || a.kind === 'file'
-        ? `${a.lines || a.source.split('\n').length} ${escapeHtml(t('artifacts.lines') || 'lines')}`
-        : escapeHtml(a.lang || kindLabel);
+      const lines = a.lines || a.source.split('\n').length;
       // A published artifact brought its own emoji and subtitle from the
       // Artifact tool; nothing else has either.
       const thumb = a.favicon
@@ -4385,21 +4390,26 @@ class ChatView extends BaseComponent {
             <span class="chat-artifact-card-meta">
               <span class="chat-artifact-kind">${escapeHtml(kindLabel)}</span>
               <span class="chat-artifact-dot">•</span>
-              <span>${meta}</span>
+              <span>${lines} ${escapeHtml(t('artifacts.lines') || 'lines')}</span>
             </span>
           </span>
         </button>`;
     }).join('');
 
     const label = artifacts.length > 1
-      ? (t('artifacts.extractsPlural') || 'extracts')
-      : (t('artifacts.extractsSingular') || 'extract');
-    artifactsPanelEl.innerHTML = `
-      <div class="chat-artifacts-summary">
-        <span class="chat-artifacts-count">${artifacts.length} ${escapeHtml(label)}</span>
-      </div>
-      <div class="chat-artifacts-grid">${cards}</div>
-    `;
+      ? (t('artifacts.documentsPlural') || 'documents')
+      : (t('artifacts.documentsSingular') || 'document');
+    artifactsSummaryEl.innerHTML = `<span class="chat-artifacts-count">${artifacts.length} ${escapeHtml(label)}</span>`;
+
+    // Opening the tab with nothing selected should still show something useful,
+    // so preview the newest extract rather than an empty right column.
+    if (!openId) openArtifact(artifacts[0].id);
+  }
+
+  function renderArtifactPlaceholder() {
+    artifactHeadEl.innerHTML = '';
+    artifactBodyEl.innerHTML = `<div class="chat-artifacts-empty">${escapeHtml(t('artifacts.selectPrompt') || 'Select an artifact to preview it.')}</div>`;
+    artifactBodyEl.classList.remove('chat-artifact-doc');
   }
 
   function artifactGlyph(kind) {
@@ -4455,22 +4465,16 @@ class ChatView extends BaseComponent {
   function openArtifact(id) {
     const artifact = artifactRegistry.get(id);
     if (!artifact) return;
-    artifactPaneEl.dataset.artifactId = id;
-    artifactPaneEl.hidden = false;
-    chatView.classList.add('artifact-open');
+    artifactViewEl.dataset.artifactId = id;
     renderArtifactPane(artifact);
-    // Keep the grid's selection ring in sync when it is the visible tab.
-    if (!artifactsPanelEl.hidden) renderArtifactsPanel();
+    // Move the selection ring without re-rendering the list, which would
+    // recurse: renderArtifactsPanel() auto-opens the newest when nothing is
+    // selected, and that would call back into here.
+    for (const card of artifactsListEl.querySelectorAll('.chat-artifact-card')) {
+      card.classList.toggle('active', card.dataset.artifactId === id);
+    }
   }
 
-  function closeArtifactPane() {
-    artifactPaneEl.hidden = true;
-    delete artifactPaneEl.dataset.artifactId;
-    chatView.classList.remove('artifact-open');
-    artifactBodyEl.innerHTML = '';
-    artifactHeadEl.innerHTML = '';
-    if (!artifactsPanelEl.hidden) renderArtifactsPanel();
-  }
 
   function renderArtifactPane(artifact) {
     const kindLabel = ARTIFACT_KIND_LABEL[artifact.kind] || artifact.kind;
@@ -4479,9 +4483,6 @@ class ChatView extends BaseComponent {
       <div class="chat-artifact-title-row">
         <span class="chat-artifact-kind-badge" data-kind="${escapeHtml(artifact.kind)}">${escapeHtml(kindLabel)}</span>
         <span class="chat-artifact-title" title="${escapeHtml(artifact.title)}">${escapeHtml(artifact.title)}</span>
-        <button class="chat-artifact-action" data-action="close" title="${escapeHtml(t('common.close') || 'Close')}">
-          <svg viewBox="0 0 12 12"><path d="M1 1l10 10M11 1L1 11" stroke="currentColor" stroke-width="1.5" fill="none"/></svg>
-        </button>
       </div>
       <div class="chat-artifact-actions">
         <button class="chat-artifact-action" data-action="copy">${escapeHtml(t('common.copy') || 'Copy')}</button>
@@ -4513,9 +4514,6 @@ class ChatView extends BaseComponent {
     if (!artifact) return;
 
     switch (btn.dataset.action) {
-      case 'close':
-        closeArtifactPane();
-        break;
       case 'copy':
         try {
           await navigator.clipboard.writeText(artifact.source);
@@ -4561,18 +4559,20 @@ class ChatView extends BaseComponent {
   });
 
   // Drag the divider between the conversation and the artifact pane.
-  const ARTIFACT_PANE_MIN = 320;
+  // Drag the divider between the list and the preview.
+  const ARTIFACT_LIST_MIN = 200;
+  const ARTIFACT_VIEW_MIN = 280;
   (function setupArtifactResizer() {
-    const handle = chatView.querySelector('.chat-artifact-resizer');
+    const handle = chatView.querySelector('.chat-artifacts-resizer');
     if (!handle) return;
     let startX = 0;
     let startWidth = 0;
 
     function onMove(e) {
-      // The pane sits on the right, so dragging left widens it.
-      const width = startWidth + (startX - e.clientX);
-      const max = Math.max(ARTIFACT_PANE_MIN, chatView.clientWidth - ARTIFACT_PANE_MIN);
-      artifactPaneEl.style.width = `${Math.min(max, Math.max(ARTIFACT_PANE_MIN, width))}px`;
+      // The list is on the left, so dragging right widens it.
+      const width = startWidth + (e.clientX - startX);
+      const max = Math.max(ARTIFACT_LIST_MIN, artifactsPanelEl.clientWidth - ARTIFACT_VIEW_MIN);
+      artifactsSideEl.style.width = `${Math.min(max, Math.max(ARTIFACT_LIST_MIN, width))}px`;
     }
 
     function onUp() {
@@ -4584,7 +4584,7 @@ class ChatView extends BaseComponent {
     handle.addEventListener('mousedown', (e) => {
       e.preventDefault();
       startX = e.clientX;
-      startWidth = artifactPaneEl.getBoundingClientRect().width;
+      startWidth = artifactsSideEl.getBoundingClientRect().width;
       document.body.classList.add('resizing-h');
       document.addEventListener('mousemove', onMove);
       document.addEventListener('mouseup', onUp);

--- a/src/renderer/ui/components/ChatView.js
+++ b/src/renderer/ui/components/ChatView.js
@@ -4336,17 +4336,38 @@ class ChatView extends BaseComponent {
 
   /**
    * Pull artifacts out of freshly rendered nodes.
+   *
    * Only ever called on settled content — never mid-stream, where a half-written
    * ```html block would be captured as a truncated page.
+   *
+   * Deferred to idle time. Scanning a replayed transcript costs a few hundred
+   * milliseconds of string building, and none of it is visible until the user
+   * opens the Documents tab, so it has no business sitting on the path that
+   * paints the conversation. Detached nodes still scan fine, so the transcript
+   * pruner running first is harmless.
    */
+  const _harvestQueue = [];
+  let _harvestScheduled = false;
+
   function harvestArtifacts(nodes) {
     if (!nodes) return;
-    try {
-      artifactRegistry.add(ArtifactService.detect(nodes, { messageIndex: messagesEl.children.length }));
-    } catch (e) {
-      // Harvesting is an enhancement; it must never break the transcript.
-      console.warn('[ChatView] artifact harvest failed:', e.message);
-    }
+    _harvestQueue.push({ nodes, messageIndex: messagesEl.children.length });
+    if (_harvestScheduled) return;
+    _harvestScheduled = true;
+    const run = () => {
+      _harvestScheduled = false;
+      const queued = _harvestQueue.splice(0, _harvestQueue.length);
+      for (const item of queued) {
+        try {
+          artifactRegistry.add(ArtifactService.detect(item.nodes, { messageIndex: item.messageIndex }));
+        } catch (e) {
+          // Harvesting is an enhancement; it must never break the transcript.
+          console.warn('[ChatView] artifact harvest failed:', e.message);
+        }
+      }
+    };
+    if (typeof requestIdleCallback === 'function') requestIdleCallback(run, { timeout: 2000 });
+    else setTimeout(run, 0);
   }
 
   function updateArtifactsTab() {

--- a/src/renderer/ui/components/ChatView.js
+++ b/src/renderer/ui/components/ChatView.js
@@ -469,7 +469,7 @@ class ChatView extends BaseComponent {
           <span class="chat-tab-badge" data-badge="changes" hidden>0</span>
         </button>
         <button class="chat-tab" data-tab="artifacts">
-          <span class="chat-tab-label">${escapeHtml(t('chat.tabArtifacts') || 'Artifacts')}</span>
+          <span class="chat-tab-label">${escapeHtml(t('chat.tabExtracts') || 'Extracts')}</span>
           <span class="chat-tab-badge" data-badge="artifacts" hidden>0</span>
         </button>
       </div>
@@ -4266,13 +4266,18 @@ class ChatView extends BaseComponent {
     toggleFileDiff(row.closest('.chat-change-item'));
   });
 
-  // ── Artifacts tab ──
+  // ── Extracts tab ──
   //
-  // Artifacts are the self-contained things Claude produced in this session: an
-  // HTML page, an SVG, a diagram, a long code block, a file it wrote. They are
-  // detected by scanning the rendered markdown (see ArtifactService), so the tab
+  // The self-contained things Claude produced in THIS conversation: an HTML
+  // page, an SVG, a diagram, a long code block, a file it wrote. Detected by
+  // scanning the rendered markdown (see ArtifactService), so the tab
   // repopulates itself for free when a session is resumed and the transcript is
   // replayed.
+  //
+  // Named "Extracts" and not "Artifacts" on purpose: `Artifact` is a distinct
+  // Agent SDK tool that publishes an .html/.md file to claude.ai and hands back
+  // a shareable URL. Those are remote and explicit; these are local and
+  // inferred, and conflating the two in the UI would be misleading.
 
   /**
    * Pull artifacts out of freshly rendered nodes.
@@ -4307,7 +4312,7 @@ class ChatView extends BaseComponent {
   function renderArtifactsPanel() {
     const artifacts = artifactRegistry.list().reverse();
     if (!artifacts.length) {
-      artifactsPanelEl.innerHTML = `<div class="chat-artifacts-empty">${escapeHtml(t('artifacts.emptySession') || 'No artifacts in this session yet.')}</div>`;
+      artifactsPanelEl.innerHTML = `<div class="chat-artifacts-empty">${escapeHtml(t('artifacts.emptySession') || 'Nothing extracted from this conversation yet.')}</div>`;
       return;
     }
 
@@ -4332,8 +4337,8 @@ class ChatView extends BaseComponent {
     }).join('');
 
     const label = artifacts.length > 1
-      ? (t('artifacts.countPlural') || 'artifacts')
-      : (t('artifacts.countSingular') || 'artifact');
+      ? (t('artifacts.extractsPlural') || 'extracts')
+      : (t('artifacts.extractsSingular') || 'extract');
     artifactsPanelEl.innerHTML = `
       <div class="chat-artifacts-summary">
         <span class="chat-artifacts-count">${artifacts.length} ${escapeHtml(label)}</span>

--- a/src/renderer/ui/panels/ArtifactsPanel.js
+++ b/src/renderer/ui/panels/ArtifactsPanel.js
@@ -3,7 +3,7 @@
  *
  * The artifact library for the current project: everything Claude has produced
  * across that project's sessions, not just the conversation currently open. The
- * per-session view lives in the chat's Extracts tab (ChatView); this is the
+ * per-session view lives in the chat's Documents tab (ChatView); this is the
  * archive behind it.
  *
  * Scope comes from the project bar, never from a picker of its own: artifacts

--- a/src/renderer/ui/panels/ArtifactsPanel.js
+++ b/src/renderer/ui/panels/ArtifactsPanel.js
@@ -40,7 +40,7 @@ let _stats = null;
 let _loadError = null;
 
 const KIND_LABEL = {
-  html: 'HTML', svg: 'SVG', mermaid: 'Diagram', code: 'Code', file: 'File',
+  published: 'Published', html: 'HTML', svg: 'SVG', mermaid: 'Diagram', code: 'Code', file: 'File',
 };
 
 const LANG_BY_EXT = {
@@ -200,9 +200,12 @@ function _renderList() {
 
   listEl.innerHTML = _rows.map((a) => `
     <button class="artifacts-row${a.id === _selectedId ? ' active' : ''}" data-id="${escapeHtml(a.id)}">
-      <span class="artifacts-row-kind" data-kind="${escapeHtml(a.kind)}">${escapeHtml(KIND_LABEL[a.kind] || a.kind)}</span>
+      ${a.favicon
+        ? `<span class="artifacts-row-favicon">${escapeHtml(a.favicon)}</span>`
+        : `<span class="artifacts-row-kind" data-kind="${escapeHtml(a.kind)}">${escapeHtml(KIND_LABEL[a.kind] || a.kind)}</span>`}
       <span class="artifacts-row-main">
         <span class="artifacts-row-title">${escapeHtml(a.title)}</span>
+        ${a.description ? `<span class="artifacts-row-desc">${escapeHtml(a.description)}</span>` : ''}
         <span class="artifacts-row-meta">
           <span>${a.lines} ${escapeHtml(t('artifacts.lines') || 'lines')}</span>
           <span class="artifacts-dot">•</span>
@@ -253,6 +256,7 @@ async function _renderDetail() {
       <div class="artifacts-detail-actions">
         <button class="artifacts-btn" data-action="copy">${escapeHtml(t('common.copy') || 'Copy')}</button>
         <button class="artifacts-btn" data-action="save">${escapeHtml(t('artifacts.saveAs') || 'Save as...')}</button>
+        ${artifact.url ? `<button class="artifacts-btn" data-action="open-url">${escapeHtml(t('artifacts.openPublished') || 'Open published page')}</button>` : ''}
         <button class="artifacts-btn artifacts-btn--danger" data-action="delete">${escapeHtml(t('common.delete') || 'Delete')}</button>
       </div>
     </div>
@@ -260,7 +264,11 @@ async function _renderDetail() {
   `;
 
   const bodyEl = detailEl.querySelector('#artifacts-detail-body');
-  bodyEl.innerHTML = MarkdownRenderer.render(_asMarkdown(artifact));
+  // A published Markdown page IS a document — render it as one rather than
+  // fencing it into a code block showing its own syntax.
+  const isMarkdownDoc = artifact.kind === 'published' && artifact.lang === 'markdown';
+  bodyEl.innerHTML = MarkdownRenderer.render(isMarkdownDoc ? artifact.source : _asMarkdown(artifact));
+  bodyEl.classList.toggle('artifacts-doc', isMarkdownDoc);
   MarkdownRenderer.postProcess(bodyEl);
 
   detailEl.querySelector('.artifacts-detail-head').addEventListener('click', (e) => {
@@ -297,6 +305,9 @@ async function _runAction(action, artifact) {
       }
       break;
     }
+    case 'open-url':
+      if (artifact.url) api.dialog.openExternal(artifact.url);
+      break;
     case 'delete': {
       const res = await api.artifacts.delete(artifact.id);
       if (!res.success) {

--- a/src/renderer/ui/panels/ArtifactsPanel.js
+++ b/src/renderer/ui/panels/ArtifactsPanel.js
@@ -1,0 +1,361 @@
+/**
+ * ArtifactsPanel
+ *
+ * The artifact library: everything Claude has produced across every session and
+ * every project, not just the conversation currently open. The per-session view
+ * lives in the chat's Artifacts tab (ChatView); this is the archive behind it.
+ *
+ * Reads the same store the chat writes to (src/shared/artifact-store.js via the
+ * `artifacts` IPC namespace), and refreshes on `artifacts-changed` so a delete
+ * made by an MCP tool in another process shows up here without a manual reload.
+ *
+ * Selection is by group rather than by row: the list shows one entry per
+ * artifact with a v1/v2/v3 switcher, because a rewritten page is the same
+ * artifact, not a new one.
+ */
+
+const { t } = require('../../i18n');
+const { escapeHtml } = require('../../utils');
+const MarkdownRenderer = require('../../services/MarkdownRenderer');
+
+const api = window.electron_api;
+
+let _container = null;
+let _unsubscribeChanged = null;
+// The list currently displayed: newest version of each artifact, filtered.
+let _rows = [];
+let _versions = [];
+let _selectedId = null;
+let _filter = { query: '', kind: '', projectId: '' };
+let _stats = null;
+let _loadError = null;
+
+const KIND_LABEL = {
+  html: 'HTML', svg: 'SVG', mermaid: 'Diagram', code: 'Code', file: 'File',
+};
+
+const LANG_BY_EXT = {
+  js: 'javascript', jsx: 'jsx', ts: 'typescript', tsx: 'tsx', py: 'python',
+  rs: 'rust', go: 'go', java: 'java', rb: 'ruby', php: 'php', cs: 'csharp',
+  cpp: 'cpp', c: 'c', lua: 'lua', sql: 'sql', sh: 'bash', json: 'json',
+  yml: 'yaml', yaml: 'yaml', toml: 'toml', xml: 'xml', css: 'css',
+  scss: 'scss', md: 'markdown', html: 'html', svg: 'svg',
+};
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function _timeAgo(iso) {
+  const diff = Date.now() - new Date(iso).getTime();
+  if (!Number.isFinite(diff) || diff < 0) return '';
+  if (diff < 60000) return `${Math.floor(diff / 1000)}s`;
+  if (diff < 3600000) return `${Math.floor(diff / 60000)}m`;
+  if (diff < 86400000) return `${Math.floor(diff / 3600000)}h`;
+  return `${Math.floor(diff / 86400000)}d`;
+}
+
+function _formatBytes(bytes) {
+  if (!bytes) return '0 B';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function _errorText(e) {
+  return String((e && e.message) || e || '')
+    .replace(/^Error invoking remote method '[^']*':\s*/, '')
+    .replace(/^Error:\s*/, '')
+    .trim();
+}
+
+/**
+ * Fence an artifact back into markdown so the normal renderer displays it.
+ * Same trick as the chat's split-pane: the HTML preview, Mermaid renderer, SVG
+ * sanitizer and syntax highlighter already exist as markdown blocks, and
+ * re-rendering re-registers the ct-preview:// document rather than reusing a
+ * URL that the bounded preview LRU may already have evicted.
+ */
+function _asMarkdown(artifact) {
+  const langByKind = { html: 'html', svg: 'svg', mermaid: 'mermaid' };
+  let lang = langByKind[artifact.kind] || artifact.lang || '';
+  if (artifact.kind === 'file') {
+    const ext = String(artifact.title || '').split('.').pop().toLowerCase();
+    lang = LANG_BY_EXT[ext] || '';
+  }
+  const longestRun = (artifact.source.match(/`+/g) || []).reduce((max, run) => Math.max(max, run.length), 0);
+  const fence = '`'.repeat(Math.max(3, longestRun + 1));
+  return `${fence}${lang}\n${artifact.source}\n${fence}`;
+}
+
+// ── Data ────────────────────────────────────────────────────────────────────
+
+async function _load() {
+  if (!api?.artifacts) {
+    _loadError = 'Artifact store unavailable';
+    _render();
+    return;
+  }
+  try {
+    const [listRes, statsRes] = await Promise.all([
+      api.artifacts.list({ ...(_filter.query ? { query: _filter.query } : {}),
+                           ...(_filter.kind ? { kind: _filter.kind } : {}),
+                           ...(_filter.projectId ? { projectId: _filter.projectId } : {}),
+                           latestOnly: true }),
+      api.artifacts.stats(),
+    ]);
+    if (!listRes.success) throw new Error(listRes.error);
+    _rows = listRes.artifacts || [];
+    _stats = statsRes.success ? statsRes.stats : null;
+    _loadError = null;
+  } catch (e) {
+    console.error('[ArtifactsPanel] load failed:', e);
+    _loadError = _errorText(e);
+  }
+  // Drop a selection that no longer has a home in the list — either it was
+  // deleted elsewhere, or the filter just excluded it. An older version stays
+  // selected as long as its group is still listed.
+  const selectedGroup = [..._rows, ..._versions].find(a => a.id === _selectedId)?.groupKey;
+  if (_selectedId && !_rows.some(r => r.groupKey === selectedGroup)) {
+    _selectedId = null;
+    _versions = [];
+  }
+  _render();
+}
+
+async function _select(id) {
+  _selectedId = id;
+  const row = _rows.find(r => r.id === id) || _versions.find(v => v.id === id);
+  if (row) {
+    const res = await api.artifacts.versions(row.groupKey);
+    _versions = res.success ? res.versions : [];
+  }
+  _renderList();
+  _renderDetail();
+}
+
+// ── Render ──────────────────────────────────────────────────────────────────
+
+function _render() {
+  if (!_container) return;
+  const kinds = ['', 'html', 'svg', 'mermaid', 'code', 'file'];
+  const kindOptions = kinds.map(k => `
+    <option value="${k}"${_filter.kind === k ? ' selected' : ''}>
+      ${escapeHtml(k ? (KIND_LABEL[k] || k) : (t('artifacts.allKinds') || 'All kinds'))}
+    </option>`).join('');
+
+  const projects = [...new Map(_rows.map(r => [r.projectId, r.projectName])).entries()]
+    .filter(([id]) => id);
+  const projectOptions = [`<option value="">${escapeHtml(t('artifacts.allProjects') || 'All projects')}</option>`]
+    .concat(projects.map(([id, name]) => `
+      <option value="${escapeHtml(id)}"${_filter.projectId === id ? ' selected' : ''}>${escapeHtml(name || id)}</option>`))
+    .join('');
+
+  _container.innerHTML = `
+    <div class="artifacts-panel">
+      <div class="artifacts-header">
+        <h2 class="artifacts-title">${escapeHtml(t('artifacts.libraryTitle') || 'Artifacts')}</h2>
+        ${_stats ? `
+          <div class="artifacts-stats">
+            <span><strong>${_stats.total}</strong> ${escapeHtml(t('artifacts.stored') || 'stored')}</span>
+            <span><strong>${_formatBytes(_stats.bytes)}</strong></span>
+            <span><strong>${_stats.projects}</strong> ${escapeHtml(t('artifacts.projects') || 'projects')}</span>
+          </div>` : ''}
+      </div>
+
+      ${_loadError ? `<div class="artifacts-error">${escapeHtml(_loadError)}</div>` : ''}
+
+      <div class="artifacts-toolbar">
+        <input type="search" class="artifacts-search" id="artifacts-search"
+               placeholder="${escapeHtml(t('common.search') || 'Search')}"
+               value="${escapeHtml(_filter.query)}" spellcheck="false" />
+        <select class="artifacts-select" id="artifacts-kind">${kindOptions}</select>
+        <select class="artifacts-select" id="artifacts-project">${projectOptions}</select>
+      </div>
+
+      <div class="artifacts-body">
+        <div class="artifacts-list" id="artifacts-list"></div>
+        <div class="artifacts-detail" id="artifacts-detail"></div>
+      </div>
+    </div>
+  `;
+
+  _renderList();
+  _renderDetail();
+  _bind();
+}
+
+function _renderList() {
+  const listEl = _container?.querySelector('#artifacts-list');
+  if (!listEl) return;
+
+  if (!_rows.length) {
+    listEl.innerHTML = `<div class="artifacts-empty">${escapeHtml(t('artifacts.emptyLibrary') || 'No artifacts yet. They appear here as Claude produces them.')}</div>`;
+    return;
+  }
+
+  listEl.innerHTML = _rows.map((a) => `
+    <button class="artifacts-row${a.id === _selectedId ? ' active' : ''}" data-id="${escapeHtml(a.id)}">
+      <span class="artifacts-row-kind" data-kind="${escapeHtml(a.kind)}">${escapeHtml(KIND_LABEL[a.kind] || a.kind)}</span>
+      <span class="artifacts-row-main">
+        <span class="artifacts-row-title">${escapeHtml(a.title)}</span>
+        <span class="artifacts-row-meta">
+          ${a.projectName ? `<span>${escapeHtml(a.projectName)}</span><span class="artifacts-dot">•</span>` : ''}
+          <span>${a.lines} ${escapeHtml(t('artifacts.lines') || 'lines')}</span>
+          <span class="artifacts-dot">•</span>
+          <span>${escapeHtml(_timeAgo(a.createdAt))}</span>
+        </span>
+      </span>
+      ${(a.version || 1) > 1 ? `<span class="artifacts-row-version">v${a.version}</span>` : ''}
+    </button>`).join('');
+}
+
+async function _renderDetail() {
+  const detailEl = _container?.querySelector('#artifacts-detail');
+  if (!detailEl) return;
+
+  if (!_selectedId) {
+    detailEl.innerHTML = `<div class="artifacts-empty">${escapeHtml(t('artifacts.selectPrompt') || 'Select an artifact to preview it.')}</div>`;
+    return;
+  }
+
+  const requestedId = _selectedId;
+  const res = await api.artifacts.get(requestedId);
+  // Two renders can be in flight (a click while a refresh is loading); the
+  // slower one must not paint over the newer selection.
+  if (requestedId !== _selectedId) return;
+  if (!res.success) {
+    detailEl.innerHTML = `<div class="artifacts-error">${escapeHtml(res.error)}</div>`;
+    return;
+  }
+  const artifact = res.artifact;
+
+  const versionChips = _versions.length > 1
+    ? `<div class="artifacts-versions">${_versions.map(v => `
+        <button class="artifacts-version${v.id === _selectedId ? ' active' : ''}" data-version-id="${escapeHtml(v.id)}"
+                title="${escapeHtml(_timeAgo(v.createdAt))}">v${v.version}</button>`).join('')}</div>`
+    : '';
+
+  detailEl.innerHTML = `
+    <div class="artifacts-detail-head">
+      <div class="artifacts-detail-title-row">
+        <span class="artifacts-row-kind" data-kind="${escapeHtml(artifact.kind)}">${escapeHtml(KIND_LABEL[artifact.kind] || artifact.kind)}</span>
+        <span class="artifacts-detail-title" title="${escapeHtml(artifact.title)}">${escapeHtml(artifact.title)}</span>
+      </div>
+      <div class="artifacts-detail-meta">
+        ${artifact.projectName ? `<span>${escapeHtml(artifact.projectName)}</span>` : ''}
+        <span>${_formatBytes(artifact.bytes)}</span>
+        <span>${artifact.lines} ${escapeHtml(t('artifacts.lines') || 'lines')}</span>
+      </div>
+      ${versionChips}
+      <div class="artifacts-detail-actions">
+        <button class="artifacts-btn" data-action="copy">${escapeHtml(t('common.copy') || 'Copy')}</button>
+        <button class="artifacts-btn" data-action="save">${escapeHtml(t('artifacts.saveAs') || 'Save as...')}</button>
+        <button class="artifacts-btn artifacts-btn--danger" data-action="delete">${escapeHtml(t('common.delete') || 'Delete')}</button>
+      </div>
+    </div>
+    <div class="artifacts-detail-body" id="artifacts-detail-body"></div>
+  `;
+
+  const bodyEl = detailEl.querySelector('#artifacts-detail-body');
+  bodyEl.innerHTML = MarkdownRenderer.render(_asMarkdown(artifact));
+  MarkdownRenderer.postProcess(bodyEl);
+
+  detailEl.querySelector('.artifacts-detail-head').addEventListener('click', (e) => {
+    const version = e.target.closest('[data-version-id]');
+    if (version) { _select(version.dataset.versionId); return; }
+    const btn = e.target.closest('[data-action]');
+    if (btn) _runAction(btn.dataset.action, artifact);
+  });
+}
+
+async function _runAction(action, artifact) {
+  const Toast = require('../components/Toast');
+  switch (action) {
+    case 'copy':
+      try {
+        await navigator.clipboard.writeText(artifact.source);
+        Toast.showToast({ message: t('common.copied') || 'Copied', type: 'success' });
+      } catch (e) {
+        Toast.showToast({ message: _errorText(e), type: 'error' });
+      }
+      break;
+    case 'save': {
+      const filePath = await api.dialog.saveFileDialog({
+        title: t('artifacts.saveAs') || 'Save as...',
+        defaultPath: artifact.title,
+      });
+      if (!filePath) break;
+      try {
+        const { fsp } = require('../../utils/fs-async');
+        await fsp.writeFile(filePath, artifact.source, 'utf8');
+        Toast.showToast({ message: t('artifacts.saved') || 'Artifact saved', type: 'success' });
+      } catch (e) {
+        Toast.showToast({ message: _errorText(e), type: 'error' });
+      }
+      break;
+    }
+    case 'delete': {
+      const res = await api.artifacts.delete(artifact.id);
+      if (!res.success) {
+        Toast.showToast({ message: res.error, type: 'error' });
+        break;
+      }
+      _selectedId = null;
+      _versions = [];
+      await _load();
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+function _bind() {
+  const searchEl = _container.querySelector('#artifacts-search');
+  let debounce = null;
+  searchEl?.addEventListener('input', () => {
+    clearTimeout(debounce);
+    debounce = setTimeout(() => {
+      _filter.query = searchEl.value.trim();
+      _load();
+    }, 200);
+  });
+
+  _container.querySelector('#artifacts-kind')?.addEventListener('change', (e) => {
+    _filter.kind = e.target.value;
+    _load();
+  });
+
+  _container.querySelector('#artifacts-project')?.addEventListener('change', (e) => {
+    _filter.projectId = e.target.value;
+    _load();
+  });
+
+  _container.querySelector('#artifacts-list')?.addEventListener('click', (e) => {
+    const row = e.target.closest('.artifacts-row');
+    if (row?.dataset.id) _select(row.dataset.id);
+  });
+}
+
+// ── Panel API ───────────────────────────────────────────────────────────────
+
+function loadPanel(container) {
+  _container = container;
+  _load();
+
+  // MCP tools mutate the store from another process; the main process watches
+  // index.json and forwards the change here.
+  if (!_unsubscribeChanged && api?.artifacts?.onChanged) {
+    _unsubscribeChanged = api.artifacts.onChanged(() => {
+      if (_container) _load();
+    });
+  }
+}
+
+function cleanup() {
+  if (_unsubscribeChanged) {
+    _unsubscribeChanged();
+    _unsubscribeChanged = null;
+  }
+}
+
+module.exports = { loadPanel, cleanup };

--- a/src/renderer/ui/panels/ArtifactsPanel.js
+++ b/src/renderer/ui/panels/ArtifactsPanel.js
@@ -351,6 +351,16 @@ function _bind() {
 function loadPanel(container, project = null) {
   _container = container;
   _project = project;
+
+  // Markdown block handlers (Preview/Code toggle, viewport buttons, copy,
+  // external links) are delegated per container and postProcess() does not set
+  // them up. Attached on the panel root, which survives every re-render, and
+  // guarded so re-entering the tab does not stack listeners.
+  if (!container.dataset.interactivityAttached) {
+    container.dataset.interactivityAttached = 'true';
+    MarkdownRenderer.attachInteractivity(container);
+  }
+
   _load();
 
   // MCP tools mutate the store from another process; the main process watches

--- a/src/renderer/ui/panels/ArtifactsPanel.js
+++ b/src/renderer/ui/panels/ArtifactsPanel.js
@@ -1,10 +1,19 @@
 /**
  * ArtifactsPanel
  *
- * The artifact library for the current project: everything Claude has produced
- * across that project's sessions, not just the conversation currently open. The
- * per-session view lives in the chat's Documents tab (ChatView); this is the
- * archive behind it.
+ * The gallery of PUBLISHED artifacts for the current project — the local
+ * equivalent of the artifact list in Claude Desktop. These come from the Agent
+ * SDK's `Artifact` tool, which uploads an .html or .md file to claude.ai and
+ * returns a shareable URL, so each one has a real title, a subtitle, a
+ * browser-tab emoji and a link that opens in a browser.
+ *
+ * Deliberately NOT the extracts. The store also holds everything harvested from
+ * conversations (HTML blocks, diagrams, long code blocks, written files), but
+ * those belong to the conversation that produced them and are shown in the
+ * chat's Documents tab. Listing both here would blur two different things: one
+ * is something the user published on purpose, the other is a by-product of a
+ * chat. They stay in the store for the artifact_* MCP tools, which is what lets
+ * a later session find a page built weeks ago.
  *
  * Scope comes from the project bar, never from a picker of its own: artifacts
  * belong to a project, so the panel follows the same "work in this project"
@@ -12,13 +21,12 @@
  * renderer.js). A panel-local project dropdown would have been a second,
  * competing notion of "current project".
  *
- * Reads the same store the chat writes to (src/shared/artifact-store.js via the
- * `artifacts` IPC namespace), and refreshes on `artifacts-changed` so a delete
- * made by an MCP tool in another process shows up here without a manual reload.
+ * Refreshes on `artifacts-changed`, so a publish made in a chat — or a delete
+ * made by an MCP tool in another process — shows up without a manual reload.
  *
  * Selection is by group rather than by row: the list shows one entry per
- * artifact with a v1/v2/v3 switcher, because a rewritten page is the same
- * artifact, not a new one.
+ * artifact with a v1/v2/v3 switcher, because a republished page is a new
+ * version of the same artifact, not a new one.
  */
 
 const { t } = require('../../i18n');
@@ -35,13 +43,8 @@ let _project = null;
 let _rows = [];
 let _versions = [];
 let _selectedId = null;
-let _filter = { query: '', kind: '' };
-let _stats = null;
+let _filter = { query: '' };
 let _loadError = null;
-
-const KIND_LABEL = {
-  published: 'Published', html: 'HTML', svg: 'SVG', mermaid: 'Diagram', code: 'Code', file: 'File',
-};
 
 const LANG_BY_EXT = {
   js: 'javascript', jsx: 'jsx', ts: 'typescript', tsx: 'tsx', py: 'python',
@@ -104,21 +107,19 @@ async function _load() {
     return;
   }
   try {
-    const [listRes, statsRes] = await Promise.all([
-      api.artifacts.list({
-        // No project on the bar means nothing is scoped yet, not "show me
-        // everything" — an unscoped list here would contradict the tab living
-        // in the Project section.
-        projectId: _project?.id || '__none__',
-        ...(_filter.query ? { query: _filter.query } : {}),
-        ...(_filter.kind ? { kind: _filter.kind } : {}),
-        latestOnly: true,
-      }),
-      api.artifacts.stats(),
-    ]);
+    const listRes = await api.artifacts.list({
+      // No project on the bar means nothing is scoped yet, not "show me
+      // everything" — an unscoped list here would contradict the tab living in
+      // the Project section.
+      projectId: _project?.id || '__none__',
+      // Published only. Conversation extracts live in the chat's Documents tab;
+      // this screen is the published gallery.
+      kind: 'published',
+      ...(_filter.query ? { query: _filter.query } : {}),
+      latestOnly: true,
+    });
     if (!listRes.success) throw new Error(listRes.error);
     _rows = listRes.artifacts || [];
-    _stats = statsRes.success ? statsRes.stats : null;
     _loadError = null;
   } catch (e) {
     console.error('[ArtifactsPanel] load failed:', e);
@@ -150,22 +151,15 @@ async function _select(id) {
 
 function _render() {
   if (!_container) return;
-  const kinds = ['', 'html', 'svg', 'mermaid', 'code', 'file'];
-  const kindOptions = kinds.map(k => `
-    <option value="${k}"${_filter.kind === k ? ' selected' : ''}>
-      ${escapeHtml(k ? (KIND_LABEL[k] || k) : (t('artifacts.allKinds') || 'All kinds'))}
-    </option>`).join('');
-
+  // No kind filter: this screen is published artifacts only, so the picker
+  // would have had a single entry.
   _container.innerHTML = `
     <div class="artifacts-panel">
       <div class="artifacts-header">
         <h2 class="artifacts-title">${escapeHtml(t('artifacts.libraryTitle') || 'Artifacts')}</h2>
-        ${_stats ? `
-          <div class="artifacts-stats">
-            <span><strong>${_rows.length}</strong> ${escapeHtml(t('artifacts.inProject') || 'in this project')}</span>
-            <span><strong>${_stats.total}</strong> ${escapeHtml(t('artifacts.stored') || 'stored')}</span>
-            <span><strong>${_formatBytes(_stats.bytes)}</strong></span>
-          </div>` : ''}
+        <div class="artifacts-stats">
+          <span><strong>${_rows.length}</strong> ${escapeHtml(t('artifacts.publishedCount') || 'published in this project')}</span>
+        </div>
       </div>
 
       ${_loadError ? `<div class="artifacts-error">${escapeHtml(_loadError)}</div>` : ''}
@@ -174,7 +168,6 @@ function _render() {
         <input type="search" class="artifacts-search" id="artifacts-search"
                placeholder="${escapeHtml(t('common.search') || 'Search')}"
                value="${escapeHtml(_filter.query)}" spellcheck="false" />
-        <select class="artifacts-select" id="artifacts-kind">${kindOptions}</select>
       </div>
 
       <div class="artifacts-body">
@@ -194,15 +187,17 @@ function _renderList() {
   if (!listEl) return;
 
   if (!_rows.length) {
-    listEl.innerHTML = `<div class="artifacts-empty">${escapeHtml(t('artifacts.emptyLibrary') || 'No artifacts yet. They appear here as Claude produces them.')}</div>`;
+    listEl.innerHTML = `<div class="artifacts-empty">${escapeHtml(t('artifacts.emptyLibrary') || 'No published artifacts in this project. They appear here when Claude publishes a page with the Artifact tool.')}</div>`;
     return;
   }
 
+  // Every row is a publish, so the emoji the Artifact tool carries is the
+  // identity — the format badge falls back only when a publish had none.
   listEl.innerHTML = _rows.map((a) => `
     <button class="artifacts-row${a.id === _selectedId ? ' active' : ''}" data-id="${escapeHtml(a.id)}">
       ${a.favicon
         ? `<span class="artifacts-row-favicon">${escapeHtml(a.favicon)}</span>`
-        : `<span class="artifacts-row-kind" data-kind="${escapeHtml(a.kind)}">${escapeHtml(KIND_LABEL[a.kind] || a.kind)}</span>`}
+        : `<span class="artifacts-row-kind" data-kind="published">${escapeHtml(a.lang === 'markdown' ? 'MD' : 'HTML')}</span>`}
       <span class="artifacts-row-main">
         <span class="artifacts-row-title">${escapeHtml(a.title)}</span>
         ${a.description ? `<span class="artifacts-row-desc">${escapeHtml(a.description)}</span>` : ''}
@@ -221,7 +216,9 @@ async function _renderDetail() {
   if (!detailEl) return;
 
   if (!_selectedId) {
-    detailEl.innerHTML = `<div class="artifacts-empty">${escapeHtml(t('artifacts.selectPrompt') || 'Select an artifact to preview it.')}</div>`;
+    detailEl.innerHTML = _rows.length
+      ? `<div class="artifacts-empty">${escapeHtml(t('artifacts.selectPrompt') || 'Select an artifact to preview it.')}</div>`
+      : '';
     return;
   }
 
@@ -245,12 +242,16 @@ async function _renderDetail() {
   detailEl.innerHTML = `
     <div class="artifacts-detail-head">
       <div class="artifacts-detail-title-row">
-        <span class="artifacts-row-kind" data-kind="${escapeHtml(artifact.kind)}">${escapeHtml(KIND_LABEL[artifact.kind] || artifact.kind)}</span>
+        ${artifact.favicon
+          ? `<span class="artifacts-row-favicon">${escapeHtml(artifact.favicon)}</span>`
+          : `<span class="artifacts-row-kind" data-kind="published">${escapeHtml(artifact.lang === 'markdown' ? 'MD' : 'HTML')}</span>`}
         <span class="artifacts-detail-title" title="${escapeHtml(artifact.title)}">${escapeHtml(artifact.title)}</span>
       </div>
+      ${artifact.description ? `<div class="artifacts-detail-desc">${escapeHtml(artifact.description)}</div>` : ''}
       <div class="artifacts-detail-meta">
         <span>${_formatBytes(artifact.bytes)}</span>
         <span>${artifact.lines} ${escapeHtml(t('artifacts.lines') || 'lines')}</span>
+        ${artifact.url ? `<span class="artifacts-detail-url" title="${escapeHtml(artifact.url)}">${escapeHtml(artifact.url)}</span>` : ''}
       </div>
       ${versionChips}
       <div class="artifacts-detail-actions">
@@ -333,11 +334,6 @@ function _bind() {
       _filter.query = searchEl.value.trim();
       _load();
     }, 200);
-  });
-
-  _container.querySelector('#artifacts-kind')?.addEventListener('change', (e) => {
-    _filter.kind = e.target.value;
-    _load();
   });
 
   _container.querySelector('#artifacts-list')?.addEventListener('click', (e) => {

--- a/src/renderer/ui/panels/ArtifactsPanel.js
+++ b/src/renderer/ui/panels/ArtifactsPanel.js
@@ -1,9 +1,16 @@
 /**
  * ArtifactsPanel
  *
- * The artifact library: everything Claude has produced across every session and
- * every project, not just the conversation currently open. The per-session view
- * lives in the chat's Artifacts tab (ChatView); this is the archive behind it.
+ * The artifact library for the current project: everything Claude has produced
+ * across that project's sessions, not just the conversation currently open. The
+ * per-session view lives in the chat's Extracts tab (ChatView); this is the
+ * archive behind it.
+ *
+ * Scope comes from the project bar, never from a picker of its own: artifacts
+ * belong to a project, so the panel follows the same "work in this project"
+ * switch the Git and Dashboard tabs follow (see applyProjectContext in
+ * renderer.js). A panel-local project dropdown would have been a second,
+ * competing notion of "current project".
  *
  * Reads the same store the chat writes to (src/shared/artifact-store.js via the
  * `artifacts` IPC namespace), and refreshes on `artifacts-changed` so a delete
@@ -22,11 +29,13 @@ const api = window.electron_api;
 
 let _container = null;
 let _unsubscribeChanged = null;
+// The project the panel is scoped to, mirrored from the project bar.
+let _project = null;
 // The list currently displayed: newest version of each artifact, filtered.
 let _rows = [];
 let _versions = [];
 let _selectedId = null;
-let _filter = { query: '', kind: '', projectId: '' };
+let _filter = { query: '', kind: '' };
 let _stats = null;
 let _loadError = null;
 
@@ -96,10 +105,15 @@ async function _load() {
   }
   try {
     const [listRes, statsRes] = await Promise.all([
-      api.artifacts.list({ ...(_filter.query ? { query: _filter.query } : {}),
-                           ...(_filter.kind ? { kind: _filter.kind } : {}),
-                           ...(_filter.projectId ? { projectId: _filter.projectId } : {}),
-                           latestOnly: true }),
+      api.artifacts.list({
+        // No project on the bar means nothing is scoped yet, not "show me
+        // everything" — an unscoped list here would contradict the tab living
+        // in the Project section.
+        projectId: _project?.id || '__none__',
+        ...(_filter.query ? { query: _filter.query } : {}),
+        ...(_filter.kind ? { kind: _filter.kind } : {}),
+        latestOnly: true,
+      }),
       api.artifacts.stats(),
     ]);
     if (!listRes.success) throw new Error(listRes.error);
@@ -142,22 +156,15 @@ function _render() {
       ${escapeHtml(k ? (KIND_LABEL[k] || k) : (t('artifacts.allKinds') || 'All kinds'))}
     </option>`).join('');
 
-  const projects = [...new Map(_rows.map(r => [r.projectId, r.projectName])).entries()]
-    .filter(([id]) => id);
-  const projectOptions = [`<option value="">${escapeHtml(t('artifacts.allProjects') || 'All projects')}</option>`]
-    .concat(projects.map(([id, name]) => `
-      <option value="${escapeHtml(id)}"${_filter.projectId === id ? ' selected' : ''}>${escapeHtml(name || id)}</option>`))
-    .join('');
-
   _container.innerHTML = `
     <div class="artifacts-panel">
       <div class="artifacts-header">
         <h2 class="artifacts-title">${escapeHtml(t('artifacts.libraryTitle') || 'Artifacts')}</h2>
         ${_stats ? `
           <div class="artifacts-stats">
+            <span><strong>${_rows.length}</strong> ${escapeHtml(t('artifacts.inProject') || 'in this project')}</span>
             <span><strong>${_stats.total}</strong> ${escapeHtml(t('artifacts.stored') || 'stored')}</span>
             <span><strong>${_formatBytes(_stats.bytes)}</strong></span>
-            <span><strong>${_stats.projects}</strong> ${escapeHtml(t('artifacts.projects') || 'projects')}</span>
           </div>` : ''}
       </div>
 
@@ -168,7 +175,6 @@ function _render() {
                placeholder="${escapeHtml(t('common.search') || 'Search')}"
                value="${escapeHtml(_filter.query)}" spellcheck="false" />
         <select class="artifacts-select" id="artifacts-kind">${kindOptions}</select>
-        <select class="artifacts-select" id="artifacts-project">${projectOptions}</select>
       </div>
 
       <div class="artifacts-body">
@@ -198,7 +204,6 @@ function _renderList() {
       <span class="artifacts-row-main">
         <span class="artifacts-row-title">${escapeHtml(a.title)}</span>
         <span class="artifacts-row-meta">
-          ${a.projectName ? `<span>${escapeHtml(a.projectName)}</span><span class="artifacts-dot">•</span>` : ''}
           <span>${a.lines} ${escapeHtml(t('artifacts.lines') || 'lines')}</span>
           <span class="artifacts-dot">•</span>
           <span>${escapeHtml(_timeAgo(a.createdAt))}</span>
@@ -241,7 +246,6 @@ async function _renderDetail() {
         <span class="artifacts-detail-title" title="${escapeHtml(artifact.title)}">${escapeHtml(artifact.title)}</span>
       </div>
       <div class="artifacts-detail-meta">
-        ${artifact.projectName ? `<span>${escapeHtml(artifact.projectName)}</span>` : ''}
         <span>${_formatBytes(artifact.bytes)}</span>
         <span>${artifact.lines} ${escapeHtml(t('artifacts.lines') || 'lines')}</span>
       </div>
@@ -325,11 +329,6 @@ function _bind() {
     _load();
   });
 
-  _container.querySelector('#artifacts-project')?.addEventListener('change', (e) => {
-    _filter.projectId = e.target.value;
-    _load();
-  });
-
   _container.querySelector('#artifacts-list')?.addEventListener('click', (e) => {
     const row = e.target.closest('.artifacts-row');
     if (row?.dataset.id) _select(row.dataset.id);
@@ -338,8 +337,9 @@ function _bind() {
 
 // ── Panel API ───────────────────────────────────────────────────────────────
 
-function loadPanel(container) {
+function loadPanel(container, project = null) {
   _container = container;
+  _project = project;
   _load();
 
   // MCP tools mutate the store from another process; the main process watches
@@ -351,6 +351,20 @@ function loadPanel(container) {
   }
 }
 
+/**
+ * Follow the project bar. Called from applyProjectContext when the user
+ * switches project while this tab is showing; a no-op otherwise, since
+ * loadPanel() re-reads the bar on activate.
+ */
+function setProject(project) {
+  if (!_container) return;
+  if (_project?.id === project?.id) return;
+  _project = project;
+  _selectedId = null;
+  _versions = [];
+  _load();
+}
+
 function cleanup() {
   if (_unsubscribeChanged) {
     _unsubscribeChanged();
@@ -358,4 +372,4 @@ function cleanup() {
   }
 }
 
-module.exports = { loadPanel, cleanup };
+module.exports = { loadPanel, setProject, cleanup };

--- a/src/renderer/ui/panels/index.js
+++ b/src/renderer/ui/panels/index.js
@@ -21,6 +21,7 @@ const ParallelTaskPanel = require('./ParallelTaskPanel');
 const WorkspacePanel = require('./WorkspacePanel');
 const ErrorLogPanel = require('./ErrorLogPanel');
 const FilesPanel = require('./FilesPanel');
+const ArtifactsPanel = require('./ArtifactsPanel');
 
 module.exports = {
   FilesPanel,
@@ -41,4 +42,5 @@ module.exports = {
   ParallelTaskPanel,
   WorkspacePanel,
   ErrorLogPanel,
+  ArtifactsPanel,
 };

--- a/src/shared/artifact-schema.js
+++ b/src/shared/artifact-schema.js
@@ -1,0 +1,82 @@
+'use strict';
+
+/**
+ * artifact-schema.js
+ * The parts of the artifact model that carry no I/O: kinds, identity, and the
+ * naming rules for blobs.
+ *
+ * Split out of artifact-store.js because the renderer needs computeId() to
+ * derive the same ids as the store, but is bundled for the browser by esbuild
+ * and cannot require fs/os. Everything here must stay dependency-free.
+ *
+ * Shared between the renderer, the main process and the MCP server.
+ */
+
+/** Artifact kinds, in the order the UI lists them. */
+const KINDS = ['html', 'svg', 'mermaid', 'code', 'file'];
+
+/**
+ * FNV-1a, 32-bit, hex. Not a cryptographic hash and does not need to be: it
+ * only has to make "same content" collide and "different content" not, over a
+ * few thousand entries. Kept here so the renderer, the main process and the MCP
+ * tools all derive identical ids from identical content.
+ */
+function hashString(str) {
+  let h = 0x811c9dc5;
+  const s = String(str ?? '');
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h.toString(16).padStart(8, '0');
+}
+
+/**
+ * Stable id for a piece of content. Same content in, same id out — which is
+ * what makes re-harvesting a replayed conversation idempotent.
+ *
+ * Two independent hashes widen the id from 32 to 64 bits, so collisions stay
+ * negligible across the few thousand artifacts the store holds.
+ */
+function computeId(kind, source) {
+  const s = String(source ?? '');
+  return `art-${hashString(`${kind} ${s}`)}${hashString(`${s.length}:${s}`)}`;
+}
+
+/**
+ * Group successive versions of the same artifact together. Artifacts sharing a
+ * groupKey are v1, v2, v3… of one thing rather than unrelated entries.
+ */
+function computeGroupKey(projectId, kind, title) {
+  return hashString(`${projectId || ''} ${kind} ${String(title || '').trim().toLowerCase()}`);
+}
+
+const EXT_BY_LANG = {
+  javascript: 'js', js: 'js', jsx: 'jsx', typescript: 'ts', ts: 'ts', tsx: 'tsx',
+  python: 'py', py: 'py', rust: 'rs', go: 'go', java: 'java', kotlin: 'kt',
+  ruby: 'rb', php: 'php', csharp: 'cs', cpp: 'cpp', c: 'c', swift: 'swift',
+  lua: 'lua', sql: 'sql', bash: 'sh', sh: 'sh', shell: 'sh', zsh: 'sh',
+  json: 'json', yaml: 'yml', yml: 'yml', toml: 'toml', xml: 'xml',
+  html: 'html', css: 'css', scss: 'scss', markdown: 'md', md: 'md',
+};
+
+/** Extension a blob is stored under, so the blobs folder stays browsable. */
+function extensionFor(kind, lang, title) {
+  if (kind === 'html') return 'html';
+  if (kind === 'svg') return 'svg';
+  if (kind === 'mermaid') return 'mmd';
+  if (kind === 'file') {
+    const fromTitle = String(title || '').split('.').pop();
+    if (fromTitle && fromTitle !== title && /^[a-z0-9]{1,8}$/i.test(fromTitle)) return fromTitle.toLowerCase();
+    return 'txt';
+  }
+  return EXT_BY_LANG[String(lang || '').toLowerCase()] || 'txt';
+}
+
+module.exports = {
+  KINDS,
+  hashString,
+  computeId,
+  computeGroupKey,
+  extensionFor,
+};

--- a/src/shared/artifact-schema.js
+++ b/src/shared/artifact-schema.js
@@ -12,8 +12,16 @@
  * Shared between the renderer, the main process and the MCP server.
  */
 
-/** Artifact kinds, in the order the UI lists them. */
-const KINDS = ['html', 'svg', 'mermaid', 'code', 'file'];
+/**
+ * Artifact kinds, in the order the UI lists them.
+ *
+ * `published` is the odd one out and the only explicit one: it comes from the
+ * Agent SDK's `Artifact` tool, which uploads an .html or .md file to claude.ai
+ * and hands back a shareable URL. Every other kind is inferred from the
+ * rendered transcript. Published artifacts therefore carry `url`, `description`
+ * and `favicon`, which nothing else has.
+ */
+const KINDS = ['published', 'html', 'svg', 'mermaid', 'code', 'file'];
 
 /**
  * FNV-1a, 32-bit, hex. Not a cryptographic hash and does not need to be: it
@@ -62,6 +70,8 @@ const EXT_BY_LANG = {
 
 /** Extension a blob is stored under, so the blobs folder stays browsable. */
 function extensionFor(kind, lang, title) {
+  // A published artifact is whatever file was uploaded: .html or .md.
+  if (kind === 'published') return String(lang).toLowerCase() === 'markdown' ? 'md' : 'html';
   if (kind === 'html') return 'html';
   if (kind === 'svg') return 'svg';
   if (kind === 'mermaid') return 'mmd';

--- a/src/shared/artifact-store.js
+++ b/src/shared/artifact-store.js
@@ -1,0 +1,447 @@
+'use strict';
+
+/**
+ * artifact-store.js
+ * The on-disk store for chat artifacts, shared between the Electron main
+ * process and the MCP server process.
+ *
+ *     ~/.claude-terminal/artifacts/
+ *     ├── index.json          { version, artifacts: [meta] }
+ *     └── blobs/<id>.<ext>    the raw source of one artifact
+ *
+ * An artifact is a self-contained thing Claude produced inside a conversation:
+ * an HTML page, an SVG, a Mermaid diagram, a substantial code block, or a file
+ * it wrote. The renderer detects them; this module is only responsible for
+ * keeping them on disk and answering questions about them.
+ *
+ * Two invariants make the rest of the feature simple:
+ *
+ *   1. `id` is derived from a hash of (kind + source) by the caller, so saving
+ *      the same artifact twice is idempotent. That is what lets the renderer
+ *      re-harvest a whole conversation on every session resume without ever
+ *      creating duplicates.
+ *   2. `groupKey` is a hash of (projectId + kind + title). Artifacts sharing a
+ *      groupKey are successive VERSIONS of one thing, numbered from 1. Three
+ *      rewrites of the same dashboard.html are one artifact with v1/v2/v3, not
+ *      three unrelated entries.
+ *
+ * Why this lives in src/shared: the MCP server runs as a plain `node` process
+ * and cannot require from inside app.asar, but scripts/copy-mcp-shared.js
+ * copies src/shared next to it at package time. Both sides therefore run the
+ * same code and honour the same lock, which is the only way a read-modify-write
+ * from the MCP process cannot lose an update written by the app (and vice
+ * versa). Requires nothing outside node builtins, on purpose.
+ */
+
+const fs = require('fs');
+const fsp = fs.promises;
+const path = require('path');
+const os = require('os');
+
+// Identity and naming live in artifact-schema.js: the renderer needs the same
+// computeId() but is bundled for the browser and cannot require fs/os.
+const { KINDS, hashString, computeId, computeGroupKey, extensionFor } = require('./artifact-schema');
+
+// Same resolution the MCP tools use (see tools/_projectsCache.js), so an
+// overridden data dir keeps the app and the MCP process pointed at one store.
+const DATA_DIR = process.env.CT_DATA_DIR || path.join(os.homedir(), '.claude-terminal');
+const ARTIFACTS_DIR = path.join(DATA_DIR, 'artifacts');
+const BLOBS_DIR = path.join(ARTIFACTS_DIR, 'blobs');
+const INDEX_FILE = path.join(ARTIFACTS_DIR, 'index.json');
+const LOCK_FILE = `${INDEX_FILE}.lock`;
+
+// Total artifacts kept. Beyond this the oldest are evicted with their blobs:
+// the store is a convenience cache over conversations, not an archive of record.
+const MAX_ARTIFACTS = 2000;
+// A single blob larger than this is not worth keeping — a 2 MB HTML page is
+// already far past anything a preview pane can usefully show.
+const MAX_BLOB_BYTES = 2 * 1024 * 1024;
+
+// ── Cross-process lock ───────────────────────────────────────────────────────
+// Same protocol as src/main/utils/fileLock.js (atomic 'wx' create, break when
+// stale). Reimplemented here rather than required so that the MCP process, which
+// cannot reach src/main, runs the identical implementation instead of a copy
+// that can drift.
+
+const LOCK_STALE_MS = 15000;
+const LOCK_GIVE_UP_MS = 30000;
+const LOCK_STEP_MS = 25;
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function acquireLock() {
+  const start = Date.now();
+  for (;;) {
+    try {
+      const fd = fs.openSync(LOCK_FILE, 'wx');
+      try { fs.writeSync(fd, `${process.pid} ${Date.now()}`); } catch { /* non-fatal */ }
+      return fd;
+    } catch (e) {
+      if (e.code !== 'EEXIST') return null; // e.g. ENOENT on the dir — proceed unlocked
+      let ageMs = 0;
+      try {
+        ageMs = Date.now() - fs.statSync(LOCK_FILE).mtimeMs;
+      } catch {
+        continue; // vanished between open and stat
+      }
+      if (ageMs > LOCK_STALE_MS) {
+        try { fs.unlinkSync(LOCK_FILE); } catch { /* someone else broke it */ }
+        continue;
+      }
+      if (Date.now() - start > LOCK_GIVE_UP_MS) {
+        try { fs.unlinkSync(LOCK_FILE); } catch { /* ignore */ }
+        try { return fs.openSync(LOCK_FILE, 'wx'); } catch { return null; }
+      }
+      await sleep(LOCK_STEP_MS);
+    }
+  }
+}
+
+function releaseLock(fd) {
+  if (fd != null) { try { fs.closeSync(fd); } catch { /* ignore */ } }
+  try { fs.unlinkSync(LOCK_FILE); } catch { /* ignore */ }
+}
+
+/** Run `fn` holding the index lock. Best-effort: never hangs. */
+async function withLock(fn) {
+  await ensureDirs();
+  const fd = await acquireLock();
+  try {
+    return await fn();
+  } finally {
+    releaseLock(fd);
+  }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+async function ensureDirs() {
+  await fsp.mkdir(BLOBS_DIR, { recursive: true });
+}
+
+/** Atomic write: temp file + rename, so a crash never truncates the target. */
+async function atomicWriteText(filePath, text) {
+  await fsp.mkdir(path.dirname(filePath), { recursive: true });
+  const tmp = `${filePath}.tmp`;
+  await fsp.writeFile(tmp, text, 'utf8');
+  await fsp.rename(tmp, filePath);
+}
+
+function blobPath(meta) {
+  return path.join(BLOBS_DIR, meta.blob || `${meta.id}.txt`);
+}
+
+// ── Index ────────────────────────────────────────────────────────────────────
+
+const EMPTY_INDEX = { version: 1, artifacts: [] };
+
+async function loadIndex() {
+  try {
+    const raw = await fsp.readFile(INDEX_FILE, 'utf8');
+    const parsed = JSON.parse(raw);
+    return {
+      version: parsed.version || 1,
+      artifacts: Array.isArray(parsed.artifacts) ? parsed.artifacts : [],
+    };
+  } catch (e) {
+    if (e.code !== 'ENOENT') {
+      console.error('[Artifacts] index.json unreadable, starting empty:', e.message);
+    }
+    return { ...EMPTY_INDEX, artifacts: [] };
+  }
+}
+
+async function saveIndex(index) {
+  await ensureDirs();
+  await atomicWriteText(INDEX_FILE, JSON.stringify(index, null, 2));
+}
+
+/**
+ * Drop the oldest artifacts once the store exceeds MAX_ARTIFACTS, blobs
+ * included. Mutates `index` and returns the number evicted.
+ */
+async function pruneIndex(index) {
+  const excess = index.artifacts.length - MAX_ARTIFACTS;
+  if (excess <= 0) return 0;
+  const byAge = [...index.artifacts].sort((a, b) => String(a.createdAt || '').localeCompare(String(b.createdAt || '')));
+  const doomed = byAge.slice(0, excess);
+  const doomedIds = new Set(doomed.map(a => a.id));
+  index.artifacts = index.artifacts.filter(a => !doomedIds.has(a.id));
+  await Promise.all(doomed.map(async (meta) => {
+    try { await fsp.unlink(blobPath(meta)); } catch { /* already gone */ }
+  }));
+  return doomed.length;
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Insert an artifact, or return the existing one untouched when its id is
+ * already known. Idempotent by design — the renderer calls this for every
+ * artifact it sees, including on every conversation replay.
+ *
+ * @returns {Promise<{artifact: object, created: boolean, skipped?: string}>}
+ */
+async function saveArtifact(input) {
+  const source = String(input?.source ?? '');
+  const kind = KINDS.includes(input?.kind) ? input.kind : 'code';
+  if (!source.trim()) return { artifact: null, created: false, skipped: 'empty' };
+
+  const bytes = Buffer.byteLength(source, 'utf8');
+  if (bytes > MAX_BLOB_BYTES) return { artifact: null, created: false, skipped: 'too-large' };
+
+  const id = input.id || computeId(kind, source);
+
+  return withLock(async () => {
+    const index = await loadIndex();
+    const existing = index.artifacts.find(a => a.id === id);
+    if (existing) return { artifact: existing, created: false };
+
+    const title = String(input.title || 'Untitled').trim().slice(0, 200);
+    const groupKey = computeGroupKey(input.projectId, kind, title);
+    // Versions are numbered per group, so a rewrite of the same thing lands as
+    // v2 rather than as a second card in the grid.
+    const version = index.artifacts.reduce(
+      (max, a) => (a.groupKey === groupKey ? Math.max(max, a.version || 1) : max), 0
+    ) + 1;
+
+    const meta = {
+      id,
+      projectId: input.projectId || null,
+      projectName: input.projectName || null,
+      sessionId: input.sessionId || null,
+      kind,
+      title,
+      lang: input.lang || null,
+      bytes,
+      lines: source.split('\n').length,
+      groupKey,
+      version,
+      messageIndex: Number.isInteger(input.messageIndex) ? input.messageIndex : null,
+      createdAt: input.createdAt || new Date().toISOString(),
+      blob: `${id}.${extensionFor(kind, input.lang, title)}`,
+    };
+
+    await atomicWriteText(blobPath(meta), source);
+    index.artifacts.push(meta);
+    const evicted = await pruneIndex(index);
+    await saveIndex(index);
+    if (evicted) console.log(`[Artifacts] pruned ${evicted} artifact(s) over the ${MAX_ARTIFACTS} cap`);
+    return { artifact: meta, created: true };
+  });
+}
+
+/**
+ * Insert many artifacts under a single lock acquisition.
+ *
+ * The renderer harvests a whole conversation at once when a session is resumed,
+ * which can be dozens of artifacts. Routing those through saveArtifact() one by
+ * one would take the cross-process lock and rewrite index.json once per
+ * artifact; this does it once for the batch.
+ *
+ * @returns {Promise<{created: object[], skipped: number}>}
+ */
+async function saveMany(inputs) {
+  const list = Array.isArray(inputs) ? inputs : [];
+  if (!list.length) return { created: [], skipped: 0 };
+
+  return withLock(async () => {
+    const index = await loadIndex();
+    const known = new Set(index.artifacts.map(a => a.id));
+    // Highest version seen per group, seeded from disk and advanced as the batch
+    // is applied, so several versions arriving together still number correctly.
+    const versionByGroup = new Map();
+    for (const a of index.artifacts) {
+      versionByGroup.set(a.groupKey, Math.max(versionByGroup.get(a.groupKey) || 0, a.version || 1));
+    }
+
+    const created = [];
+    let skipped = 0;
+    const writes = [];
+
+    for (const input of list) {
+      const source = String(input?.source ?? '');
+      const kind = KINDS.includes(input?.kind) ? input.kind : 'code';
+      const bytes = Buffer.byteLength(source, 'utf8');
+      if (!source.trim() || bytes > MAX_BLOB_BYTES) { skipped++; continue; }
+
+      const id = input.id || computeId(kind, source);
+      if (known.has(id)) { skipped++; continue; }
+      known.add(id);
+
+      const title = String(input.title || 'Untitled').trim().slice(0, 200);
+      const groupKey = computeGroupKey(input.projectId, kind, title);
+      const version = (versionByGroup.get(groupKey) || 0) + 1;
+      versionByGroup.set(groupKey, version);
+
+      const meta = {
+        id,
+        projectId: input.projectId || null,
+        projectName: input.projectName || null,
+        sessionId: input.sessionId || null,
+        kind,
+        title,
+        lang: input.lang || null,
+        bytes,
+        lines: source.split('\n').length,
+        groupKey,
+        version,
+        messageIndex: Number.isInteger(input.messageIndex) ? input.messageIndex : null,
+        createdAt: input.createdAt || new Date().toISOString(),
+        blob: `${id}.${extensionFor(kind, input.lang, title)}`,
+      };
+      writes.push(atomicWriteText(blobPath(meta), source));
+      index.artifacts.push(meta);
+      created.push(meta);
+    }
+
+    if (!created.length) return { created: [], skipped };
+
+    await Promise.all(writes);
+    await pruneIndex(index);
+    await saveIndex(index);
+    return { created, skipped };
+  });
+}
+
+/**
+ * List artifact metadata, newest first. All filters are optional and combine.
+ * @param {{projectId?: string, kind?: string, sessionId?: string,
+ *          query?: string, limit?: number, offset?: number,
+ *          latestOnly?: boolean}} [options]
+ */
+async function listArtifacts(options = {}) {
+  const index = await loadIndex();
+  let rows = index.artifacts;
+
+  if (options.projectId) rows = rows.filter(a => a.projectId === options.projectId);
+  if (options.sessionId) rows = rows.filter(a => a.sessionId === options.sessionId);
+  if (options.kind) rows = rows.filter(a => a.kind === options.kind);
+  if (options.query) {
+    const needle = String(options.query).toLowerCase();
+    rows = rows.filter(a =>
+      String(a.title || '').toLowerCase().includes(needle) ||
+      String(a.lang || '').toLowerCase().includes(needle) ||
+      String(a.projectName || '').toLowerCase().includes(needle)
+    );
+  }
+
+  rows = [...rows].sort((a, b) => String(b.createdAt || '').localeCompare(String(a.createdAt || '')));
+
+  // Collapse version chains down to their newest member, the way the grid shows
+  // one card per artifact with a v1/v2/v3 switcher inside it.
+  if (options.latestOnly) {
+    const best = new Map();
+    for (const row of rows) {
+      const current = best.get(row.groupKey);
+      if (!current || (row.version || 1) > (current.version || 1)) best.set(row.groupKey, row);
+    }
+    rows = [...best.values()].sort((a, b) => String(b.createdAt || '').localeCompare(String(a.createdAt || '')));
+  }
+
+  const total = rows.length;
+  const offset = Math.max(0, options.offset || 0);
+  const limit = options.limit != null ? Math.max(0, options.limit) : rows.length;
+  return { artifacts: rows.slice(offset, offset + limit), total };
+}
+
+/** One artifact, metadata plus its source. Null when unknown. */
+async function getArtifact(id) {
+  const index = await loadIndex();
+  const meta = index.artifacts.find(a => a.id === id);
+  if (!meta) return null;
+  let source = '';
+  try {
+    source = await fsp.readFile(blobPath(meta), 'utf8');
+  } catch (e) {
+    // The index survived but the blob did not: report the metadata rather than
+    // failing the whole call, so the UI can still offer to delete the entry.
+    console.warn(`[Artifacts] blob missing for ${id}:`, e.message);
+  }
+  return { ...meta, source };
+}
+
+/** Every version of an artifact, oldest first. */
+async function getVersions(groupKey) {
+  const index = await loadIndex();
+  return index.artifacts
+    .filter(a => a.groupKey === groupKey)
+    .sort((a, b) => (a.version || 1) - (b.version || 1));
+}
+
+/** Delete one artifact and its blob. Returns false when it was already gone. */
+async function deleteArtifact(id) {
+  return withLock(async () => {
+    const index = await loadIndex();
+    const meta = index.artifacts.find(a => a.id === id);
+    if (!meta) return false;
+    index.artifacts = index.artifacts.filter(a => a.id !== id);
+    try { await fsp.unlink(blobPath(meta)); } catch { /* already gone */ }
+    await saveIndex(index);
+    return true;
+  });
+}
+
+/**
+ * Delete every artifact matching a filter. Used by "clear this project" and by
+ * the MCP cleanup tool. Returns how many went.
+ */
+async function deleteWhere({ projectId, sessionId, kind } = {}) {
+  if (!projectId && !sessionId && !kind) throw new Error('deleteWhere requires at least one filter');
+  return withLock(async () => {
+    const index = await loadIndex();
+    const doomed = index.artifacts.filter(a =>
+      (!projectId || a.projectId === projectId) &&
+      (!sessionId || a.sessionId === sessionId) &&
+      (!kind || a.kind === kind)
+    );
+    if (!doomed.length) return 0;
+    const doomedIds = new Set(doomed.map(a => a.id));
+    index.artifacts = index.artifacts.filter(a => !doomedIds.has(a.id));
+    await Promise.all(doomed.map(async (meta) => {
+      try { await fsp.unlink(blobPath(meta)); } catch { /* already gone */ }
+    }));
+    await saveIndex(index);
+    return doomed.length;
+  });
+}
+
+/** Counts and total size, for the library header. */
+async function getStats() {
+  const index = await loadIndex();
+  const byKind = Object.fromEntries(KINDS.map(k => [k, 0]));
+  const projects = new Set();
+  let bytes = 0;
+  for (const a of index.artifacts) {
+    if (byKind[a.kind] !== undefined) byKind[a.kind]++;
+    if (a.projectId) projects.add(a.projectId);
+    bytes += a.bytes || 0;
+  }
+  return { total: index.artifacts.length, byKind, bytes, projects: projects.size };
+}
+
+module.exports = {
+  // paths, exported for tests and for the MCP tool's error messages
+  ARTIFACTS_DIR,
+  BLOBS_DIR,
+  INDEX_FILE,
+  KINDS,
+  MAX_ARTIFACTS,
+  MAX_BLOB_BYTES,
+  // pure helpers, shared with the renderer's detection pass
+  hashString,
+  computeId,
+  computeGroupKey,
+  extensionFor,
+  // store
+  saveArtifact,
+  saveMany,
+  listArtifacts,
+  getArtifact,
+  getVersions,
+  deleteArtifact,
+  deleteWhere,
+  getStats,
+};

--- a/src/shared/artifact-store.js
+++ b/src/shared/artifact-store.js
@@ -133,6 +133,20 @@ function blobPath(meta) {
   return path.join(BLOBS_DIR, meta.blob || `${meta.id}.txt`);
 }
 
+/**
+ * Fields only a `published` artifact has: the claude.ai URL it lives at, the
+ * one-line gallery subtitle and the browser-tab emoji. Omitted entirely for
+ * every other kind rather than stored as nulls, so index.json stays readable.
+ */
+function publishedFields(input) {
+  const extra = {};
+  if (input.url) extra.url = String(input.url);
+  if (input.description) extra.description = String(input.description).slice(0, 300);
+  if (input.favicon) extra.favicon = String(input.favicon).slice(0, 8);
+  if (input.path) extra.path = String(input.path);
+  return extra;
+}
+
 // ── Index ────────────────────────────────────────────────────────────────────
 
 const EMPTY_INDEX = { version: 1, artifacts: [] };
@@ -222,6 +236,7 @@ async function saveArtifact(input) {
       messageIndex: Number.isInteger(input.messageIndex) ? input.messageIndex : null,
       createdAt: input.createdAt || new Date().toISOString(),
       blob: `${id}.${extensionFor(kind, input.lang, title)}`,
+      ...publishedFields(input),
     };
 
     await atomicWriteText(blobPath(meta), source);
@@ -291,6 +306,7 @@ async function saveMany(inputs) {
         messageIndex: Number.isInteger(input.messageIndex) ? input.messageIndex : null,
         createdAt: input.createdAt || new Date().toISOString(),
         blob: `${id}.${extensionFor(kind, input.lang, title)}`,
+        ...publishedFields(input),
       };
       writes.push(atomicWriteText(blobPath(meta), source));
       index.artifacts.push(meta);

--- a/styles/artifacts.css
+++ b/styles/artifacts.css
@@ -1,0 +1,462 @@
+/* ==========================================================================
+   Artifacts
+   Two surfaces over the same store:
+     - the chat's Artifacts tab + split-pane viewer (.chat-artifact*)
+     - the global library panel (.artifacts-*)
+   ========================================================================== */
+
+/* ── Chat: artifacts tab (card grid) ── */
+
+.chat-artifacts-panel {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 14px 16px 60px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.chat-artifacts-panel[hidden] { display: none; }
+
+.chat-artifacts-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 10px 10px;
+  margin-bottom: 4px;
+  border-bottom: 1px solid var(--border-color);
+  font-size: var(--font-sm);
+}
+.chat-artifacts-count { color: var(--text-secondary); font-weight: 500; }
+
+.chat-artifacts-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 8px;
+}
+
+.chat-artifact-card {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px;
+  text-align: left;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+  color: var(--text-primary);
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.1s ease, border-color 0.1s ease;
+}
+.chat-artifact-card:hover {
+  background: var(--bg-hover);
+  border-color: var(--text-muted);
+}
+.chat-artifact-card.active {
+  border-color: var(--accent);
+  background: var(--accent-dim);
+}
+
+.chat-artifact-thumb {
+  flex-shrink: 0;
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border-radius: var(--radius-sm);
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+}
+.chat-artifact-thumb svg { width: 17px; height: 17px; }
+.chat-artifact-thumb[data-kind="html"] { color: var(--info); }
+.chat-artifact-thumb[data-kind="svg"] { color: var(--success); }
+.chat-artifact-thumb[data-kind="mermaid"] { color: var(--accent-hover); }
+.chat-artifact-thumb[data-kind="file"] { color: var(--text-secondary); }
+
+.chat-artifact-card-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.chat-artifact-card-title {
+  font-size: var(--font-sm);
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.chat-artifact-card-meta {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: var(--font-2xs);
+  color: var(--text-muted);
+}
+.chat-artifact-kind { text-transform: uppercase; letter-spacing: 0.03em; }
+.chat-artifact-dot { opacity: 0.5; }
+
+/* Brief ring on the block an artifact came from, after "Go to message". */
+.chat-artifact-flash {
+  animation: chat-artifact-flash 1.2s ease-out;
+}
+@keyframes chat-artifact-flash {
+  0%, 40% { box-shadow: 0 0 0 2px var(--accent); }
+  100% { box-shadow: 0 0 0 2px transparent; }
+}
+
+.chat-artifacts-empty {
+  padding: 28px 12px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: var(--font-sm);
+}
+
+/* ── Chat: split-pane viewer ── */
+
+.chat-artifact-pane {
+  position: relative;
+  display: flex;
+  flex-shrink: 0;
+  width: 46%;
+  min-width: 320px;
+  height: 100%;
+  background: var(--bg-secondary);
+  border-left: 1px solid var(--border-color);
+}
+.chat-artifact-pane[hidden] { display: none; }
+
+.chat-artifact-pane-inner {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.chat-artifact-resizer {
+  position: absolute;
+  left: -3px;
+  top: 0;
+  width: 7px;
+  height: 100%;
+  cursor: col-resize;
+  z-index: 2;
+}
+.chat-artifact-resizer:hover,
+.chat-artifact-resizer:focus-visible {
+  background: var(--accent-dim);
+  outline: none;
+}
+
+/* Held on <body> for the duration of a pane drag. The iframe rule is the
+   load-bearing one: an <iframe> swallows mousemove, so a drag that crossed the
+   artifact preview would stall until the pointer left it again. */
+body.resizing-h {
+  cursor: col-resize;
+  user-select: none;
+}
+body.resizing-h iframe { pointer-events: none; }
+
+.chat-artifact-head {
+  flex-shrink: 0;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-primary);
+}
+
+.chat-artifact-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+.chat-artifact-title {
+  flex: 1;
+  min-width: 0;
+  font-size: var(--font-sm);
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chat-artifact-kind-badge,
+.artifacts-row-kind {
+  flex-shrink: 0;
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  font-size: var(--font-2xs);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+.chat-artifact-kind-badge[data-kind="html"],
+.artifacts-row-kind[data-kind="html"] { color: var(--info); }
+.chat-artifact-kind-badge[data-kind="svg"],
+.artifacts-row-kind[data-kind="svg"] { color: var(--success); }
+.chat-artifact-kind-badge[data-kind="mermaid"],
+.artifacts-row-kind[data-kind="mermaid"] { color: var(--accent-hover); }
+
+.chat-artifact-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.chat-artifact-action {
+  padding: 4px 9px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font-family: inherit;
+  font-size: var(--font-xs);
+  cursor: pointer;
+  transition: background 0.1s ease, color 0.1s ease;
+}
+.chat-artifact-action:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+.chat-artifact-title-row .chat-artifact-action {
+  padding: 3px;
+  background: none;
+  border: none;
+  line-height: 0;
+}
+.chat-artifact-title-row .chat-artifact-action svg { width: 11px; height: 11px; }
+
+.chat-artifact-body {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 12px;
+}
+/* The viewer reuses the markdown blocks, which are sized for the transcript.
+   In the pane they should fill it instead. */
+.chat-artifact-body .chat-preview-container,
+.chat-artifact-body .chat-code-block { margin: 0; }
+.chat-artifact-body .chat-preview-iframe-wrap { min-height: 420px; }
+.chat-artifact-body .chat-svg-block .chat-svg-render svg { max-height: none; }
+
+/* ── Library panel ── */
+
+.artifacts-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.artifacts-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px 20px 10px;
+}
+.artifacts-title {
+  margin: 0;
+  font-size: var(--font-lg);
+  font-weight: 600;
+}
+.artifacts-stats {
+  display: flex;
+  gap: 16px;
+  font-size: var(--font-xs);
+  color: var(--text-muted);
+}
+.artifacts-stats strong { color: var(--text-secondary); font-weight: 600; }
+
+.artifacts-error {
+  margin: 0 20px 10px;
+  padding: 8px 12px;
+  border: 1px solid var(--danger);
+  border-radius: var(--radius-sm);
+  background: rgba(239, 68, 68, 0.08);
+  color: var(--danger);
+  font-size: var(--font-xs);
+}
+
+.artifacts-toolbar {
+  display: flex;
+  gap: 8px;
+  padding: 0 20px 12px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.artifacts-search,
+.artifacts-select {
+  padding: 6px 10px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: var(--font-sm);
+}
+.artifacts-search { flex: 1; min-width: 0; }
+.artifacts-search:focus,
+.artifacts-select:focus { outline: none; border-color: var(--accent); }
+
+.artifacts-body {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(260px, 340px) 1fr;
+}
+
+.artifacts-list {
+  overflow-y: auto;
+  padding: 8px;
+  border-right: 1px solid var(--border-color);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.artifacts-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 10px;
+  text-align: left;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.1s ease;
+}
+.artifacts-row:hover { background: var(--bg-hover); }
+.artifacts-row.active {
+  background: var(--accent-dim);
+  border-color: var(--accent);
+}
+
+.artifacts-row-main {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+.artifacts-row-title {
+  font-size: var(--font-sm);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.artifacts-row-meta {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: var(--font-2xs);
+  color: var(--text-muted);
+}
+.artifacts-dot { opacity: 0.5; }
+.artifacts-row-version {
+  flex-shrink: 0;
+  font-size: var(--font-2xs);
+  color: var(--accent);
+  font-variant-numeric: tabular-nums;
+}
+
+.artifacts-detail {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.artifacts-detail-head {
+  flex-shrink: 0;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border-color);
+}
+.artifacts-detail-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+.artifacts-detail-title {
+  font-size: var(--font-md);
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.artifacts-detail-meta {
+  display: flex;
+  gap: 12px;
+  margin-top: 4px;
+  font-size: var(--font-2xs);
+  color: var(--text-muted);
+}
+
+.artifacts-versions {
+  display: flex;
+  gap: 4px;
+  margin-top: 10px;
+}
+.artifacts-version {
+  padding: 3px 8px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font-family: inherit;
+  font-size: var(--font-2xs);
+  cursor: pointer;
+}
+.artifacts-version:hover { background: var(--bg-hover); color: var(--text-primary); }
+.artifacts-version.active {
+  background: var(--accent-dim);
+  border-color: var(--accent);
+  color: var(--accent-hover);
+}
+
+.artifacts-detail-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 12px;
+}
+.artifacts-btn {
+  padding: 5px 10px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font-family: inherit;
+  font-size: var(--font-xs);
+  cursor: pointer;
+  transition: background 0.1s ease, color 0.1s ease;
+}
+.artifacts-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
+.artifacts-btn--danger:hover {
+  background: rgba(239, 68, 68, 0.12);
+  border-color: var(--danger);
+  color: var(--danger);
+}
+
+.artifacts-detail-body {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 16px 18px 40px;
+}
+.artifacts-detail-body .chat-preview-iframe-wrap { min-height: 460px; }
+.artifacts-detail-body .chat-svg-block .chat-svg-render svg { max-height: none; }
+
+.artifacts-empty {
+  padding: 32px 16px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: var(--font-sm);
+}

--- a/styles/artifacts.css
+++ b/styles/artifacts.css
@@ -422,12 +422,28 @@ body.resizing-h iframe { pointer-events: none; }
   overflow: hidden;
   text-overflow: ellipsis;
 }
+.artifacts-detail-desc {
+  margin-top: 6px;
+  font-size: var(--font-sm);
+  color: var(--text-secondary);
+}
+
 .artifacts-detail-meta {
   display: flex;
+  align-items: center;
   gap: 12px;
   margin-top: 4px;
   font-size: var(--font-2xs);
   color: var(--text-muted);
+}
+/* The published URL is the useful identity of an artifact, but it is long —
+   let it take the leftover room and ellipsize rather than wrap the row. */
+.artifacts-detail-url {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--accent);
 }
 
 .artifacts-versions {

--- a/styles/artifacts.css
+++ b/styles/artifacts.css
@@ -222,12 +222,58 @@ body.resizing-h iframe { pointer-events: none; }
   color: var(--accent-hover);
 }
 
-/* A published .md page renders as a document, so give it document measure
-   instead of letting it run the full width of the pane. */
+/* ── Published Markdown, rendered as a document ──
+   The chat's prose rules are scoped to .chat-msg-content and tuned for
+   transcript density (18px h1, 4px paragraph gaps). A published page is meant
+   to be read, not skimmed in a message list, so it gets its own measure and
+   rhythm rather than inheriting either the chat's or the browser's defaults. */
 .chat-artifact-doc,
 .artifacts-doc {
   max-width: 72ch;
   margin: 0 auto;
+  font-size: var(--font-base);
+  line-height: 1.65;
+}
+
+.chat-artifact-doc h1, .artifacts-doc h1,
+.chat-artifact-doc h2, .artifacts-doc h2,
+.chat-artifact-doc h3, .artifacts-doc h3,
+.chat-artifact-doc h4, .artifacts-doc h4 {
+  color: var(--text-primary);
+  line-height: 1.3;
+  margin: 1.6em 0 0.5em;
+}
+/* No leading gap above the very first heading of the document. */
+.chat-artifact-doc > :first-child, .artifacts-doc > :first-child { margin-top: 0; }
+
+.chat-artifact-doc h1, .artifacts-doc h1 {
+  font-size: 1.6rem;
+  font-weight: 650;
+  padding-bottom: 0.3em;
+  border-bottom: 1px solid var(--border-color);
+}
+.chat-artifact-doc h2, .artifacts-doc h2 { font-size: 1.25rem; font-weight: 650; }
+.chat-artifact-doc h3, .artifacts-doc h3 { font-size: 1.05rem; font-weight: 600; }
+.chat-artifact-doc h4, .artifacts-doc h4 { font-size: 0.95rem; font-weight: 600; }
+
+.chat-artifact-doc p, .artifacts-doc p { margin: 0 0 1em; }
+
+.chat-artifact-doc ul, .artifacts-doc ul,
+.chat-artifact-doc ol, .artifacts-doc ol { margin: 0 0 1em; padding-left: 1.5em; }
+.chat-artifact-doc li, .artifacts-doc li { margin: 0.3em 0; }
+
+.chat-artifact-doc blockquote, .artifacts-doc blockquote {
+  margin: 0 0 1em;
+  padding: 0.2em 0 0.2em 1em;
+  border-left: 3px solid var(--accent);
+  color: var(--text-secondary);
+}
+
+.chat-artifact-doc table, .artifacts-doc table { margin: 0 0 1.2em; }
+.chat-artifact-doc hr, .artifacts-doc hr {
+  margin: 2em 0;
+  border: none;
+  border-top: 1px solid var(--border-color);
 }
 
 .chat-artifact-actions {

--- a/styles/artifacts.css
+++ b/styles/artifacts.css
@@ -87,6 +87,27 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+/* Published artifacts bring their own emoji from the Artifact tool's favicon. */
+.chat-artifact-favicon,
+.artifacts-row-favicon {
+  font-size: 17px;
+  line-height: 1;
+}
+.artifacts-row-favicon {
+  flex-shrink: 0;
+  width: 22px;
+  text-align: center;
+}
+
+.chat-artifact-card-desc,
+.artifacts-row-desc {
+  font-size: var(--font-2xs);
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .chat-artifact-card-meta {
   display: flex;
   align-items: center;
@@ -199,6 +220,19 @@ body.resizing-h iframe { pointer-events: none; }
 .artifacts-row-kind[data-kind="svg"] { color: var(--success); }
 .chat-artifact-kind-badge[data-kind="mermaid"],
 .artifacts-row-kind[data-kind="mermaid"] { color: var(--accent-hover); }
+.chat-artifact-kind-badge[data-kind="published"],
+.artifacts-row-kind[data-kind="published"] {
+  background: var(--accent-dim);
+  color: var(--accent-hover);
+}
+
+/* A published .md page renders as a document, so give it document measure
+   instead of letting it run the full width of the pane. */
+.chat-artifact-doc,
+.artifacts-doc {
+  max-width: 72ch;
+  margin: 0 auto;
+}
 
 .chat-artifact-actions {
   display: flex;

--- a/styles/artifacts.css
+++ b/styles/artifacts.css
@@ -1,58 +1,91 @@
 /* ==========================================================================
    Artifacts
    Two surfaces over the same store:
-     - the chat's Artifacts tab + split-pane viewer (.chat-artifact*)
+     - the chat's Documents tab: list + preview, two columns (.chat-artifact*)
      - the global library panel (.artifacts-*)
    ========================================================================== */
 
-/* ── Chat: artifacts tab (card grid) ── */
+/* ── Chat: Documents tab ──
+   Two columns inside the tab: the list of what this conversation produced on
+   the left, the preview of the selected one on the right. Both belong to the
+   tab, so switching tabs takes the preview with it. */
 
 .chat-artifacts-panel {
   flex: 1;
   min-height: 0;
-  overflow-y: auto;
-  padding: 14px 16px 60px;
   display: flex;
-  flex-direction: column;
-  gap: 4px;
+  flex-direction: row;
+  overflow: hidden;
 }
 .chat-artifacts-panel[hidden] { display: none; }
 
-.chat-artifacts-summary {
+.chat-artifacts-side {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 6px 10px 10px;
-  margin-bottom: 4px;
+  flex-direction: column;
+  width: 300px;
+  min-width: 200px;
+  flex-shrink: 0;
+  overflow: hidden;
+  border-right: 1px solid var(--border-color);
+}
+
+.chat-artifacts-summary {
+  flex-shrink: 0;
+  padding: 10px 14px;
   border-bottom: 1px solid var(--border-color);
   font-size: var(--font-sm);
 }
 .chat-artifacts-count { color: var(--text-secondary); font-weight: 500; }
 
-.chat-artifacts-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: 8px;
+.chat-artifacts-list {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.chat-artifacts-resizer {
+  flex-shrink: 0;
+  width: 5px;
+  margin: 0 -2px;
+  cursor: col-resize;
+  z-index: 2;
+}
+.chat-artifacts-resizer:hover,
+.chat-artifacts-resizer:focus-visible {
+  background: var(--accent-dim);
+  outline: none;
+}
+
+.chat-artifact-view {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  /* Without this a long code line pushes the list off-screen instead of
+     scrolling inside the preview. */
+  min-width: 0;
+  overflow: hidden;
 }
 
 .chat-artifact-card {
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 10px;
+  width: 100%;
+  padding: 8px 10px;
   text-align: left;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius);
+  background: none;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
   color: var(--text-primary);
   cursor: pointer;
   font-family: inherit;
   transition: background 0.1s ease, border-color 0.1s ease;
 }
-.chat-artifact-card:hover {
-  background: var(--bg-hover);
-  border-color: var(--text-muted);
-}
+.chat-artifact-card:hover { background: var(--bg-hover); }
 .chat-artifact-card.active {
   border-color: var(--accent);
   background: var(--accent-dim);
@@ -132,43 +165,6 @@
   text-align: center;
   color: var(--text-muted);
   font-size: var(--font-sm);
-}
-
-/* ── Chat: split-pane viewer ── */
-
-.chat-artifact-pane {
-  position: relative;
-  display: flex;
-  flex-shrink: 0;
-  width: 46%;
-  min-width: 320px;
-  height: 100%;
-  background: var(--bg-secondary);
-  border-left: 1px solid var(--border-color);
-}
-.chat-artifact-pane[hidden] { display: none; }
-
-.chat-artifact-pane-inner {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-  min-width: 0;
-  overflow: hidden;
-}
-
-.chat-artifact-resizer {
-  position: absolute;
-  left: -3px;
-  top: 0;
-  width: 7px;
-  height: 100%;
-  cursor: col-resize;
-  z-index: 2;
-}
-.chat-artifact-resizer:hover,
-.chat-artifact-resizer:focus-visible {
-  background: var(--accent-dim);
-  outline: none;
 }
 
 /* Held on <body> for the duration of a pane drag. The iframe rule is the

--- a/styles/chat.css
+++ b/styles/chat.css
@@ -6,31 +6,16 @@
    ========================================================================== */
 
 /* ── Chat view container ── */
-/* A row: the conversation column, plus the artifact pane when one is open.
-   `.chat-main` carries the column layout the view itself used to have, so
-   nothing inside the conversation had to change. */
 .chat-view {
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   height: 100%;
   background: var(--bg-primary);
   overflow: hidden;
   position: relative;
 }
 
-.chat-main {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-  /* Without this a wide artifact (a long code line) would push the
-     conversation column out instead of scrolling inside its own pane. */
-  min-width: 0;
-  height: 100%;
-  overflow: hidden;
-  position: relative;
-}
-
-/* ── Session tab bar (Conversation / Changes / Artifacts) ── */
+/* ── Session tab bar (Conversation / Changes / Documents) ── */
 .chat-tabbar {
   display: flex;
   align-items: stretch;

--- a/styles/chat.css
+++ b/styles/chat.css
@@ -6,16 +6,31 @@
    ========================================================================== */
 
 /* ── Chat view container ── */
+/* A row: the conversation column, plus the artifact pane when one is open.
+   `.chat-main` carries the column layout the view itself used to have, so
+   nothing inside the conversation had to change. */
 .chat-view {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   height: 100%;
   background: var(--bg-primary);
   overflow: hidden;
   position: relative;
 }
 
-/* ── Session tab bar (Conversation / Changes) ── */
+.chat-main {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  /* Without this a wide artifact (a long code line) would push the
+     conversation column out instead of scrolling inside its own pane. */
+  min-width: 0;
+  height: 100%;
+  overflow: hidden;
+  position: relative;
+}
+
+/* ── Session tab bar (Conversation / Changes / Artifacts) ── */
 .chat-tabbar {
   display: flex;
   align-items: stretch;

--- a/styles/index.css
+++ b/styles/index.css
@@ -26,3 +26,4 @@
 @import './session-replay.css';
 @import './discord-theme.css';
 @import './workspace.css';
+@import './artifacts.css';

--- a/tests/services/ArtifactService.test.js
+++ b/tests/services/ArtifactService.test.js
@@ -23,6 +23,8 @@ const {
 const {
   detect,
   fromFileTool,
+  fromArtifactTool,
+  isArtifactPublish,
   deriveTitle,
   readCodeSource,
   createRegistry,
@@ -191,6 +193,87 @@ describe('fromFileTool', () => {
     expect(fromFileTool('Edit', { file_path: '/a.js', old_string: 'a', new_string: 'b' })).toBeNull();
     expect(fromFileTool('Read', { file_path: '/a.js' })).toBeNull();
     expect(fromFileTool('Write', { file_path: '/a.js' })).toBeNull();
+  });
+});
+
+describe('published artifacts (the Agent SDK Artifact tool)', () => {
+  describe('isArtifactPublish', () => {
+    it('accepts a publish, which is the default action', () => {
+      expect(isArtifactPublish('Artifact', { file_path: '/tmp/page.html', favicon: '📊' })).toBe(true);
+      expect(isArtifactPublish('Artifact', { action: 'publish', file_path: '/tmp/page.html' })).toBe(true);
+    });
+
+    it('rejects a list, which only enumerates the gallery', () => {
+      expect(isArtifactPublish('Artifact', { action: 'list', limit: 25 })).toBe(false);
+    });
+
+    it('rejects a call with no file to publish, and other tools', () => {
+      expect(isArtifactPublish('Artifact', { favicon: '📊' })).toBe(false);
+      expect(isArtifactPublish('Write', { file_path: '/tmp/page.html' })).toBe(false);
+    });
+  });
+
+  it('carries the URL, description and favicon that only a publish has', () => {
+    const artifact = fromArtifactTool(
+      { file_path: '/tmp/report.html', description: 'Q3 numbers', favicon: '📊' },
+      '<html><title>Q3 report</title></html>',
+      'https://claude.ai/public/artifacts/abc'
+    );
+
+    expect(artifact).toMatchObject({
+      kind: 'published',
+      lang: 'html',
+      title: 'Q3 report',
+      description: 'Q3 numbers',
+      favicon: '📊',
+      url: 'https://claude.ai/public/artifacts/abc',
+      path: '/tmp/report.html',
+    });
+  });
+
+  it('lets a Markdown page keep its filename identity, per the tool contract', () => {
+    const artifact = fromArtifactTool(
+      { file_path: '/tmp/audit-notes.md', title: 'Ignored for markdown' },
+      '# Some heading\n\nbody',
+    );
+
+    expect(artifact).toMatchObject({ lang: 'markdown', title: 'audit-notes.md' });
+  });
+
+  it('prefers the HTML <title> over the title parameter, which only fills in', () => {
+    const withTag = fromArtifactTool(
+      { file_path: '/tmp/p.html', title: 'Fallback' },
+      '<html><title>From the tag</title></html>'
+    );
+    const withoutTag = fromArtifactTool({ file_path: '/tmp/p.html', title: 'Fallback' }, '<div>no tag</div>');
+
+    expect(withTag.title).toBe('From the tag');
+    expect(withoutTag.title).toBe('Fallback');
+  });
+
+  it('falls back to the basename when neither a tag nor a title is given', () => {
+    const artifact = fromArtifactTool({ file_path: '/a/b/dashboard.html' }, '<div>x</div>');
+
+    expect(artifact.title).toBe('dashboard.html');
+  });
+
+  it('is null-safe on a call with no path', () => {
+    expect(fromArtifactTool({}, 'content')).toBeNull();
+  });
+
+  it('captures without a URL, since replayed history may have no result to pair', () => {
+    const artifact = fromArtifactTool({ file_path: '/tmp/p.html' }, '<div>x</div>');
+
+    expect(artifact.url).toBeNull();
+    expect(artifact.kind).toBe('published');
+  });
+
+  it('gives identical content the same id whatever the URL, so recapture is idempotent', () => {
+    const source = '<html><title>Same</title></html>';
+    const a = fromArtifactTool({ file_path: '/tmp/p.html' }, source, 'https://claude.ai/a');
+    const b = fromArtifactTool({ file_path: '/tmp/p.html' }, source, null);
+
+    expect(a.id).toBe(b.id);
   });
 });
 

--- a/tests/services/ArtifactService.test.js
+++ b/tests/services/ArtifactService.test.js
@@ -1,0 +1,291 @@
+/**
+ * Artifact detection test suite.
+ *
+ * The fixtures are built by the REAL block renderers from
+ * src/renderer/services/markdown/blocks/code.js rather than by hand-written
+ * HTML. That is the point of the suite: detection reads the rendered DOM, so
+ * the thing worth guarding against is the renderer changing its markup out from
+ * under the selectors. A hand-written fixture would keep passing while the app
+ * silently stopped finding artifacts.
+ */
+
+jest.mock('../../src/renderer/i18n', () => ({
+  t: (key) => key,
+}));
+
+const {
+  renderHtmlPreviewBlock,
+  renderSvgBlock,
+  renderMermaidBlock,
+  renderDiffBlock,
+} = require('../../src/renderer/services/markdown/blocks/code');
+
+const {
+  detect,
+  fromFileTool,
+  deriveTitle,
+  readCodeSource,
+  createRegistry,
+  MIN_CODE_LINES,
+} = require('../../src/renderer/services/ArtifactService');
+
+const { computeId } = require('../../src/shared/artifact-schema');
+
+/** Mount HTML into a detached container the way ChatView hands nodes to detect(). */
+function mount(html) {
+  const el = document.createElement('div');
+  el.className = 'chat-msg-content';
+  el.innerHTML = html;
+  return el;
+}
+
+/**
+ * Reproduce the standard code block markup from configure.js: every line in a
+ * <span class="code-line">, joined by newlines, blank lines rendered as a space.
+ */
+function codeBlockHtml(source, lang, filename = '') {
+  const lines = source.split('\n')
+    .map((line, i) => `<span class="code-line" data-line="${i + 1}">${line || ' '}</span>`)
+    .join('\n');
+  const filenameHtml = filename ? `<span class="chat-code-filename">${filename}</span>` : '';
+  return `<div class="chat-code-block"><div class="chat-code-header">${filenameHtml}`
+    + `<span class="chat-code-lang">${lang}</span></div>`
+    + `<pre><code class="line-numbers-off">${lines}</code></pre></div>`;
+}
+
+describe('artifact detection', () => {
+  it('finds an HTML preview and titles it from <title>', () => {
+    const source = '<html><head><title>Sales dashboard</title></head><body><p>hi</p></body></html>';
+    const found = detect(mount(renderHtmlPreviewBlock(source, '')));
+
+    expect(found).toHaveLength(1);
+    expect(found[0].kind).toBe('html');
+    expect(found[0].title).toBe('Sales dashboard');
+    expect(found[0].source).toBe(source);
+  });
+
+  it('prefers an explicit filename over the document title', () => {
+    const source = '<html><title>Ignored</title></html>';
+    const found = detect(mount(renderHtmlPreviewBlock(source, 'report.html')));
+
+    expect(found[0].title).toBe('report.html');
+  });
+
+  it('finds an SVG and recovers its unsanitized source', () => {
+    const source = '<svg viewBox="0 0 10 10"><title>Logo</title><circle cx="5" cy="5" r="4"/></svg>';
+    const found = detect(mount(renderSvgBlock(source)));
+
+    expect(found).toHaveLength(1);
+    expect(found[0].kind).toBe('svg');
+    expect(found[0].title).toBe('Logo');
+    // The rendered SVG is sanitized for display; the artifact keeps the original.
+    expect(found[0].source).toBe(source);
+  });
+
+  it('finds a Mermaid diagram and names it by diagram type', () => {
+    const found = detect(mount(renderMermaidBlock('graph LR\n  A --> B')));
+
+    expect(found).toHaveLength(1);
+    expect(found[0].kind).toBe('mermaid');
+    expect(found[0].title).toBe('Flowchart');
+  });
+
+  it('uses an explicit mermaid title when the diagram declares one', () => {
+    const found = detect(mount(renderMermaidBlock('---\ntitle: Deploy pipeline\n---\ngraph LR\n A-->B')));
+
+    expect(found[0].title).toBe('Deploy pipeline');
+  });
+
+  it('ignores diff blocks, which are a view of a change rather than a thing', () => {
+    const diff = renderDiffBlock('- old line\n+ new line\n'.repeat(20), 'app.js');
+
+    expect(detect(mount(diff))).toHaveLength(0);
+  });
+
+  describe('code blocks', () => {
+    const longSource = Array.from({ length: 25 }, (_, i) => `const x${i} = ${i};`).join('\n');
+
+    it('promotes a long block with a known language', () => {
+      const found = detect(mount(codeBlockHtml(longSource, 'javascript', 'app.js')));
+
+      expect(found).toHaveLength(1);
+      expect(found[0].kind).toBe('code');
+      expect(found[0].lang).toBe('javascript');
+      expect(found[0].title).toBe('app.js');
+    });
+
+    it('recovers the source, restoring blank lines the renderer padded', () => {
+      const withBlanks = `line one\n\nline three${'\nx'.repeat(MIN_CODE_LINES)}`;
+      const found = detect(mount(codeBlockHtml(withBlanks, 'javascript')));
+
+      expect(found[0].source).toBe(withBlanks);
+    });
+
+    it('skips a block shorter than the threshold', () => {
+      const short = Array.from({ length: MIN_CODE_LINES - 1 }, () => 'x').join('\n');
+
+      expect(detect(mount(codeBlockHtml(short, 'python')))).toHaveLength(0);
+    });
+
+    it('skips a block with no language, which is usually pasted output', () => {
+      expect(detect(mount(codeBlockHtml(longSource, 'text')))).toHaveLength(0);
+    });
+
+    it('falls back to the first comment line for an unnamed block', () => {
+      const commented = `# Parse the changelog into releases\n${longSource}`;
+      const found = detect(mount(codeBlockHtml(commented, 'python')));
+
+      expect(found[0].title).toBe('Parse the changelog into releases');
+    });
+
+    it('does not double-count the code view inside an HTML preview', () => {
+      const source = `<div>\n${longSource}\n</div>`;
+      const found = detect(mount(renderHtmlPreviewBlock(source, 'page.html')));
+
+      expect(found).toHaveLength(1);
+      expect(found[0].kind).toBe('html');
+    });
+  });
+
+  it('returns artifacts in document order across a batch of nodes', () => {
+    const nodes = [
+      mount(renderMermaidBlock('graph LR\n A-->B')),
+      mount(renderSvgBlock('<svg><title>Second</title></svg>')),
+    ];
+    const found = detect(nodes);
+
+    expect(found.map((a) => a.kind)).toEqual(['mermaid', 'svg']);
+  });
+
+  it('assigns content-derived ids, so the same content always yields the same id', () => {
+    const source = '<html><title>Stable</title></html>';
+    const first = detect(mount(renderHtmlPreviewBlock(source, '')));
+    const second = detect(mount(renderHtmlPreviewBlock(source, '')));
+
+    expect(first[0].id).toBe(second[0].id);
+    expect(first[0].id).toBe(computeId('html', source));
+  });
+
+  it('carries the message index through, so the UI can jump back to the message', () => {
+    const found = detect(mount(renderMermaidBlock('pie title Votes\n "a": 1')), { messageIndex: 7 });
+
+    expect(found[0].messageIndex).toBe(7);
+  });
+
+  it('tolerates a malformed node instead of losing the whole batch', () => {
+    const broken = mount('<div class="chat-preview-container"></div>');
+    const good = mount(renderMermaidBlock('graph LR\n A-->B'));
+
+    expect(detect([broken, good])).toHaveLength(1);
+  });
+});
+
+describe('fromFileTool', () => {
+  it('turns a Write call into a file artifact named after the basename', () => {
+    const artifact = fromFileTool('Write', { file_path: '/repo/src/util/parse.js', content: 'export const a = 1;' });
+
+    expect(artifact).toMatchObject({ kind: 'file', title: 'parse.js', path: '/repo/src/util/parse.js' });
+  });
+
+  it('ignores tools that are not a full file write', () => {
+    expect(fromFileTool('Edit', { file_path: '/a.js', old_string: 'a', new_string: 'b' })).toBeNull();
+    expect(fromFileTool('Read', { file_path: '/a.js' })).toBeNull();
+    expect(fromFileTool('Write', { file_path: '/a.js' })).toBeNull();
+  });
+});
+
+describe('deriveTitle', () => {
+  it('falls back through the chain for HTML', () => {
+    expect(deriveTitle('html', '<h1>Only a heading</h1>')).toBe('Only a heading');
+    expect(deriveTitle('html', '<div>nothing</div>')).toBe('Preview');
+  });
+
+  it('names a snippet after its language when nothing better exists', () => {
+    expect(deriveTitle('code', 'a = 1', { lang: 'ruby' })).toBe('ruby snippet');
+  });
+
+  it('rejects a decorative comment as a title', () => {
+    expect(deriveTitle('code', '// ------------\nconst a = 1;', { lang: 'js' })).toBe('js snippet');
+  });
+});
+
+describe('readCodeSource', () => {
+  it('returns an empty string rather than throwing on a missing node', () => {
+    expect(readCodeSource(null)).toBe('');
+  });
+});
+
+describe('session registry', () => {
+  let saveMany;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    saveMany = jest.fn().mockResolvedValue({ created: [], skipped: 0 });
+    window.electron_api = { artifacts: { saveMany } };
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    delete window.electron_api;
+  });
+
+  const artifact = (id) => ({ id, kind: 'code', title: `t${id}`, lang: 'js', source: 'x', messageIndex: 1 });
+
+  it('deduplicates by id across repeated harvests', () => {
+    const registry = createRegistry({ project: { id: 'p1', name: 'Proj' } });
+
+    expect(registry.add([artifact('a'), artifact('b')])).toBe(2);
+    expect(registry.add([artifact('a'), artifact('b')])).toBe(0);
+    expect(registry.size).toBe(2);
+  });
+
+  it('notifies only when something new arrived', () => {
+    const onChange = jest.fn();
+    const registry = createRegistry({ onChange });
+
+    registry.add(artifact('a'));
+    registry.add(artifact('a'));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(1);
+  });
+
+  it('persists one batch per burst rather than one call per artifact', () => {
+    const registry = createRegistry({
+      project: { id: 'p1', name: 'Proj' },
+      getSessionId: () => 'sess-1',
+    });
+
+    registry.add(artifact('a'));
+    registry.add(artifact('b'));
+    expect(saveMany).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(500);
+
+    expect(saveMany).toHaveBeenCalledTimes(1);
+    const batch = saveMany.mock.calls[0][0];
+    expect(batch).toHaveLength(2);
+    expect(batch[0]).toMatchObject({ projectId: 'p1', projectName: 'Proj', sessionId: 'sess-1' });
+  });
+
+  it('still tracks artifacts when the persistence bridge is absent', () => {
+    delete window.electron_api;
+    const registry = createRegistry({});
+
+    registry.add(artifact('a'));
+    jest.advanceTimersByTime(500);
+
+    expect(registry.list()).toHaveLength(1);
+  });
+
+  it('drops everything on clear, including work not yet flushed', () => {
+    const registry = createRegistry({});
+
+    registry.add(artifact('a'));
+    registry.clear();
+    jest.advanceTimersByTime(500);
+
+    expect(registry.size).toBe(0);
+    expect(saveMany).not.toHaveBeenCalled();
+  });
+});

--- a/tests/services/artifactStore.test.js
+++ b/tests/services/artifactStore.test.js
@@ -1,0 +1,254 @@
+/**
+ * Artifact store test suite.
+ *
+ * Runs against a real temporary data directory rather than a mocked fs: the
+ * store's contract is about what survives on disk (idempotence, version
+ * numbering, blob round-trip, pruning), and a mocked fs would verify the mock
+ * instead of the behaviour.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+let tmpDir;
+let store;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ct-artifacts-'));
+  // The store resolves its directory once at require time.
+  process.env.CT_DATA_DIR = tmpDir;
+  jest.resetModules();
+  store = require('../../src/shared/artifact-store');
+});
+
+afterEach(() => {
+  delete process.env.CT_DATA_DIR;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const html = (body) => `<html><title>Dashboard</title><body>${body}</body></html>`;
+
+describe('saveArtifact', () => {
+  it('writes the source to a blob and indexes its metadata', async () => {
+    const { artifact, created } = await store.saveArtifact({
+      projectId: 'p1', projectName: 'Proj', kind: 'html', title: 'Dashboard', source: html('v1'),
+    });
+
+    expect(created).toBe(true);
+    expect(artifact).toMatchObject({ kind: 'html', title: 'Dashboard', version: 1, lines: 1 });
+
+    const blob = path.join(tmpDir, 'artifacts', 'blobs', artifact.blob);
+    expect(fs.readFileSync(blob, 'utf8')).toBe(html('v1'));
+  });
+
+  it('is idempotent: saving identical content twice creates one entry', async () => {
+    const first = await store.saveArtifact({ projectId: 'p1', kind: 'html', title: 'Dashboard', source: html('v1') });
+    const second = await store.saveArtifact({ projectId: 'p1', kind: 'html', title: 'Dashboard', source: html('v1') });
+
+    expect(second.created).toBe(false);
+    expect(second.artifact.id).toBe(first.artifact.id);
+    expect((await store.listArtifacts({})).total).toBe(1);
+  });
+
+  it('numbers a rewrite of the same title as the next version of one artifact', async () => {
+    const v1 = await store.saveArtifact({ projectId: 'p1', kind: 'html', title: 'Dashboard', source: html('v1') });
+    const v2 = await store.saveArtifact({ projectId: 'p1', kind: 'html', title: 'Dashboard', source: html('v2') });
+
+    expect(v2.artifact.version).toBe(2);
+    expect(v2.artifact.groupKey).toBe(v1.artifact.groupKey);
+  });
+
+  it('keeps the same title in different projects apart', async () => {
+    const a = await store.saveArtifact({ projectId: 'p1', kind: 'html', title: 'Dashboard', source: html('a') });
+    const b = await store.saveArtifact({ projectId: 'p2', kind: 'html', title: 'Dashboard', source: html('b') });
+
+    expect(b.artifact.groupKey).not.toBe(a.artifact.groupKey);
+    expect(b.artifact.version).toBe(1);
+  });
+
+  it('refuses a blob past the size cap instead of filling the store', async () => {
+    const huge = 'x'.repeat(store.MAX_BLOB_BYTES + 1);
+    const result = await store.saveArtifact({ projectId: 'p1', kind: 'code', title: 'huge.js', source: huge });
+
+    expect(result).toMatchObject({ created: false, skipped: 'too-large' });
+    expect((await store.listArtifacts({})).total).toBe(0);
+  });
+
+  it('refuses an empty artifact', async () => {
+    const result = await store.saveArtifact({ projectId: 'p1', kind: 'code', title: 'empty', source: '   ' });
+
+    expect(result).toMatchObject({ created: false, skipped: 'empty' });
+  });
+});
+
+describe('saveMany', () => {
+  it('numbers versions correctly when they arrive in one batch', async () => {
+    const { created } = await store.saveMany([
+      { projectId: 'p1', kind: 'html', title: 'Page', source: html('1') },
+      { projectId: 'p1', kind: 'html', title: 'Page', source: html('2') },
+      { projectId: 'p1', kind: 'html', title: 'Page', source: html('3') },
+    ]);
+
+    expect(created.map(a => a.version)).toEqual([1, 2, 3]);
+  });
+
+  it('skips duplicates inside the batch and against what is already stored', async () => {
+    await store.saveArtifact({ projectId: 'p1', kind: 'html', title: 'Page', source: html('1') });
+
+    const { created, skipped } = await store.saveMany([
+      { projectId: 'p1', kind: 'html', title: 'Page', source: html('1') }, // already on disk
+      { projectId: 'p1', kind: 'html', title: 'Page', source: html('2') },
+      { projectId: 'p1', kind: 'html', title: 'Page', source: html('2') }, // dup within batch
+    ]);
+
+    expect(created).toHaveLength(1);
+    expect(skipped).toBe(2);
+  });
+
+  it('continues past an oversized entry rather than failing the batch', async () => {
+    const { created, skipped } = await store.saveMany([
+      { projectId: 'p1', kind: 'code', title: 'huge.js', source: 'x'.repeat(store.MAX_BLOB_BYTES + 1) },
+      { projectId: 'p1', kind: 'code', title: 'ok.js', source: 'const a = 1;' },
+    ]);
+
+    expect(created).toHaveLength(1);
+    expect(created[0].title).toBe('ok.js');
+    expect(skipped).toBe(1);
+  });
+
+  it('does nothing on an empty batch', async () => {
+    await expect(store.saveMany([])).resolves.toEqual({ created: [], skipped: 0 });
+  });
+});
+
+describe('listArtifacts', () => {
+  beforeEach(async () => {
+    await store.saveMany([
+      { projectId: 'p1', projectName: 'Alpha', kind: 'html', title: 'Page', source: html('1') },
+      { projectId: 'p1', projectName: 'Alpha', kind: 'html', title: 'Page', source: html('2') },
+      { projectId: 'p2', projectName: 'Beta', kind: 'code', lang: 'python', title: 'parser.py', source: 'a = 1' },
+    ]);
+  });
+
+  it('filters by project and by kind', async () => {
+    expect((await store.listArtifacts({ projectId: 'p2' })).total).toBe(1);
+    expect((await store.listArtifacts({ kind: 'html' })).total).toBe(2);
+  });
+
+  it('matches a query against title, language and project name', async () => {
+    expect((await store.listArtifacts({ query: 'parser' })).total).toBe(1);
+    expect((await store.listArtifacts({ query: 'python' })).total).toBe(1);
+    expect((await store.listArtifacts({ query: 'alpha' })).total).toBe(2);
+  });
+
+  it('collapses version chains to their newest member with latestOnly', async () => {
+    const { artifacts } = await store.listArtifacts({ latestOnly: true });
+
+    expect(artifacts).toHaveLength(2);
+    const page = artifacts.find(a => a.title === 'Page');
+    expect(page.version).toBe(2);
+  });
+
+  it('reports the total independently of the page returned', async () => {
+    const { artifacts, total } = await store.listArtifacts({ limit: 1 });
+
+    expect(artifacts).toHaveLength(1);
+    expect(total).toBe(3);
+  });
+});
+
+describe('getArtifact', () => {
+  it('returns metadata plus the stored source', async () => {
+    const { artifact } = await store.saveArtifact({ projectId: 'p1', kind: 'html', title: 'Page', source: html('body') });
+
+    await expect(store.getArtifact(artifact.id)).resolves.toMatchObject({
+      id: artifact.id,
+      source: html('body'),
+    });
+  });
+
+  it('returns null for an unknown id', async () => {
+    await expect(store.getArtifact('art-nope')).resolves.toBeNull();
+  });
+
+  it('still returns metadata when the blob went missing, so the entry can be cleaned up', async () => {
+    const { artifact } = await store.saveArtifact({ projectId: 'p1', kind: 'html', title: 'Page', source: html('x') });
+    fs.unlinkSync(path.join(tmpDir, 'artifacts', 'blobs', artifact.blob));
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const found = await store.getArtifact(artifact.id);
+
+    expect(found.id).toBe(artifact.id);
+    expect(found.source).toBe('');
+    console.warn.mockRestore();
+  });
+});
+
+describe('delete', () => {
+  it('removes the entry and its blob', async () => {
+    const { artifact } = await store.saveArtifact({ projectId: 'p1', kind: 'html', title: 'Page', source: html('x') });
+
+    await expect(store.deleteArtifact(artifact.id)).resolves.toBe(true);
+    expect((await store.listArtifacts({})).total).toBe(0);
+    expect(fs.existsSync(path.join(tmpDir, 'artifacts', 'blobs', artifact.blob))).toBe(false);
+  });
+
+  it('reports false for an id that is already gone', async () => {
+    await expect(store.deleteArtifact('art-nope')).resolves.toBe(false);
+  });
+
+  it('deletes by filter', async () => {
+    await store.saveMany([
+      { projectId: 'p1', kind: 'html', title: 'A', source: html('a') },
+      { projectId: 'p1', kind: 'code', title: 'B', source: 'b' },
+      { projectId: 'p2', kind: 'html', title: 'C', source: html('c') },
+    ]);
+
+    await expect(store.deleteWhere({ projectId: 'p1' })).resolves.toBe(2);
+    expect((await store.listArtifacts({})).total).toBe(1);
+  });
+
+  it('refuses an unfiltered mass delete', async () => {
+    await expect(store.deleteWhere({})).rejects.toThrow(/at least one filter/);
+  });
+});
+
+describe('getStats', () => {
+  it('counts by kind, sums bytes and counts distinct projects', async () => {
+    await store.saveMany([
+      { projectId: 'p1', kind: 'html', title: 'A', source: 'ab' },
+      { projectId: 'p2', kind: 'code', title: 'B', source: 'cde' },
+    ]);
+
+    await expect(store.getStats()).resolves.toMatchObject({
+      total: 2,
+      bytes: 5,
+      projects: 2,
+      byKind: { html: 1, code: 1, svg: 0, mermaid: 0, file: 0 },
+    });
+  });
+});
+
+describe('resilience', () => {
+  it('starts empty rather than throwing when index.json is corrupt', async () => {
+    const indexFile = path.join(tmpDir, 'artifacts', 'index.json');
+    fs.mkdirSync(path.dirname(indexFile), { recursive: true });
+    fs.writeFileSync(indexFile, '{ not json', 'utf8');
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(store.listArtifacts({})).resolves.toEqual({ artifacts: [], total: 0 });
+
+    console.error.mockRestore();
+  });
+
+  it('serializes concurrent writes instead of losing updates', async () => {
+    await Promise.all(
+      Array.from({ length: 8 }, (_, i) =>
+        store.saveArtifact({ projectId: 'p1', kind: 'code', title: `f${i}.js`, source: `const a = ${i};` })
+      )
+    );
+
+    expect((await store.listArtifacts({})).total).toBe(8);
+  });
+});

--- a/tests/services/artifactStore.test.js
+++ b/tests/services/artifactStore.test.js
@@ -82,6 +82,51 @@ describe('saveArtifact', () => {
   });
 });
 
+describe('published artifacts', () => {
+  it('persists the URL, description and favicon a publish carries', async () => {
+    const { artifact } = await store.saveArtifact({
+      projectId: 'p1',
+      kind: 'published',
+      lang: 'markdown',
+      title: 'audit.md',
+      source: '# Audit',
+      url: 'https://claude.ai/public/artifacts/abc',
+      description: 'Findings from the Q3 audit',
+      favicon: '🔍',
+      path: '/tmp/audit.md',
+    });
+
+    expect(artifact).toMatchObject({
+      kind: 'published',
+      url: 'https://claude.ai/public/artifacts/abc',
+      description: 'Findings from the Q3 audit',
+      favicon: '🔍',
+      path: '/tmp/audit.md',
+    });
+    // Markdown publishes keep a .md blob so the folder stays browsable.
+    expect(artifact.blob.endsWith('.md')).toBe(true);
+  });
+
+  it('omits the published-only fields entirely for other kinds', async () => {
+    const { artifact } = await store.saveArtifact({
+      projectId: 'p1', kind: 'code', lang: 'js', title: 'a.js', source: 'const a = 1;',
+    });
+
+    expect(artifact).not.toHaveProperty('url');
+    expect(artifact).not.toHaveProperty('favicon');
+    expect(artifact).not.toHaveProperty('description');
+  });
+
+  it('carries them through a batch too', async () => {
+    const { created } = await store.saveMany([
+      { projectId: 'p1', kind: 'published', lang: 'html', title: 'p.html', source: '<p>a</p>', url: 'https://claude.ai/a', favicon: '📊' },
+    ]);
+
+    expect(created[0]).toMatchObject({ url: 'https://claude.ai/a', favicon: '📊' });
+    expect(created[0].blob.endsWith('.html')).toBe(true);
+  });
+});
+
 describe('saveMany', () => {
   it('numbers versions correctly when they arrive in one batch', async () => {
     const { created } = await store.saveMany([

--- a/tests/services/previewToolbar.test.js
+++ b/tests/services/previewToolbar.test.js
@@ -1,0 +1,117 @@
+/**
+ * HTML preview toolbar behaviour.
+ *
+ * The toolbar has two independent groups: Preview/Code, which swaps what the
+ * block shows, and the three viewport widths. The Preview/Code pair moved its
+ * `.active` highlight from the start; the viewport buttons changed the frame
+ * width but never moved the highlight, so the selected width was invisible.
+ *
+ * Fixtures come from the real renderHtmlPreviewBlock so a markup change in the
+ * toolbar fails here rather than silently detaching the handler.
+ */
+
+jest.mock('../../src/renderer/i18n', () => ({ t: (key) => key }));
+
+const { renderHtmlPreviewBlock } = require('../../src/renderer/services/markdown/blocks/code');
+const { attachInteractivity } = require('../../src/renderer/services/markdown/interactivity');
+
+function mountPreview() {
+  const container = document.createElement('div');
+  container.innerHTML = renderHtmlPreviewBlock('<p>hello</p>', 'page.html');
+  document.body.appendChild(container);
+  attachInteractivity(container);
+  return container;
+}
+
+const btn = (root, action) => root.querySelector(`.chat-preview-btn[data-action="${action}"]`);
+const activeActions = (root) =>
+  [...root.querySelectorAll('.chat-preview-btn.active')].map((b) => b.dataset.action).sort();
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  // Clicking Preview initializes the iframe, which registers the document over
+  // the ct-preview:// scheme. Stubbed so the suite exercises the toolbar rather
+  // than warning about a bridge jsdom cannot have.
+  window.electron_api = { preview: { register: jest.fn().mockResolvedValue({ url: 'ct-preview://test' }) } };
+});
+
+afterEach(() => {
+  delete window.electron_api;
+});
+
+describe('viewport selector', () => {
+  it('starts on desktop, which is the width the block renders at', () => {
+    const root = mountPreview();
+
+    expect(btn(root, 'viewport-desktop').classList.contains('active')).toBe(true);
+    expect(btn(root, 'viewport-tablet').classList.contains('active')).toBe(false);
+    expect(btn(root, 'viewport-mobile').classList.contains('active')).toBe(false);
+  });
+
+  it('moves the highlight to the clicked width', () => {
+    const root = mountPreview();
+
+    btn(root, 'viewport-mobile').click();
+
+    expect(btn(root, 'viewport-mobile').classList.contains('active')).toBe(true);
+    expect(btn(root, 'viewport-desktop').classList.contains('active')).toBe(false);
+  });
+
+  it('keeps exactly one width highlighted across several switches', () => {
+    const root = mountPreview();
+
+    btn(root, 'viewport-tablet').click();
+    btn(root, 'viewport-mobile').click();
+    btn(root, 'viewport-desktop').click();
+
+    const active = [...root.querySelectorAll('.chat-preview-btn[data-action^="viewport-"].active')];
+    expect(active).toHaveLength(1);
+    expect(active[0].dataset.action).toBe('viewport-desktop');
+  });
+
+  it('still drives the frame width it always did', () => {
+    const root = mountPreview();
+    const preview = root.querySelector('.chat-preview-container');
+
+    btn(root, 'viewport-tablet').click();
+    expect(preview.classList.contains('viewport-tablet')).toBe(true);
+
+    // Desktop is the absence of a modifier, not a class of its own.
+    btn(root, 'viewport-desktop').click();
+    expect(preview.className).not.toMatch(/viewport-/);
+  });
+});
+
+describe('the two toolbar groups are independent', () => {
+  it('switching width does not disturb the Preview/Code selection', () => {
+    const root = mountPreview();
+
+    btn(root, 'code').click();
+    btn(root, 'viewport-mobile').click();
+
+    expect(activeActions(root)).toEqual(['code', 'viewport-mobile']);
+  });
+
+  it('switching to Code does not disturb the selected width', () => {
+    const root = mountPreview();
+
+    btn(root, 'viewport-tablet').click();
+    btn(root, 'code').click();
+
+    expect(activeActions(root)).toEqual(['code', 'viewport-tablet']);
+  });
+
+  it('swaps the preview and code panes as before', () => {
+    const root = mountPreview();
+    const iframeWrap = root.querySelector('.chat-preview-iframe-wrap');
+    const codeWrap = root.querySelector('.chat-preview-code-wrap');
+
+    btn(root, 'code').click();
+    expect(iframeWrap.style.display).toBe('none');
+    expect(codeWrap.style.display).toBe('');
+
+    btn(root, 'preview').click();
+    expect(iframeWrap.style.display).toBe('');
+    expect(codeWrap.style.display).toBe('none');
+  });
+});


### PR DESCRIPTION
## What this adds

Two screens for the things Claude produces, kept deliberately separate because they are different kinds of thing.

**Artifacts** (sidebar, under Claude in the Project section) is the gallery of artifacts **published to claude.ai** with the Agent SDK's `Artifact` tool — the local equivalent of the artifact list in Claude Desktop. Each one keeps the three fields only a publish has: the shareable URL, the gallery subtitle and the browser-tab emoji.

**Documents** (third tab in a chat, next to Conversation and Changes) is what the *current conversation* produced: HTML pages, SVGs, Mermaid diagrams, long code blocks, files written. Two columns — the list on the left, the preview on the right.

![Artifacts gallery](https://raw.githubusercontent.com/bleleve/claude-terminal/assets/artifacts-screenshots/.pr-assets/artifacts-gallery.png)

A republished page becomes v2 of the same artifact rather than a second card. The preview reuses the existing markdown blocks, so the HTML preview arrives with its viewport toolbar for free.

![Published Markdown](https://raw.githubusercontent.com/bleleve/claude-terminal/assets/artifacts-screenshots/.pr-assets/artifacts-markdown.png)

A published `.md` renders as a document rather than being fenced into a code block showing its own syntax.

## How it works

**Detection runs on the rendered DOM, not on the markdown source.** The renderer has already decided what each fenced block is, so scanning its output means never re-implementing that dispatch — and anything it learns to render becomes harvestable by adding one selector.

**Ids are content hashes.** Re-harvesting a replayed conversation is therefore idempotent: the Documents tab repopulates itself on session resume with no bookkeeping on either side. Same content in, same id out.

**Harvesting is deferred to idle time.** Scanning a long transcript costs real milliseconds and none of it is visible until the tab is opened, so it must not sit on the path that paints the conversation.

**Published artifacts are captured from the tool call, not inferred.** A publish is explicit, so it is read from the `Artifact` tool's input and deferred until its result arrives — that is where the URL lives, and waiting also drops failed publishes instead of listing them. History replay pairs results by `toolUseId` the same way, so a resumed session recovers its URLs.

**The store is shared with the MCP server, not duplicated.** `src/shared/artifact-store.js` runs in both processes and both take the same cross-process lock, so neither can lose the other's update. Identity helpers are split into `artifact-schema.js` because the renderer needs `computeId()` but is bundled for the browser and cannot require `fs`.

Conversation extracts are still persisted even though this gallery no longer lists them: the `artifact_*` MCP tools search them, which is what lets a later session find a page built weeks ago.

## Also fixed along the way

Two pre-existing bugs in the shared preview block, so these land in the transcript too:

- The Preview/Code toggle, viewport buttons, copy buttons and external links were inert in any container other than the transcript. `attachInteractivity()` delegates per container and `postProcess()` does not set it up, so every markdown container needs its own call.
- The viewport selector changed the frame width but never moved its `.active` highlight, so the three buttons looked identical whatever was selected.

## Surface

| | |
|---|---|
| Storage | `~/.claude-terminal/artifacts/` — `index.json` + `blobs/`, atomic writes, 2000-artifact cap, 2 MB per blob |
| IPC | 8 handlers, `artifacts` preload namespace |
| MCP | `artifact_list`, `artifact_get`, `artifact_search`, `artifact_versions`, `artifact_delete`, `artifact_stats` |
| i18n | EN, FR, ES, ID, zh-CN |
| Tests | 71 new (2325 total, 86 suites green) |

Detection fixtures are built from the **real block renderers**, so a markup change in the renderer fails the suite instead of silently breaking the harvest.

## Notes

- `action: 'list'` on the `Artifact` tool returns only title, url, updatedAt and rel — no thumbnail, no description — and the app cannot invoke a model tool directly. Mirroring the full claude.ai gallery would mean burning tokens on a throwaway SDK session for strictly less data than interception already gives, so it is not attempted.
- Screenshots were captured against a throwaway `HOME` containing only invented data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

