### PR TITLE
fix(chat): settle background tasks from the live set, not just bookends

### DIFF
--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -589,6 +589,7 @@ contextBridge.exposeInMainWorld('electron_api', {
     getContextUsage: (params) => ipcRenderer.invoke('chat-get-context-usage', params),
     stopTask: (params) => ipcRenderer.invoke('chat-stop-task', params),
     onTaskUpdate: createListener('chat-task-update'),
+    onBackgroundTasks: createListener('chat-background-tasks'),
     respondElicitation: (params) => ipcRenderer.send('chat-elicitation-response', params),
     onElicitationRequest: createListener('chat-elicitation-request'),
     reloadSkills: (params) => ipcRenderer.invoke('chat-reload-skills', params || {}),

--- a/src/main/services/ChatService.js
+++ b/src/main/services/ChatService.js
@@ -20,6 +20,28 @@ let resolvedRuntime = null;
 const FORK_REJECTED_PREFIX = 'Resume rejected by --resume-drops-turn:';
 
 /**
+ * Shape a `background_tasks_changed` payload for the renderer.
+ *
+ * Ambient entries are the CLI's own housekeeping — skip_transcript tasks and
+ * auto-started watchers — which the SDK asks hosts to keep out of activity
+ * indicators. Dropping them here rather than in the renderer means no consumer
+ * has to remember the rule.
+ *
+ * @param {Array<{task_id: string, task_type?: string, description?: string, ambient?: boolean}>} tasks
+ * @returns {Array<{taskId: string, taskType: string|null, description: string}>}
+ */
+function normalizeBackgroundTasks(tasks) {
+  if (!Array.isArray(tasks)) return [];
+  return tasks
+    .filter(task => task && task.task_id && task.ambient !== true)
+    .map(task => ({
+      taskId: task.task_id,
+      taskType: task.task_type || null,
+      description: task.description || '',
+    }));
+}
+
+/**
  * Tools whose `tool_use` block names a file the session is about to write.
  * Read-only tools are deliberately absent: the point of the record is "what did
  * this conversation change", which is what an automation needs to scope a commit.
@@ -803,6 +825,10 @@ class ChatService {
       });
 
       this._emitLifecycle('start', sessionId, { projectId, cwd });
+      // The background-task level is per CLI process and nothing is emitted at
+      // startup, so the host owns the reset. Without it, a resumed tab would
+      // keep showing tasks that belonged to the process that just went away.
+      this._send('chat-background-tasks', { sessionId, tasks: [] });
       this._processStream(sessionId, queryStream);
       return sessionId;
     } catch (err) {
@@ -1324,6 +1350,20 @@ class ChatService {
             workflowName: message.workflow_name || null,
             usage: message.usage || null,
             skipTranscript: message.skip_transcript === true,
+          });
+        }
+
+        // The level counterpart of the task_started/task_notification bookends:
+        // the full set of live background tasks, re-sent on every membership
+        // change. REPLACE semantics — the renderer swaps its set for this
+        // payload rather than pairing edges, so a bookend that never arrives
+        // (dropped frame, CLI restart) cannot wedge a task as permanently
+        // running. Ambient entries are the CLI's own housekeeping and are
+        // dropped here rather than in the renderer, since no consumer wants them.
+        if (message.type === 'system' && message.subtype === 'background_tasks_changed') {
+          this._send('chat-background-tasks', {
+            sessionId,
+            tasks: normalizeBackgroundTasks(message.tasks),
           });
         }
         this._send('chat-message', { sessionId, message });
@@ -2811,3 +2851,4 @@ function _deleteWorkflowSession(cwd, sessionId) {
 }
 
 module.exports = new ChatService();
+module.exports.normalizeBackgroundTasks = normalizeBackgroundTasks;

--- a/src/renderer/services/BackgroundTaskReconciler.js
+++ b/src/renderer/services/BackgroundTaskReconciler.js
@@ -1,0 +1,89 @@
+/**
+ * BackgroundTaskReconciler
+ *
+ * Decides when a background-task card whose end was never announced should be
+ * settled anyway.
+ *
+ * The CLI describes background tasks through two feeds. `task_started` /
+ * `task_notification` are edge bookends and are the only source that knows *how*
+ * a task ended. `background_tasks_changed` carries the full live set on every
+ * membership change and is authoritative about *whether* one is still running.
+ * The SDK is explicit that consumers must key "is it running" off the set, so a
+ * bookend that never arrives — a dropped frame, a CLI restart — cannot wedge a
+ * spinner forever.
+ *
+ * Ordering between the two feeds is unspecified, and in practice the set drops a
+ * task slightly *before* its bookend lands. Settling the moment a task leaves
+ * the set would therefore flash a generic outcome over the real one on every
+ * normal completion. Hence the grace window: only a task still running after it
+ * is treated as one whose bookend is never coming.
+ *
+ * Pure with respect to the DOM — it owns ids and timers, the caller owns cards.
+ */
+
+'use strict';
+
+const DEFAULT_GRACE_MS = 2000;
+
+class BackgroundTaskReconciler {
+  /**
+   * @param {object} opts
+   * @param {(taskId: string) => void} opts.onSettle Called when a task has been
+   *   absent from the live set for the whole grace window.
+   * @param {number} [opts.graceMs]
+   * @param {(fn: Function, ms: number) => any} [opts.setTimer] Injectable for tests.
+   * @param {(handle: any) => void} [opts.clearTimer]
+   */
+  constructor({ onSettle, graceMs = DEFAULT_GRACE_MS, setTimer, clearTimer } = {}) {
+    this._onSettle = typeof onSettle === 'function' ? onSettle : () => {};
+    this._graceMs = graceMs;
+    this._setTimer = setTimer || ((fn, ms) => setTimeout(fn, ms));
+    this._clearTimer = clearTimer || ((h) => clearTimeout(h));
+    /** @type {Map<string, any>} taskId -> pending timer handle */
+    this._pending = new Map();
+  }
+
+  /**
+   * Reconcile the live set against the tasks the caller still shows as running.
+   *
+   * @param {Iterable<string>} liveIds Task ids in the latest `background_tasks_changed`.
+   * @param {Iterable<string>} runningIds Task ids the caller currently renders as running.
+   */
+  sync(liveIds, runningIds) {
+    const live = liveIds instanceof Set ? liveIds : new Set(liveIds || []);
+    for (const taskId of runningIds || []) {
+      if (!taskId) continue;
+      if (live.has(taskId)) {
+        // Back in the set: the earlier absence was transient, so the task is
+        // still running and any pending settle must be called off.
+        this.cancel(taskId);
+        continue;
+      }
+      if (this._pending.has(taskId)) continue;
+      this._pending.set(taskId, this._setTimer(() => {
+        this._pending.delete(taskId);
+        this._onSettle(taskId);
+      }, this._graceMs));
+    }
+  }
+
+  /** The bookend won the race — drop any backstop for this task. */
+  cancel(taskId) {
+    const handle = this._pending.get(taskId);
+    if (handle === undefined) return;
+    this._clearTimer(handle);
+    this._pending.delete(taskId);
+  }
+
+  /** @returns {boolean} whether a settle is currently scheduled for `taskId`. */
+  isPending(taskId) {
+    return this._pending.has(taskId);
+  }
+
+  dispose() {
+    for (const handle of this._pending.values()) this._clearTimer(handle);
+    this._pending.clear();
+  }
+}
+
+module.exports = { BackgroundTaskReconciler, DEFAULT_GRACE_MS };

--- a/src/renderer/ui/components/ChatView.js
+++ b/src/renderer/ui/components/ChatView.js
@@ -6,6 +6,7 @@
 
 const { BaseComponent } = require('../../core/BaseComponent');
 const { escapeHtml, highlight } = require('../../utils');
+const { BackgroundTaskReconciler } = require('../../services/BackgroundTaskReconciler');
 const { sanitizeColor } = require('../../utils/color');
 const {
   getToolIcon,
@@ -6557,50 +6558,95 @@ class ChatView extends BaseComponent {
   unsubscribers.push(unsubElicit);
 
   // ── Background task lifecycle (live task list with stop button) ──
+  //
+  // Two feeds describe the same tasks. `chat-task-update` carries the
+  // start/end bookends and is the only one that knows *how* a task ended.
+  // `chat-background-tasks` carries the full live set on every membership
+  // change and is authoritative about *whether* one is still running. A card is
+  // normally settled by its bookend; the set is the backstop for a bookend that
+  // never arrives, which would otherwise leave a spinner turning forever.
+
+  function findTaskCard(taskId) {
+    try {
+      return messagesEl.querySelector(`.chat-task-card[data-task-id="${CSS.escape(taskId)}"]`);
+    } catch (_) {
+      return Array.from(messagesEl.querySelectorAll('.chat-task-card'))
+        .find(c => c.dataset.taskId === taskId) || null;
+    }
+  }
+
+  // Owns the "the set says it's gone but no bookend said how" backstop.
+  const taskReconciler = new BackgroundTaskReconciler({
+    onSettle: (taskId) => {
+      const stale = findTaskCard(taskId);
+      if (stale && stale.classList.contains('running')) settleTaskCard(stale, 'ended');
+    },
+  });
+
+  /**
+   * @param {HTMLElement} card
+   * @param {'completed'|'failed'|'stopped'|'ended'} status `ended` is the
+   *   backstop outcome: the task is gone from the live set, but no bookend said
+   *   how it finished, so the card must not claim success.
+   */
+  function settleTaskCard(card, status) {
+    card.classList.remove('running', 'stopping');
+    card.classList.add('done', status);
+    const stopBtn = card.querySelector('.chat-task-stop');
+    if (stopBtn) stopBtn.remove();
+    const spinner = card.querySelector('.chat-task-spinner');
+    if (spinner) {
+      const glyph = status === 'completed' ? '✓'
+        : status === 'stopped' ? '■'
+        : status === 'ended' ? '·'
+        : '✕';
+      spinner.outerHTML = `<span class="chat-task-status-icon ${status}">${glyph}</span>`;
+    }
+  }
+
   const unsubTask = api.chat.onTaskUpdate((data) => {
     if (data.sessionId !== sessionId) return;
     if (data.skipTranscript) return; // ambient/housekeeping tasks stay hidden
     const taskId = data.taskId;
     if (!taskId) return;
-    let card;
-    try {
-      card = messagesEl.querySelector(`.chat-task-card[data-task-id="${CSS.escape(taskId)}"]`);
-    } catch (_) {
-      card = Array.from(messagesEl.querySelectorAll('.chat-task-card')).find(c => c.dataset.taskId === taskId);
-    }
+    const card = findTaskCard(taskId);
 
     if (data.phase === 'started') {
       if (card) return;
-      card = document.createElement('div');
-      card.className = 'chat-task-card running';
-      card.dataset.taskId = taskId;
+      const el = document.createElement('div');
+      el.className = 'chat-task-card running';
+      el.dataset.taskId = taskId;
       const label = escapeHtml(data.description || data.subagentType || data.workflowName || t('chat.backgroundTask') || 'Background task');
-      card.innerHTML = `
+      el.innerHTML = `
         <div class="chat-task-spinner"></div>
         <span class="chat-task-label">${label}</span>
         <button class="chat-task-stop" title="${escapeHtml(t('chat.stopTask') || 'Stop task')}">
           <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="6" width="12" height="12" rx="1"/></svg>
         </button>`;
-      card.querySelector('.chat-task-stop')?.addEventListener('click', () => {
+      el.querySelector('.chat-task-stop')?.addEventListener('click', () => {
         try { api.chat.stopTask({ sessionId, taskId }); } catch (_) {}
-        card.classList.add('stopping');
+        el.classList.add('stopping');
       });
-      messagesEl.appendChild(card);
-      requestAnimationFrame(() => card.scrollIntoView({ behavior: 'smooth', block: 'end' }));
+      messagesEl.appendChild(el);
+      requestAnimationFrame(() => el.scrollIntoView({ behavior: 'smooth', block: 'end' }));
     } else if (data.phase === 'ended' && card) {
-      const status = data.status || 'completed';
-      card.classList.remove('running', 'stopping');
-      card.classList.add('done', status);
-      const stopBtn = card.querySelector('.chat-task-stop');
-      if (stopBtn) stopBtn.remove();
-      const spinner = card.querySelector('.chat-task-spinner');
-      if (spinner) {
-        const ok = status === 'completed';
-        spinner.outerHTML = `<span class="chat-task-status-icon ${status}">${ok ? '✓' : (status === 'stopped' ? '■' : '✕')}</span>`;
-      }
+      // The bookend won the race — cancel the backstop and use its real status.
+      taskReconciler.cancel(taskId);
+      settleTaskCard(card, data.status || 'completed');
     }
   });
   unsubscribers.push(unsubTask);
+
+  const unsubBgTasks = api.chat.onBackgroundTasks((data) => {
+    if (data.sessionId !== sessionId) return;
+    const live = (data.tasks || []).map(task => task.taskId).filter(Boolean);
+    const running = Array.from(messagesEl.querySelectorAll('.chat-task-card.running'))
+      .map(card => card.dataset.taskId)
+      .filter(Boolean);
+    taskReconciler.sync(live, running);
+  });
+  unsubscribers.push(unsubBgTasks);
+  unsubscribers.push(() => taskReconciler.dispose());
 
   // If resuming, load and display conversation history
   if (pendingResumeId) {

--- a/styles/chat.css
+++ b/styles/chat.css
@@ -4695,6 +4695,9 @@ input.chat-elicit-input[type="checkbox"] {
 .chat-task-card.failed { border-left: 3px solid var(--danger); }
 .chat-task-card.stopped { border-left: 3px solid var(--warning); }
 .chat-task-card.completed { border-left: 3px solid var(--success); }
+/* Settled by the live-task set rather than a bookend: the task is over, but
+   nothing told us how, so it must not read as success or failure. */
+.chat-task-card.ended { border-left: 3px solid var(--text-muted); }
 .chat-task-label {
   flex: 1;
   color: var(--text-primary);
@@ -4720,6 +4723,7 @@ input.chat-elicit-input[type="checkbox"] {
 .chat-task-status-icon.completed { color: var(--success); }
 .chat-task-status-icon.failed { color: var(--danger); }
 .chat-task-status-icon.stopped { color: var(--warning); }
+.chat-task-status-icon.ended { color: var(--text-muted); }
 .chat-task-stop {
   display: flex;
   align-items: center;

--- a/tests/services/BackgroundTaskReconciler.test.js
+++ b/tests/services/BackgroundTaskReconciler.test.js
@@ -1,0 +1,156 @@
+// BackgroundTaskReconciler — the backstop that keeps a background-task card
+// from spinning forever when its end bookend never arrives.
+//
+// The subtlety under test is the race: the live-task set normally drops a task
+// slightly *before* its bookend lands, so settling on absence alone would
+// mislabel every normal completion. Timers are injected so the grace window is
+// exercised deterministically rather than by waiting.
+
+const { BackgroundTaskReconciler, DEFAULT_GRACE_MS } = require('../../src/renderer/services/BackgroundTaskReconciler');
+
+/** Minimal controllable clock: run() fires everything scheduled so far. */
+function makeClock() {
+  let nextId = 1;
+  const scheduled = new Map();
+  return {
+    setTimer: (fn, ms) => { const id = nextId++; scheduled.set(id, { fn, ms }); return id; },
+    clearTimer: (id) => { scheduled.delete(id); },
+    run: () => {
+      const due = [...scheduled.values()];
+      scheduled.clear();
+      for (const { fn } of due) fn();
+    },
+    pendingCount: () => scheduled.size,
+    lastDelay: () => [...scheduled.values()].pop()?.ms,
+  };
+}
+
+function makeReconciler(overrides = {}) {
+  const clock = makeClock();
+  const settled = [];
+  const reconciler = new BackgroundTaskReconciler({
+    onSettle: (id) => settled.push(id),
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+    ...overrides,
+  });
+  return { reconciler, clock, settled };
+}
+
+describe('sync', () => {
+  test('settles a running task that vanished from the live set', () => {
+    const { reconciler, clock, settled } = makeReconciler();
+
+    reconciler.sync([], ['task-1']);
+    expect(settled).toEqual([]); // not before the grace window
+
+    clock.run();
+    expect(settled).toEqual(['task-1']);
+  });
+
+  test('leaves a task alone while it is still in the live set', () => {
+    const { reconciler, clock, settled } = makeReconciler();
+
+    reconciler.sync(['task-1'], ['task-1']);
+    clock.run();
+
+    expect(settled).toEqual([]);
+  });
+
+  test('does not stack timers when the same absence repeats', () => {
+    const { reconciler, clock } = makeReconciler();
+
+    reconciler.sync([], ['task-1']);
+    reconciler.sync([], ['task-1']);
+    reconciler.sync([], ['task-1']);
+
+    // Membership changes are frequent; one backstop per task, not one per event.
+    expect(clock.pendingCount()).toBe(1);
+  });
+
+  test('cancels the backstop when a task returns to the live set', () => {
+    const { reconciler, clock, settled } = makeReconciler();
+
+    reconciler.sync([], ['task-1']);
+    expect(reconciler.isPending('task-1')).toBe(true);
+
+    reconciler.sync(['task-1'], ['task-1']);
+    expect(reconciler.isPending('task-1')).toBe(false);
+
+    clock.run();
+    expect(settled).toEqual([]);
+  });
+
+  test('handles several tasks independently', () => {
+    const { reconciler, clock, settled } = makeReconciler();
+
+    reconciler.sync(['task-2'], ['task-1', 'task-2', 'task-3']);
+    clock.run();
+
+    expect(settled.sort()).toEqual(['task-1', 'task-3']);
+  });
+
+  test('ignores empty ids rather than scheduling for them', () => {
+    const { reconciler, clock } = makeReconciler();
+
+    reconciler.sync([], ['', null, undefined]);
+
+    expect(clock.pendingCount()).toBe(0);
+  });
+
+  test('accepts a Set as the live collection', () => {
+    const { reconciler, clock, settled } = makeReconciler();
+
+    reconciler.sync(new Set(['task-1']), ['task-1']);
+    clock.run();
+
+    expect(settled).toEqual([]);
+  });
+
+  test('tolerates missing collections', () => {
+    const { reconciler, clock } = makeReconciler();
+
+    expect(() => reconciler.sync(null, null)).not.toThrow();
+    expect(clock.pendingCount()).toBe(0);
+  });
+
+  test('uses the default grace window unless told otherwise', () => {
+    const { reconciler, clock } = makeReconciler();
+    reconciler.sync([], ['task-1']);
+    expect(clock.lastDelay()).toBe(DEFAULT_GRACE_MS);
+  });
+});
+
+describe('cancel', () => {
+  test('a bookend arriving inside the window wins the race', () => {
+    const { reconciler, clock, settled } = makeReconciler();
+
+    // The set drops the task first — the normal ordering.
+    reconciler.sync([], ['task-1']);
+    // Then its bookend lands and the caller settles it for real.
+    reconciler.cancel('task-1');
+    clock.run();
+
+    // The backstop must not fire, or it would overwrite the real outcome.
+    expect(settled).toEqual([]);
+  });
+
+  test('is a no-op for an unknown task', () => {
+    const { reconciler } = makeReconciler();
+    expect(() => reconciler.cancel('never-seen')).not.toThrow();
+  });
+});
+
+describe('dispose', () => {
+  test('drops every pending backstop', () => {
+    const { reconciler, clock, settled } = makeReconciler();
+
+    reconciler.sync([], ['task-1', 'task-2']);
+    reconciler.dispose();
+    clock.run();
+
+    // A closed tab must not settle cards that no longer exist.
+    expect(settled).toEqual([]);
+    expect(clock.pendingCount()).toBe(0);
+  });
+});

--- a/tests/services/ChatService.test.js
+++ b/tests/services/ChatService.test.js
@@ -401,3 +401,47 @@ describe('ChatService._isCliFailureText', () => {
     expect(chatService._isCliFailureText(undefined)).toBe(false);
   });
 });
+
+// ── normalizeBackgroundTasks ──
+// Shapes the `background_tasks_changed` level payload for the renderer.
+describe('normalizeBackgroundTasks', () => {
+  const { normalizeBackgroundTasks } = require('../../src/main/services/ChatService');
+
+  test('maps the SDK payload to the renderer shape', () => {
+    expect(normalizeBackgroundTasks([
+      { task_id: 't1', task_type: 'subagent', description: 'Review the auth module' },
+    ])).toEqual([
+      { taskId: 't1', taskType: 'subagent', description: 'Review the auth module' },
+    ]);
+  });
+
+  test('drops ambient housekeeping tasks', () => {
+    // The SDK asks hosts to keep these out of activity indicators; filtering
+    // here means no consumer has to remember the rule.
+    const out = normalizeBackgroundTasks([
+      { task_id: 't1', task_type: 'shell', description: 'npm test' },
+      { task_id: 't2', task_type: 'monitor', description: 'watcher', ambient: true },
+    ]);
+    expect(out.map(t => t.taskId)).toEqual(['t1']);
+  });
+
+  test('drops entries without a task id', () => {
+    // An id-less entry could never be reconciled against a card.
+    expect(normalizeBackgroundTasks([{ task_type: 'shell' }, null])).toEqual([]);
+  });
+
+  test('defaults the optional fields', () => {
+    expect(normalizeBackgroundTasks([{ task_id: 't1' }])).toEqual([
+      { taskId: 't1', taskType: null, description: '' },
+    ]);
+  });
+
+  test('returns an empty list for a malformed payload', () => {
+    // An empty set is meaningful here — it means "nothing is running" — so it
+    // must never be confused with "no information".
+    expect(normalizeBackgroundTasks(undefined)).toEqual([]);
+    expect(normalizeBackgroundTasks(null)).toEqual([]);
+    expect(normalizeBackgroundTasks('nope')).toEqual([]);
+
+  });
+});


### PR DESCRIPTION
Fixes #118

## The bug

A background-task card could keep spinning for the rest of the session, its stop button pointing at a task that had already finished.

The CLI describes background tasks through two feeds, and the app consumed only one:

| Feed | Knows | Consumed before |
|---|---|---|
| `task_started` / `task_notification` | *how* a task ended | yes |
| `background_tasks_changed` | *whether* one is still running | **no** |

The SDK says why that is not enough:

> consumers that only need 'is background work running' should replace their set with each payload rather than pairing edges, **so a missed bookend cannot wedge a stale running indicator**

`ChatView` only settled a card in its `phase === 'ended'` branch, so a lost bookend — dropped frame, CLI restart mid-task — wedged it permanently.

## The fix

`background_tasks_changed` is forwarded as `chat-background-tasks` and drives a backstop for cards whose bookend never arrives.

**The race matters here.** Ordering between the two feeds is unspecified, and in practice the set drops a task *just before* its bookend lands. Settling on absence alone would therefore flash a generic outcome over the real one on **every normal completion**, which would be a worse bug than the one being fixed. A short grace window resolves it: the bookend wins when it arrives, the backstop fires only when it does not.

A backstop-settled card reads **`ended`**, not `completed` — nothing told us how the task finished, so it must not claim success. It gets its own neutral styling rather than borrowing the success or failure colour.

Two related gaps closed at the same time:

- **Reset on CLI (re)start.** The level is per-process and nothing is emitted at startup, so the SDK requires the host to reset. `startSession` now pushes an empty set explicitly; without it a resumed tab kept showing tasks from the process that just went away.
- **Ambient filtering.** `skip_transcript` tasks and auto-started watchers carry `ambient: true` and the SDK asks hosts to exclude them from activity indicators. Filtered in the main process, so no consumer has to remember the rule.

## Structure

The reconciliation lives in `src/renderer/services/BackgroundTaskReconciler.js` rather than inline in `ChatView`, following the existing `transcriptPruner` / `idleAnimationPauser` pattern. It owns ids and timers, the caller owns cards, and timers are injectable — so the race this exists to handle is covered by deterministic tests instead of by waiting on real clocks.

## Verification

- 84 suites / 2271 tests green (17 new: grace window, bookend-wins-the-race, task returning to the set, no timer stacking, dispose, ambient filtering, malformed payloads).
- Renderer build clean.

The empty-set case is deliberately tested as meaningful: "nothing is running" must never be confused with "no information", or the reset would settle nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
