### PR TITLE
feat(accounts): bind a Claude account to a project

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -6357,20 +6357,35 @@ const usageElements = {
 let usageAccountId = null;
 
 /**
- * The account the tab on screen actually runs as.
+ * The project whose tab is on screen.
+ * @returns {Object|null}
+ */
+function currentUsageProject() {
+  try {
+    const { projectsState } = require('./src/renderer/state');
+    const state = projectsState.get();
+    return state.projects[state.selectedProjectFilter] || null;
+  } catch (_) {
+    return null;
+  }
+}
+
+/**
+ * Which account the figures should be fetched for.
+ *
+ * `null` means the machine-wide store, which is what an unbound project's CLI
+ * reads — so the fetch follows the binding, not the label. The label still
+ * names the account that owns that store (see the resolver in accounts.state),
+ * because "whose numbers are these" always has an answer.
+ *
  * @returns {string|null}
  */
 function currentUsageAccountId() {
   try {
-    const { projectsState, getAccountForProject } = require('./src/renderer/state');
-    const state = projectsState.get();
-    const project = state.projects[state.selectedProjectFilter];
-    if (!project) return null;
-    // Only a binding counts: an unbound project runs on the machine-wide
-    // login, whichever account the default currently points at.
     const { getProjectAccount } = require('./src/renderer/state');
-    if (!getProjectAccount(project.id)) return null;
-    return getAccountForProject(project.id)?.id || null;
+    const project = currentUsageProject();
+    if (!project) return null;
+    return getProjectAccount(project.id) || null;
   } catch (_) {
     return null;
   }
@@ -6378,8 +6393,10 @@ function currentUsageAccountId() {
 
 /**
  * Name the account next to the bars, in its own colour, so the numbers are
- * attributable at a glance. Hidden when nothing is bound — the titlebar then
- * means what it always did.
+ * always attributable — bound or not. A project running on the default is
+ * marked as such rather than left blank: the tab is tinted either way, and a
+ * silent titlebar next to a coloured tab is the inconsistency, not the
+ * information.
  */
 function renderUsageAccountLabel() {
   const { container } = usageElements;
@@ -6387,24 +6404,40 @@ function renderUsageAccountLabel() {
 
   let el = usageElements.account;
   if (!el) {
-    el = document.createElement('span');
+    el = document.createElement('button');
     el.className = 'usage-account';
+    el.type = 'button';
+    // Clicking the bars refreshes; clicking the account opens its picker.
+    el.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const project = currentUsageProject();
+      if (!project) return;
+      const rect = el.getBoundingClientRect();
+      try {
+        const { showProjectAccountMenu } = require('./src/renderer/ui/components/AccountMenu');
+        showProjectAccountMenu({ projectId: project.id, x: rect.left, y: rect.bottom + 4 });
+      } catch (_) {
+        // Menu unavailable; the tab's context menu still offers the same choice.
+      }
+    });
     container.insertBefore(el, container.firstChild);
     usageElements.account = el;
   }
 
-  if (!usageAccountId) {
-    el.style.display = 'none';
-    return;
-  }
-
   try {
-    const { getAccount } = require('./src/renderer/state');
+    const { getUsageAccountForProject } = require('./src/renderer/state');
     const { sanitizeColor } = require('./src/renderer/utils');
-    const account = getAccount(usageAccountId);
+    const project = currentUsageProject();
+    const { account, isDefault } = getUsageAccountForProject(project?.id || null);
     if (!account) { el.style.display = 'none'; return; }
+
     el.style.display = '';
     el.textContent = account.name;
+    el.classList.toggle('usage-account--default', isDefault);
+    el.disabled = !project;
+    el.title = isDefault
+      ? t('accounts.usageDefaultTitle', { name: account.name })
+      : t('accounts.usageBoundTitle', { name: account.name });
     const color = sanitizeColor(account.color);
     el.style.setProperty('--account-color', color || 'var(--text-secondary)');
   } catch (_) {
@@ -6695,10 +6728,12 @@ if (usageElements.container) {
   // Bindings and colours can change under us too, hence both subscriptions.
   const syncUsageAccount = () => {
     const next = currentUsageAccountId();
+    // The label tracks more than the fetched account — a project can move
+    // between two accounts that both resolve to the machine store — so it is
+    // redrawn on every notification, not only when the fetch target changes.
     renderUsageAccountLabel();
     if (next === usageAccountId) return;
     usageAccountId = next;
-    renderUsageAccountLabel();
     // Blank the bars rather than leave the previous account's figures up while
     // the new ones are in flight.
     renderUsageBuckets(PLACEHOLDER_USAGE_BUCKETS);

--- a/renderer.js
+++ b/renderer.js
@@ -6348,6 +6348,70 @@ const usageElements = {
   }
 };
 
+// ── Which account the titlebar is reporting on ──
+//
+// Figures belong to an account, and projects pick their own. So the bars follow
+// the active project tab: showing the default account's numbers while the tab
+// in front runs on another one would be a confident lie. `null` is the
+// machine-wide login, which unbound projects run as.
+let usageAccountId = null;
+
+/**
+ * The account the tab on screen actually runs as.
+ * @returns {string|null}
+ */
+function currentUsageAccountId() {
+  try {
+    const { projectsState, getAccountForProject } = require('./src/renderer/state');
+    const state = projectsState.get();
+    const project = state.projects[state.selectedProjectFilter];
+    if (!project) return null;
+    // Only a binding counts: an unbound project runs on the machine-wide
+    // login, whichever account the default currently points at.
+    const { getProjectAccount } = require('./src/renderer/state');
+    if (!getProjectAccount(project.id)) return null;
+    return getAccountForProject(project.id)?.id || null;
+  } catch (_) {
+    return null;
+  }
+}
+
+/**
+ * Name the account next to the bars, in its own colour, so the numbers are
+ * attributable at a glance. Hidden when nothing is bound — the titlebar then
+ * means what it always did.
+ */
+function renderUsageAccountLabel() {
+  const { container } = usageElements;
+  if (!container) return;
+
+  let el = usageElements.account;
+  if (!el) {
+    el = document.createElement('span');
+    el.className = 'usage-account';
+    container.insertBefore(el, container.firstChild);
+    usageElements.account = el;
+  }
+
+  if (!usageAccountId) {
+    el.style.display = 'none';
+    return;
+  }
+
+  try {
+    const { getAccount } = require('./src/renderer/state');
+    const { sanitizeColor } = require('./src/renderer/utils');
+    const account = getAccount(usageAccountId);
+    if (!account) { el.style.display = 'none'; return; }
+    el.style.display = '';
+    el.textContent = account.name;
+    const color = sanitizeColor(account.color);
+    el.style.setProperty('--account-color', color || 'var(--text-secondary)');
+  } catch (_) {
+    el.style.display = 'none';
+  }
+}
+
 /**
  * Build the nodes for one usage bucket.
  *
@@ -6563,7 +6627,11 @@ async function refreshUsageDisplay() {
   usageElements.container.classList.add('loading');
 
   try {
-    const result = await api.usage.refresh();
+    const requested = usageAccountId;
+    const result = await api.usage.refresh(requested);
+    // Tabs can be switched mid-flight; a late answer for the account we left
+    // must not repaint the bars.
+    if (requested !== usageAccountId) return;
     // A failed fetch that still has cached data is rendered rather than blanked
     // (stale numbers beat empty bars), but the container is flagged so the UI
     // can say so instead of passing them off as current.
@@ -6603,17 +6671,19 @@ if (usageElements.container) {
   // Listen for push updates from main process (no polling needed)
   if (api.usage.onDataUpdated) {
     api.usage.onDataUpdated((usagePayload) => {
-      if (usagePayload && usagePayload.data) {
-        updateUsageDisplay(usagePayload);
-      }
+      if (!usagePayload || !usagePayload.data) return;
+      // A background refresh for another account must not land in the bars.
+      if ((usagePayload.accountId || null) !== usageAccountId) return;
+      updateUsageDisplay(usagePayload);
     });
   }
 
   // Fallback poll every 30s (in case push event is missed)
   setInterval(async () => {
     try {
-      const data = await api.usage.getData();
-      if (data && data.data) {
+      const requested = usageAccountId;
+      const data = await api.usage.getData(requested);
+      if (data && data.data && requested === usageAccountId) {
         updateUsageDisplay(data);
       }
     } catch (e) {
@@ -6621,8 +6691,32 @@ if (usageElements.container) {
     }
   }, 30000);
 
+  // Follow the active project tab: its account owns the numbers on screen.
+  // Bindings and colours can change under us too, hence both subscriptions.
+  const syncUsageAccount = () => {
+    const next = currentUsageAccountId();
+    renderUsageAccountLabel();
+    if (next === usageAccountId) return;
+    usageAccountId = next;
+    renderUsageAccountLabel();
+    // Blank the bars rather than leave the previous account's figures up while
+    // the new ones are in flight.
+    renderUsageBuckets(PLACEHOLDER_USAGE_BUCKETS);
+    api.usage.setFocus(next).catch(() => {});
+    refreshUsageDisplay();
+  };
+
+  try {
+    const { projectsState, accountsState } = require('./src/renderer/state');
+    projectsState.subscribe(syncUsageAccount);
+    accountsState.subscribe(syncUsageAccount);
+  } catch (_) {
+    // State not ready yet; the initial fetch below still runs.
+  }
+
   // Initial fetch (after 2s to let main process start)
   setTimeout(() => {
+    syncUsageAccount();
     refreshUsageDisplay();
   }, 2000);
 }

--- a/renderer.js
+++ b/renderer.js
@@ -4544,6 +4544,81 @@ async function renderDashboardContent(projectIndex) {
 }
 
 // ========== NEW PROJECT ==========
+/**
+ * Account field for the new-project wizard.
+ *
+ * Offered here because creation is when the intent is known — "this one is
+ * work" — rather than leaving it to be remembered afterwards. "Default" is
+ * pre-selected: choosing an account is an override, not a required step.
+ * Omitted when there is only one account, since there is nothing to choose.
+ *
+ * @returns {string} HTML, or '' when the field has no purpose
+ */
+function buildWizardAccountField() {
+  try {
+    const { getAccounts, getDefaultAccount } = require('./src/renderer/state');
+    const { escapeHtml } = require('./src/renderer/utils');
+    const accounts = getAccounts();
+    if (accounts.length < 2) return '';
+    const fallback = getDefaultAccount();
+    const defaultLabel = fallback
+      ? t('accounts.useDefaultNamed', { name: fallback.name })
+      : (t('accounts.useDefault') || 'Default account');
+    // A native <select> cannot show a colour dot: macOS draws the popup
+    // itself and ignores option styling. Hence a button plus a panel, with
+    // the value parked in a hidden input so the create step reads it the same
+    // way it would read a select.
+    const { sanitizeColor } = require('./src/renderer/utils');
+    const dot = (c) => {
+      const safe = sanitizeColor(c);
+      return `<span class="wizard-account-dot"${safe ? ` style="background:${safe}"` : ''}></span>`;
+    };
+    const options = [{ id: '', label: defaultLabel, color: fallback?.color }]
+      .concat(accounts.map(a => ({ id: a.id, label: a.name, color: a.color })));
+    return `
+      <div class="wizard-field wizard-account-field">
+        <label class="wizard-label">${escapeHtml(t('accounts.chooseForProjectTitle') || 'Claude account')}</label>
+        <input type="hidden" id="wizard-account" value="">
+        <button type="button" class="wizard-input wizard-account-btn" id="wizard-account-btn">
+          ${dot(fallback?.color)}
+          <span class="wizard-account-label">${escapeHtml(defaultLabel)}</span>
+        </button>
+        <div class="wizard-account-panel" id="wizard-account-panel" hidden>
+          ${options.map(o => `
+            <button type="button" class="wizard-account-option" data-id="${escapeHtml(o.id)}">
+              ${dot(o.color)}
+              <span>${escapeHtml(o.label)}</span>
+            </button>`).join('')}
+        </div>
+      </div>`;
+  } catch (_) {
+    return '';
+  }
+}
+
+// Delegated: the wizard is rebuilt on every open, so binding per-instance
+// handlers would mean re-binding them each time.
+document.addEventListener('click', (e) => {
+  const panel = document.getElementById('wizard-account-panel');
+  if (!panel) return;
+
+  if (e.target.closest('#wizard-account-btn')) {
+    panel.hidden = !panel.hidden;
+    return;
+  }
+
+  const option = e.target.closest('.wizard-account-option');
+  if (option) {
+    const btn = document.getElementById('wizard-account-btn');
+    document.getElementById('wizard-account').value = option.dataset.id || '';
+    btn.innerHTML = option.innerHTML;
+    panel.hidden = true;
+    return;
+  }
+
+  if (!e.target.closest('.wizard-account-field')) panel.hidden = true;
+});
+
 document.getElementById('btn-new-project').onclick = () => {
   const projectTypes = registry.getAll();
   const categoriesGrouped = registry.getByCategory();
@@ -4639,6 +4714,8 @@ document.getElementById('btn-new-project').onclick = () => {
           </div>
           <div class="type-specific-fields">${projectTypes.map(tp => tp.getWizardFields()).filter(Boolean).join('')}</div>
         </div>
+
+        ${buildWizardAccountField()}
 
         <div class="wizard-field clone-status" style="display: none;">
           <div class="clone-progress">
@@ -5092,6 +5169,11 @@ document.getElementById('btn-new-project').onclick = () => {
     // Register project — wrapped in try-catch (BUG 1)
     try {
       const project = { id: generateProjectId(), name, path: projPath, type: selectedType, folderId: null };
+      // Empty value means "follow the default", which is the absence of a
+      // binding rather than a binding to the default account — otherwise the
+      // project would stop following the default the day it changes.
+      const chosenAccount = document.getElementById('wizard-account')?.value;
+      if (chosenAccount) project.accountId = chosenAccount;
       // Merge type-specific wizard config
       const typeHandler = registry.get(selectedType);
       const typeConfig = typeHandler.getWizardConfig(document.getElementById('form-project'));
@@ -6357,17 +6439,50 @@ const usageElements = {
 let usageAccountId = null;
 
 /**
- * The project whose tab is on screen.
+ * Screens where a project is the subject, so the usage chip may re-bind it.
+ * Everywhere else the chip reports which account the figures belong to and
+ * nothing more.
+ */
+const USAGE_PROJECT_SCREENS = new Set(['claude', 'git', 'tasks', 'session-replay']);
+
+/**
+ * The project the screen is actually showing, or null when there is none.
+ *
+ * Read from the active project tab rather than `selectedProjectFilter`: that
+ * index keeps pointing at the last project opened even on the dashboard or in
+ * settings, where no project is in context. Trusting it let the account picker
+ * silently re-bind that project from a screen that never mentioned it.
+ *
  * @returns {Object|null}
  */
 function currentUsageProject() {
   try {
+    // From state, not from the active tab in the DOM: this runs from a
+    // projectsState subscription, which fires before ProjectBar has re-rendered.
+    // Reading the tab there returned the *previous* project, so with two
+    // projects on two accounts the chip showed each other's account.
     const { projectsState } = require('./src/renderer/state');
     const state = projectsState.get();
     return state.projects[state.selectedProjectFilter] || null;
   } catch (_) {
     return null;
   }
+}
+
+/**
+ * Whether the screen on show is one whose subject is a project.
+ *
+ * The project bar is shared by every screen, so `selectedProjectFilter` keeps
+ * pointing at the last project opened even on the dashboard or in a workspace.
+ * Re-binding from there hit a project the screen never mentioned — hence a
+ * separate check, consulted when the chip is clicked rather than when the
+ * label is drawn.
+ *
+ * @returns {boolean}
+ */
+function canRebindFromUsageChip() {
+  const screen = document.querySelector('.nav-tab[data-tab].active')?.dataset.tab;
+  return USAGE_PROJECT_SCREENS.has(screen);
 }
 
 /**
@@ -6407,11 +6522,18 @@ function renderUsageAccountLabel() {
     el = document.createElement('button');
     el.className = 'usage-account';
     el.type = 'button';
+    // The pill lives in an inner span while the button stretches to the strip
+    // height. Centring the pill against a stretched box is exact; relying on
+    // align-self against a container whose height comes from its own children
+    // is what left it looking high.
+    el.innerHTML = '<span class="usage-account-pill"></span>';
     // Clicking the bars refreshes; clicking the account opens its picker.
     el.addEventListener('click', (e) => {
       e.stopPropagation();
       const project = currentUsageProject();
-      if (!project) return;
+      // Checked at click time: the screen can change without any state
+      // notification, so a value captured at render would go stale.
+      if (!project || !canRebindFromUsageChip()) return;
       const rect = el.getBoundingClientRect();
       try {
         const { showProjectAccountMenu } = require('./src/renderer/ui/components/AccountMenu');
@@ -6432,9 +6554,10 @@ function renderUsageAccountLabel() {
     if (!account) { el.style.display = 'none'; return; }
 
     el.style.display = '';
-    el.textContent = account.name;
+    const pill = el.querySelector('.usage-account-pill') || el;
+    pill.textContent = account.name;
     el.classList.toggle('usage-account--default', isDefault);
-    el.disabled = !project;
+    el.disabled = !project || !canRebindFromUsageChip();
     el.title = isDefault
       ? t('accounts.usageDefaultTitle', { name: account.name })
       : t('accounts.usageBoundTitle', { name: account.name });
@@ -6748,6 +6871,13 @@ if (usageElements.container) {
   } catch (_) {
     // State not ready yet; the initial fetch below still runs.
   }
+
+  // Switching screens changes whether the chip may re-bind, and that emits no
+  // state notification — so listen for it directly, after the class has moved.
+  document.addEventListener('click', (e) => {
+    if (!e.target.closest('.nav-tab[data-tab]')) return;
+    requestAnimationFrame(syncUsageAccount);
+  }, true);
 
   // Initial fetch (after 2s to let main process start)
   setTimeout(() => {

--- a/scripts/dev-sandbox.js
+++ b/scripts/dev-sandbox.js
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * Launch the app against a throwaway HOME.
+ *
+ * Every path the app owns hangs off os.homedir() — ~/.claude-terminal for
+ * projects, settings and accounts, ~/.claude for sessions and credentials —
+ * and paths.js has no environment override. os.homedir() follows $HOME on
+ * POSIX, so pointing HOME at a scratch directory isolates all of it at once,
+ * plus Electron's own userData, which is what gives this instance its own
+ * single-instance lock instead of stealing focus from another test run.
+ *
+ *   node scripts/dev-sandbox.js [name] [-- extra electron args]
+ *
+ * NOT isolated: the macOS login Keychain, which is per-user and ignores HOME.
+ * Reading it is what lets a sandbox capture an existing account without a
+ * fresh login. Writing it is another matter — see the warning printed below.
+ */
+
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { spawn } = require('child_process');
+
+const argv = process.argv.slice(2);
+const sep = argv.indexOf('--');
+const passthrough = sep === -1 ? [] : argv.slice(sep + 1);
+const name = (sep === -1 ? argv[0] : argv.slice(0, sep)[0]) || 'default';
+
+if (!/^[a-zA-Z0-9._-]+$/.test(name)) {
+  console.error(`Invalid sandbox name: ${name}`);
+  process.exit(1);
+}
+
+const realHome = os.homedir();
+const sandboxRoot = path.join(realHome, '.claude-terminal-sandboxes');
+const sandboxHome = path.join(sandboxRoot, name);
+
+// A sandbox that resolved to the real home would quietly defeat the point.
+if (path.resolve(sandboxHome) === path.resolve(realHome)) {
+  console.error('Refusing to run: sandbox HOME resolves to the real home.');
+  process.exit(1);
+}
+
+for (const dir of [sandboxHome, path.join(sandboxHome, '.claude'), path.join(sandboxHome, '.claude-terminal')]) {
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+}
+
+const repoRoot = path.join(__dirname, '..');
+const electron = require(path.join(repoRoot, 'node_modules', 'electron'));
+
+console.log(`
+  Sandbox     ${sandboxHome}
+  Isolated    projects, settings, accounts, sessions, time tracking,
+              Electron userData (so its own single-instance lock)
+  Shared      the macOS login Keychain — per-user, ignores HOME
+
+  Capturing an account here reads your real Keychain entry, which is how a
+  fresh sandbox gets credentials without a login. But "Make default" writes
+  that same entry, so it reaches back into your real login: bind projects to
+  test, and leave the default alone.
+
+  Delete with: rm -rf ${sandboxHome}
+`);
+
+const child = spawn(electron, [repoRoot, ...passthrough], {
+  stdio: 'inherit',
+  env: {
+    ...process.env,
+    HOME: sandboxHome,
+    // Belt and braces: the CLI reads this directly rather than via homedir.
+    CLAUDE_CONFIG_DIR: path.join(sandboxHome, '.claude'),
+    // The app is launched from a shell that has one; a sandbox HOME has no
+    // rc files, so pass the resolved PATH through rather than lose it.
+    PATH: process.env.PATH,
+  },
+});
+
+child.on('exit', (code) => process.exit(code ?? 0));

--- a/src/main/ipc/accounts.ipc.js
+++ b/src/main/ipc/accounts.ipc.js
@@ -51,6 +51,23 @@ function registerAccountsHandlers() {
     return result;
   });
 
+  ipcMain.handle('accounts-set-default', async (_event, { id } = {}) => {
+    const result = await wrap(() => AccountManager.setDefault(id ?? null));
+    if (result.success) await broadcastAccounts();
+    return result;
+  });
+
+  ipcMain.handle('accounts-update', async (_event, { id, name, color } = {}) => {
+    // Only forward the keys the caller actually sent: undefined means "leave
+    // it alone", and the renderer sends one field at a time.
+    const patch = {};
+    if (name !== undefined) patch.name = name;
+    if (color !== undefined) patch.color = color;
+    const result = await wrap(() => AccountManager.updateAccount(id, patch));
+    if (result.success) await broadcastAccounts();
+    return result;
+  });
+
   ipcMain.handle('accounts-rename', async (_event, { id, name } = {}) => {
     const result = await wrap(() => AccountManager.renameAccount(id, name));
     if (result.success) await broadcastAccounts();

--- a/src/main/ipc/terminal.ipc.js
+++ b/src/main/ipc/terminal.ipc.js
@@ -4,6 +4,7 @@
  */
 
 const { ipcMain } = require('electron');
+const AccountManager = require('../services/AccountManager');
 const terminalService = require('../services/TerminalService');
 const { sendFeaturePing } = require('../services/TelemetryService');
 
@@ -12,10 +13,13 @@ const { sendFeaturePing } = require('../services/TelemetryService');
  */
 function registerTerminalHandlers() {
   // Create terminal
-  ipcMain.handle('terminal-create', (event, { cwd, runClaude, skipPermissions, resumeSessionId, projectId, projectPath }) => {
+  ipcMain.handle('terminal-create', async (event, { cwd, runClaude, skipPermissions, resumeSessionId, projectId, projectPath, accountId }) => {
     try {
       sendFeaturePing('terminal:create');
-      return terminalService.create({ cwd, runClaude, skipPermissions, resumeSessionId, projectId, projectPath });
+      // Resolved here rather than inside create(), which stays synchronous:
+      // reading an account's store can hit the Keychain.
+      const accountEnv = await AccountManager.accountEnv(accountId || null);
+      return terminalService.create({ cwd, runClaude, skipPermissions, resumeSessionId, projectId, projectPath, accountEnv });
     } catch (error) {
       console.error('[Terminal IPC] Create error:', error);
       return { success: false, error: error.message };

--- a/src/main/ipc/usage.ipc.js
+++ b/src/main/ipc/usage.ipc.js
@@ -20,8 +20,16 @@ function setMainWindow(win) {
  */
 function registerUsageHandlers() {
   // Get current cached usage data
-  ipcMain.handle('get-usage-data', () => {
-    return usageService.getUsageData();
+  // Figures are per account: the caller says which one it is showing, and
+  // omitting it means the machine-wide login that unbound projects run as.
+  ipcMain.handle('get-usage-data', (_event, accountId = null) => {
+    return usageService.getUsageData(accountId);
+  });
+
+  // The poller only refreshes the account on screen.
+  ipcMain.handle('set-usage-focus', (_event, accountId = null) => {
+    usageService.setFocusedAccount(accountId);
+    return { success: true };
   });
 
   // Force refresh usage data.
@@ -29,11 +37,11 @@ function registerUsageHandlers() {
   // resolved promise is NOT proof the numbers are current — ask the service
   // whether the fetch actually succeeded before reporting success. Otherwise an
   // expired OAuth token or a moved endpoint shows the same percentages forever.
-  ipcMain.handle('refresh-usage', async () => {
+  ipcMain.handle('refresh-usage', async (_event, accountId = null) => {
     try {
-      const data = await usageService.refreshUsage();
+      const data = await usageService.refreshUsage(accountId);
       const fetchState = typeof usageService.getFetchState === 'function'
-        ? usageService.getFetchState()
+        ? usageService.getFetchState(accountId)
         : null;
 
       if (fetchState && fetchState.stale) {
@@ -55,7 +63,7 @@ function registerUsageHandlers() {
         };
       }
 
-      return { success: true, data };
+      return { success: true, data, accountId };
     } catch (error) {
       return { success: false, error: error && error.message };
     }
@@ -74,9 +82,12 @@ function registerUsageHandlers() {
   });
 
   // Push usage updates to renderer when data arrives from periodic fetch
-  usageService.onUpdate((data) => {
+  usageService.onUpdate((data, accountId) => {
     if (mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.webContents.send('usage-data-updated', { data, lastFetch: new Date().toISOString() });
+      // The renderer drops a payload for an account it is no longer showing —
+      // a background refresh must not repaint the titlebar with another
+      // account's numbers.
+      mainWindow.webContents.send('usage-data-updated', { data, accountId, lastFetch: new Date().toISOString() });
     }
   });
 
@@ -84,8 +95,12 @@ function registerUsageHandlers() {
   // so the renderer can offer to switch accounts before a 429 occurs.
   usageService.onLimit(async (alert) => {
     if (!mainWindow || mainWindow.isDestroyed()) return;
-    let activeAccountId = null;
-    try { activeAccountId = (await require('../services/AccountManager').listAccounts()).activeId; } catch (_) {}
+    // The alert names the account it was measured for. Falling back to the
+    // default only covers the machine-wide login, whose figures it is.
+    let activeAccountId = alert.accountId || null;
+    if (!activeAccountId) {
+      try { activeAccountId = (await require('../services/AccountManager').listAccounts()).defaultId; } catch (_) {}
+    }
     if (!mainWindow || mainWindow.isDestroyed()) return;
     mainWindow.webContents.send('usage-limit-reached', { ...alert, activeAccountId });
   });

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -716,8 +716,9 @@ contextBridge.exposeInMainWorld('electron_api', {
 
   // ==================== USAGE ====================
   usage: {
-    getData: () => ipcRenderer.invoke('get-usage-data'),
-    refresh: () => ipcRenderer.invoke('refresh-usage'),
+    getData: (accountId = null) => ipcRenderer.invoke('get-usage-data', accountId),
+    refresh: (accountId = null) => ipcRenderer.invoke('refresh-usage', accountId),
+    setFocus: (accountId = null) => ipcRenderer.invoke('set-usage-focus', accountId),
     startMonitor: (intervalMs) => ipcRenderer.invoke('start-usage-monitor', intervalMs),
     stopMonitor: () => ipcRenderer.invoke('stop-usage-monitor'),
     onDataUpdated: (callback) => ipcRenderer.on('usage-data-updated', (event, data) => callback(data)),

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -571,6 +571,8 @@ contextBridge.exposeInMainWorld('electron_api', {
     list: () => ipcRenderer.invoke('accounts-list'),
     capture: (name) => ipcRenderer.invoke('accounts-capture', { name }),
     switch: (id) => ipcRenderer.invoke('accounts-switch', { id }),
+    setDefault: (id) => ipcRenderer.invoke('accounts-set-default', { id }),
+    setColor: (id, color) => ipcRenderer.invoke('accounts-update', { id, color }),
     rename: (id, name) => ipcRenderer.invoke('accounts-rename', { id, name }),
     remove: (id) => ipcRenderer.invoke('accounts-remove', { id }),
     syncActive: () => ipcRenderer.invoke('accounts-sync-active'),

--- a/src/main/services/AccountManager.js
+++ b/src/main/services/AccountManager.js
@@ -17,24 +17,60 @@ const crypto = require('crypto');
 const { dataDir } = require('../utils/paths');
 // The live store is platform-dependent (Keychain on darwin, file elsewhere);
 // claudeCredentials owns that choice so every reader agrees on it.
-const { readCredentials, writeCredentials } = require('../utils/claudeCredentials');
+const {
+  readCredentials,
+  writeCredentials,
+  readCredentialsForDir,
+  writeSeedForDir,
+  pruneSeedForDir,
+  deleteCredentialsForDir,
+} = require('../utils/claudeCredentials');
 
 const accountsDir = path.join(dataDir, 'accounts');
 const indexFile = path.join(accountsDir, 'index.json');
+const storesDir = path.join(accountsDir, 'config');
+
+/**
+ * The credential directory handed to a CLI spawned for this account, via
+ * CLAUDE_SECURESTORAGE_CONFIG_DIR. Its path is what namespaces the account's
+ * Keychain entry, so it must stay stable for the life of the account.
+ */
+function accountConfigDir(id) {
+  return path.join(storesDir, id);
+}
 
 function ensureDir() {
   // 0700: these files hold OAuth tokens in plaintext.
   if (!fs.existsSync(accountsDir)) fs.mkdirSync(accountsDir, { recursive: true, mode: 0o700 });
 }
 
+function emptyIndex() {
+  return { accounts: [], defaultId: null, liveId: null };
+}
+
+/**
+ * Read the index, migrating the pre-binding shape on the way.
+ *
+ * `activeId` used to mean "the account currently swapped into the machine-wide
+ * store". Accounts are now picked per project, so the surviving notion is
+ * `defaultId`: the account used by projects with no binding of their own.
+ */
 function readIndex() {
   ensureDir();
-  if (!fs.existsSync(indexFile)) return { accounts: [], activeId: null };
+  if (!fs.existsSync(indexFile)) return emptyIndex();
+  let index;
   try {
-    return JSON.parse(fs.readFileSync(indexFile, 'utf-8'));
+    index = JSON.parse(fs.readFileSync(indexFile, 'utf-8'));
   } catch {
-    return { accounts: [], activeId: null };
+    return emptyIndex();
   }
+  // The old activeId carried both meanings at once: the fallback for new work
+  // and the owner of the machine-wide store. They split here.
+  if (index.defaultId === undefined) index.defaultId = index.activeId ?? null;
+  if (index.liveId === undefined) index.liveId = index.activeId ?? null;
+  delete index.activeId;
+  if (!Array.isArray(index.accounts)) index.accounts = [];
+  return index;
 }
 
 function writeIndex(index) {
@@ -135,6 +171,7 @@ function summarize(account) {
   return {
     id: account.id,
     name: account.name,
+    color: account.color || null,
     fingerprint: account.fingerprint,
     createdAt: account.createdAt,
     lastUsedAt: account.lastUsedAt || null
@@ -142,23 +179,76 @@ function summarize(account) {
 }
 
 /**
- * List all stored accounts with the currently active one flagged.
+ * List the stored accounts.
+ *
+ * `defaultId` is a stored pointer — the account projects fall back to — and no
+ * longer describes what sits in the machine-wide store. `liveId` still reports
+ * which account the machine-wide login belongs to, since that is the one
+ * `claude /login` last wrote and the one a capture would pick up.
  */
 async function listAccounts() {
   const index = readIndex();
   const currentFp = fingerprintCredentials(await readCurrentCredentials());
-  let activeId = index.activeId;
-  if (currentFp) {
-    const match = index.accounts.find(a => a.fingerprint === currentFp);
-    if (match) activeId = match.id;
-  } else {
-    activeId = null;
-  }
+  const live = currentFp ? index.accounts.find(a => a.fingerprint === currentFp) : null;
   return {
     accounts: index.accounts.map(summarize),
-    activeId,
+    defaultId: index.defaultId,
+    // Fall back to the stored pointer: a refresh moves the access token the
+    // fingerprint hashes, and that alone should not orphan the live account.
+    liveId: live?.id ?? index.liveId ?? null,
     hasCredentials: currentFp !== null
   };
+}
+
+/**
+ * Point unbound projects at this account. Unlike the old switchTo(), nothing
+ * is written to any credential store — spawns resolve their account at launch.
+ */
+function setDefault(id) {
+  const index = readIndex();
+  if (id !== null && !index.accounts.some(a => a.id === id)) {
+    throw new Error(`Account ${id} not found.`);
+  }
+  index.defaultId = id;
+  writeIndex(index);
+  return { defaultId: id };
+}
+
+/**
+ * Make sure a spawn for this account will find credentials, seeding the
+ * directory from the stored snapshot the first time. Returns the directory, or
+ * null when the account cannot be resolved — the caller then falls back to the
+ * machine-wide login rather than spawning with no credentials at all.
+ * @param {string} id
+ * @returns {Promise<string|null>}
+ */
+async function ensureAccountStore(id) {
+  const index = readIndex();
+  if (!index.accounts.some(a => a.id === id)) return null;
+  const dir = accountConfigDir(id);
+
+  if (await readCredentialsForDir(dir)) {
+    // Already provisioned; drop the seed if the Keychain has taken over.
+    await pruneSeedForDir(dir);
+    return dir;
+  }
+
+  const snapshot = readSnapshot(id);
+  if (!snapshot) return null;
+  writeSeedForDir(dir, snapshot);
+  return dir;
+}
+
+/**
+ * Resolve the credential directory for a project, honouring its binding and
+ * falling back to the default account.
+ * @param {string|null} accountId - The project's binding, if any
+ * @returns {Promise<string|null>}
+ */
+async function resolveStoreDir(accountId) {
+  const id = accountId || readIndex().defaultId;
+  if (!id) return null;
+  return ensureAccountStore(id);
 }
 
 /**
@@ -181,21 +271,30 @@ async function captureCurrent(name) {
   const account = {
     id,
     name: name?.trim() || `Account ${index.accounts.length + 1}`,
+    color: null,
     fingerprint,
     createdAt: new Date().toISOString(),
     lastUsedAt: new Date().toISOString()
   };
 
-  fs.writeFileSync(accountFile(id), JSON.stringify(accountCredentials(creds), null, 2), { mode: 0o600 });
+  const stored = accountCredentials(creds);
+  fs.writeFileSync(accountFile(id), JSON.stringify(stored, null, 2), { mode: 0o600 });
   index.accounts.push(account);
-  index.activeId = id;
+  // The first account captured becomes the fallback for unbound projects;
+  // later ones do not steal that role behind the user's back.
+  if (!index.defaultId) index.defaultId = id;
+  index.liveId = id;
   writeIndex(index);
+
+  writeSeedForDir(accountConfigDir(id), stored);
   return summarize(account);
 }
 
 /**
- * Point the live credential store (Keychain on macOS, file elsewhere) at the
- * stored snapshot for this account. Returns the swapped account summary.
+ * Point the machine-wide credential store at this account's snapshot.
+ *
+ * Off the normal path now that spawns resolve their own account: kept for the
+ * `claude` CLI run outside the app, which reads only the machine-wide store.
  */
 async function switchTo(id) {
   const name = readIndex().accounts.find(a => a.id === id)?.name;
@@ -224,24 +323,27 @@ async function switchTo(id) {
   const account = index.accounts.find(a => a.id === id);
   if (!account) throw new Error(`Account ${id} not found.`);
   account.lastUsedAt = new Date().toISOString();
-  index.activeId = id;
+  index.liveId = id;
   writeIndex(index);
   return summarize(account);
 }
 
 /**
- * Refresh the stored snapshot of the active account from the live credential
+ * Refresh the stored snapshot of whichever account owns the machine-wide
  * store, so backups stay usable after the CLI rotates its tokens.
  *
  * Matching prefers the fingerprint, which is exact when it hits. It stops
- * matching once the CLI refreshes the access token it hashes, so `activeId`
- * — the account we last swapped in — is the fallback.
+ * matching once the CLI refreshes the access token it hashes, so `liveId`
+ * — the account last written to that store — is the fallback.
  *
  * That fallback is only taken when the live credentials are provably a
- * rotation of the active account's snapshot. Without the check, a manual
+ * rotation of that account's snapshot. Without the check, a manual
  * `claude /login` onto a never-captured account would be attributed to the
- * previously active one, overwriting a good snapshot — and its fingerprint —
- * with a stranger's tokens. Bailing out instead just skips the refresh.
+ * previous one, overwriting a good snapshot — and its fingerprint — with a
+ * stranger's tokens. Bailing out instead just skips the refresh.
+ *
+ * Bound accounts do not go through here: the CLI refreshes them inside their
+ * own store, which stays authoritative on its own.
  */
 async function syncActiveFromDisk() {
   const creds = await readCurrentCredentials();
@@ -252,45 +354,70 @@ async function syncActiveFromDisk() {
   const index = readIndex();
   let match = index.accounts.find(a => a.fingerprint === fp);
   if (!match) {
-    const active = index.accounts.find(a => a.id === index.activeId);
-    if (active && isRotationOf(creds, readSnapshot(active.id))) match = active;
+    const live = index.accounts.find(a => a.id === index.liveId);
+    if (live && isRotationOf(creds, readSnapshot(live.id))) match = live;
   }
   if (!match) return null;
 
   fs.writeFileSync(accountFile(match.id), JSON.stringify(accountCredentials(creds), null, 2), { mode: 0o600 });
   match.fingerprint = fp;
   match.lastUsedAt = new Date().toISOString();
-  index.activeId = match.id;
+  index.liveId = match.id;
   writeIndex(index);
   return summarize(match);
 }
 
-function renameAccount(id, name) {
+/**
+ * Update the mutable, user-facing fields of an account. Only the keys present
+ * are touched, so a colour change cannot blank a name.
+ * @param {string} id
+ * @param {{name?: string, color?: string|null}} patch
+ */
+function updateAccount(id, patch = {}) {
   const index = readIndex();
   const account = index.accounts.find(a => a.id === id);
   if (!account) throw new Error(`Account ${id} not found.`);
-  account.name = name.trim() || account.name;
+  if (patch.name !== undefined) account.name = patch.name.trim() || account.name;
+  if (patch.color !== undefined) account.color = patch.color || null;
   writeIndex(index);
   return summarize(account);
 }
 
-function removeAccount(id) {
+function renameAccount(id, name) {
+  return updateAccount(id, { name });
+}
+
+/**
+ * Forget an account: snapshot, index entry and its credential store.
+ *
+ * Callers are expected to have cleared any project bindings first — the
+ * renderer blocks the deletion while projects still point here rather than
+ * silently moving them to another account.
+ */
+async function removeAccount(id) {
   const index = readIndex();
   const idx = index.accounts.findIndex(a => a.id === id);
   if (idx === -1) throw new Error(`Account ${id} not found.`);
   const file = accountFile(id);
   if (fs.existsSync(file)) fs.unlinkSync(file);
   index.accounts.splice(idx, 1);
-  if (index.activeId === id) index.activeId = null;
+  if (index.defaultId === id) index.defaultId = index.accounts[0]?.id ?? null;
+  if (index.liveId === id) index.liveId = null;
   writeIndex(index);
-  return { removed: id };
+  await deleteCredentialsForDir(accountConfigDir(id));
+  return { removed: id, defaultId: index.defaultId };
 }
 
 module.exports = {
   listAccounts,
   captureCurrent,
   switchTo,
+  setDefault,
   syncActiveFromDisk,
+  updateAccount,
   renameAccount,
-  removeAccount
+  removeAccount,
+  accountConfigDir,
+  ensureAccountStore,
+  resolveStoreDir
 };

--- a/src/main/services/AccountManager.js
+++ b/src/main/services/AccountManager.js
@@ -24,6 +24,7 @@ const {
   writeSeedForDir,
   pruneSeedForDir,
   deleteCredentialsForDir,
+  SECURESTORAGE_ENV,
 } = require('../utils/claudeCredentials');
 
 const accountsDir = path.join(dataDir, 'accounts');
@@ -201,16 +202,27 @@ async function listAccounts() {
 }
 
 /**
- * Point unbound projects at this account. Unlike the old switchTo(), nothing
- * is written to any credential store — spawns resolve their account at launch.
+ * Make this the account for everything that is not pinned to one of its own.
+ *
+ * Only bound projects get a private credential store; unbound work — and the
+ * `claude` CLI run outside the app — reads the machine-wide one. So the
+ * default is not merely a pointer: it is also what that store must hold.
+ * Keeping it a pointer alone would let the UI claim a default that no unbound
+ * session actually used.
+ *
+ * It also leaves `claude /login` working the way it always did, which is what
+ * capturing a new account still depends on.
  */
-function setDefault(id) {
+async function setDefault(id) {
   const index = readIndex();
   if (id !== null && !index.accounts.some(a => a.id === id)) {
     throw new Error(`Account ${id} not found.`);
   }
-  index.defaultId = id;
-  writeIndex(index);
+  if (id) await switchTo(id);
+  // Re-read: switchTo() writes the index.
+  const next = readIndex();
+  next.defaultId = id;
+  writeIndex(next);
   return { defaultId: id };
 }
 
@@ -240,15 +252,22 @@ async function ensureAccountStore(id) {
 }
 
 /**
- * Resolve the credential directory for a project, honouring its binding and
- * falling back to the default account.
+ * The environment a spawn should inherit to authenticate as this project's
+ * account, or null when it should use the machine-wide login.
+ *
+ * Deliberately no fallback to the default account: unbound work runs against
+ * the machine-wide store, which is what keeps `claude /login` — and therefore
+ * capturing a new account — behaving as it always has. setDefault() is what
+ * makes the default real, by putting it in that store.
+ *
  * @param {string|null} accountId - The project's binding, if any
- * @returns {Promise<string|null>}
+ * @returns {Promise<Object|null>} Env overlay, or null
  */
-async function resolveStoreDir(accountId) {
-  const id = accountId || readIndex().defaultId;
-  if (!id) return null;
-  return ensureAccountStore(id);
+async function accountEnv(accountId) {
+  if (!accountId) return null;
+  const dir = await ensureAccountStore(accountId);
+  if (!dir) return null;
+  return { [SECURESTORAGE_ENV]: dir };
 }
 
 /**
@@ -419,5 +438,5 @@ module.exports = {
   removeAccount,
   accountConfigDir,
   ensureAccountStore,
-  resolveStoreDir
+  accountEnv
 };

--- a/src/main/services/ChatService.js
+++ b/src/main/services/ChatService.js
@@ -9,6 +9,7 @@ const fs = require('fs');
 const { app } = require('electron');
 const { execFileSync } = require('child_process');
 const ModelCatalogService = require('./ModelCatalogService');
+const AccountManager = require('./AccountManager');
 
 let sdkPromise = null;
 let resolvedRuntime = null;
@@ -652,7 +653,7 @@ class ChatService {
    * @param {string[]} [params.disallowedTools] - Tools to withhold from the session.
    * @returns {Promise<string>} Session ID
    */
-  async startSession({ cwd, projectId = null, prompt, permissionMode = 'default', resumeSessionId = null, sessionId = null, images = [], mentions = [], model = null, enable1MContext = false, forkSession = false, resumeSessionAt = null, resumeDropsTurn = null, effort = null, outputFormat = null, skills = null, systemPrompt = null, settingSources = null, maxTurns = null, cloud = false, cloudProjectName = null, userMessageUuid = null, persistSession = true, allowedTools = null, disallowedTools = null }) {
+  async startSession({ cwd, projectId = null, accountId = null, prompt, permissionMode = 'default', resumeSessionId = null, sessionId = null, images = [], mentions = [], model = null, enable1MContext = false, forkSession = false, resumeSessionAt = null, resumeDropsTurn = null, effort = null, outputFormat = null, skills = null, systemPrompt = null, settingSources = null, maxTurns = null, cloud = false, cloudProjectName = null, userMessageUuid = null, persistSession = true, allowedTools = null, disallowedTools = null }) {
     if (!sessionId) sessionId = `chat-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
     // Cloud session: delegate to cloud server instead of local SDK
@@ -694,6 +695,12 @@ class ChatService {
 
     try {
       const runtime = resolveRuntime();
+      // A project pinned to an account authenticates as that account: the
+      // overlay points the CLI's credential store at the account's own
+      // directory, leaving everything else in ~/.claude shared. Unbound
+      // projects keep reading the machine-wide login.
+      const accountOverlay = await AccountManager.accountEnv(accountId);
+      if (accountOverlay) runtime.env = { ...runtime.env, ...accountOverlay };
       const effectiveCwd = cwd || require('os').homedir();
       // An allowlist is what makes a session hands-free, so it is also what
       // marks it unattended. An empty array is not a restriction.
@@ -818,6 +825,9 @@ class ChatService {
         alwaysAllow: permissionMode === 'bypassPermissions',
         cwd,
         projectId,
+        // Which account this session authenticated as, so a usage limit names
+        // the right one instead of whatever the default happens to be now.
+        accountId,
         _stderr: '',
         // Retained so a refused fork can be replayed without the guard
         _forkGuard: (resumeSessionId && resumeSessionAt && resumeDropsTurn)
@@ -1519,11 +1529,19 @@ class ChatService {
         }
         const errorType = this._isUsageLimitError(err.message, stderrLog) ? 'usage_limit' : 'generic';
         if (errorType === 'usage_limit') {
-          let activeAccountId = null;
+          // The limit belongs to whichever account ran this session: its
+          // project's binding, or the default when it has none. The renderer
+          // offers to re-bind the project rather than swap a global account.
+          let activeAccountId = session?.accountId || null;
           try {
-            activeAccountId = (await require('./AccountManager').listAccounts()).activeId;
+            if (!activeAccountId) activeAccountId = (await AccountManager.listAccounts()).defaultId;
           } catch (_) { /* AccountManager not initialized yet */ }
-          this._send('chat-account-limit', { sessionId, error: errorMsg, activeAccountId });
+          this._send('chat-account-limit', {
+            sessionId,
+            error: errorMsg,
+            activeAccountId,
+            projectId: session?.projectId || null
+          });
         }
         this._send('chat-error', { sessionId, error: errorMsg, errorType });
         this._emitLifecycle('end', sessionId, { status: 'error', error: errorMsg });
@@ -1566,6 +1584,7 @@ class ChatService {
     const ctx = session ? {
       cwd: session.cwd || null,
       projectId: session.projectId || null,
+      accountId: session.accountId || null,
     } : null;
     this.closeSession(sessionId);
     return ctx;

--- a/src/main/services/TerminalService.js
+++ b/src/main/services/TerminalService.js
@@ -51,7 +51,7 @@ class TerminalService {
    * @param {string} options.resumeSessionId - Session ID to resume
    * @returns {Object} - { success: boolean, id?: number, error?: string }
    */
-  create({ cwd, runClaude, skipPermissions, resumeSessionId, projectId, projectPath }) {
+  create({ cwd, runClaude, skipPermissions, resumeSessionId, projectId, projectPath, accountEnv = null }) {
     const id = ++this.terminalId;
     let shellPath = process.platform === 'win32' ? 'powershell.exe' : (process.env.SHELL || '/bin/bash');
     let shellArgs = process.platform === 'win32' ? ['-NoLogo', '-NoProfile'] : [];
@@ -90,7 +90,9 @@ class TerminalService {
         cols: 120,
         rows: 30,
         cwd: effectiveCwd,
-        env: process.env
+        // A project pinned to an account gets that account's credential store;
+        // everything else in ~/.claude stays shared.
+        env: accountEnv ? { ...process.env, ...accountEnv } : process.env
       });
 
       if (!ptyProcess) {

--- a/src/main/services/UsageService.js
+++ b/src/main/services/UsageService.js
@@ -4,70 +4,123 @@
  */
 
 const https = require('https');
-const { readAccessToken } = require('../utils/claudeCredentials');
+const { readAccessToken, readCredentialsForDir, tokenFromCredentials } = require('../utils/claudeCredentials');
 
-// Cache
-let usageData = null;
-let lastFetch = null;
+// Per-account state.
+//
+// Projects pick their own account, so there is no single set of numbers to
+// hold any more: figures fetched for one account are simply wrong for another.
+// Everything that used to be a module-level singleton is keyed by account id,
+// with the MACHINE key standing for the machine-wide login — what unbound
+// projects, and the default account, actually run as.
+const MACHINE = '__machine__';
+
 let fetchInterval = null;
-let isFetching = false;
 let _onUpdateCallback = null;
 let _onLimitCallback = null;
-// Staleness tracking: set whenever a fetch attempt fails. `isStale` stays true
-// for as long as we keep serving `usageData` that the API refused to confirm,
-// so the renderer can badge the numbers instead of showing them as current.
-let lastError = null;
-let isStale = false;
-// De-dupe limit notifications until the next reset window
-let _lastLimitNotifiedReset = null;
+
+// Which account the UI is showing. Only this one is polled: fetching every
+// known account on a timer would multiply API calls by the number of accounts
+// to keep numbers nobody is looking at warm.
+let focusedAccount = MACHINE;
+
+/** @type {Map<string, Object>} */
+const entries = new Map();
+
+function key(accountId) {
+  return accountId || MACHINE;
+}
+
+/**
+ * Per-account slot. `isStale` stays true for as long as we keep serving data
+ * the API refused to confirm, so the renderer can badge the numbers instead of
+ * showing them as current.
+ */
+function entryFor(accountId) {
+  const k = key(accountId);
+  let entry = entries.get(k);
+  if (!entry) {
+    entry = {
+      accountId: accountId || null,
+      usageData: null,
+      lastFetch: null,
+      isFetching: false,
+      lastError: null,
+      isStale: false,
+      lastLimitNotifiedReset: null,
+      tokenCache: null,
+      tokenCacheTime: 0
+    };
+    entries.set(k, entry);
+  }
+  return entry;
+}
 
 const USAGE_API_URL = 'https://api.anthropic.com/api/oauth/usage';
 const OAUTH_BETA_HEADER = 'oauth-2025-04-20';
 
 // ── OAuth API (primary) ──
 
-// Token cache to avoid hitting the credential store (and, on macOS, the
+// Token cache TTL, to avoid hitting the credential store (and, on macOS, the
 // Keychain) on every poll.
-let _tokenCache = null;
-let _tokenCacheTime = 0;
 const TOKEN_CACHE_TTL = 30000; // 30s
 
 /**
- * Read the OAuth access token from the CLI's live credential store — the macOS
- * login Keychain on darwin, ~/.claude/.credentials.json elsewhere. Reading only
- * the file here is what left the usage panel blank on macOS, where the CLI has
- * never written one.
+ * Read the OAuth access token for an account.
+ *
+ * A bound account is read from its own credential directory — the same one its
+ * spawned CLI authenticates against — so the figures come back for the account
+ * that actually did the work. With no id, this is the machine-wide login: the
+ * macOS Keychain on darwin, ~/.claude/.credentials.json elsewhere.
+ *
+ * @param {string|null} accountId
  * @returns {Promise<string|null>}
  */
-async function readOAuthToken() {
+async function readOAuthToken(accountId) {
+  const entry = entryFor(accountId);
   const now = Date.now();
-  if (_tokenCache !== null && now - _tokenCacheTime < TOKEN_CACHE_TTL) {
-    return _tokenCache;
+  if (entry.tokenCache !== null && now - entry.tokenCacheTime < TOKEN_CACHE_TTL) {
+    return entry.tokenCache;
   }
   try {
-    _tokenCache = await readAccessToken();
+    if (accountId) {
+      const { accountConfigDir } = require('./AccountManager');
+      entry.tokenCache = tokenFromCredentials(await readCredentialsForDir(accountConfigDir(accountId)));
+    } else {
+      entry.tokenCache = await readAccessToken();
+    }
   } catch (e) {
-    _tokenCache = null;
+    entry.tokenCache = null;
   }
-  _tokenCacheTime = now;
-  return _tokenCache;
+  entry.tokenCacheTime = now;
+  return entry.tokenCache;
 }
 
 /**
- * Drop the cached token and usage figures.
+ * Drop cached tokens and figures — for one account, or all of them.
  *
- * Called after an account switch: the numbers belong to the account that was
- * active when they were fetched, so serving them for the incoming one would be
- * a plain lie, and the 30s token cache would keep querying the outgoing account.
+ * The numbers belong to the account they were fetched for, so serving them for
+ * another would be a plain lie, and the 30s token cache would keep querying the
+ * outgoing one. Called with no id after a change to the machine-wide store,
+ * which every unbound project reads.
+ *
+ * @param {string|null} [accountId] - omit to clear every account
  */
-function invalidateCredentials() {
-  _tokenCache = null;
-  _tokenCacheTime = 0;
-  usageData = null;
-  lastFetch = null;
-  isStale = false;
-  lastError = null;
-  _lastLimitNotifiedReset = null;
+function invalidateCredentials(accountId) {
+  const reset = (entry) => {
+    entry.tokenCache = null;
+    entry.tokenCacheTime = 0;
+    entry.usageData = null;
+    entry.lastFetch = null;
+    entry.isStale = false;
+    entry.lastError = null;
+    entry.lastLimitNotifiedReset = null;
+  };
+  if (accountId === undefined) {
+    for (const entry of entries.values()) reset(entry);
+    return;
+  }
+  reset(entryFor(accountId));
 }
 
 /**
@@ -204,45 +257,65 @@ function fetchUsageFromAPI(token) {
  * marks the cached data stale rather than silently passing it off as fresh.
  * @returns {Promise<Object|null>}
  */
-async function fetchUsage() {
-  if (isFetching) return usageData;
-  isFetching = true;
+async function fetchUsage(accountId) {
+  const entry = entryFor(accountId);
+  if (entry.isFetching) return entry.usageData;
+  entry.isFetching = true;
 
   try {
     // Try OAuth API first
-    const token = await readOAuthToken();
+    const token = await readOAuthToken(entry.accountId);
     if (token) {
       try {
         const data = await fetchUsageFromAPI(token);
-        usageData = data;
-        lastFetch = new Date();
-        lastError = null;
-        isStale = false;
+        entry.usageData = data;
+        entry.lastFetch = new Date();
+        entry.lastError = null;
+        entry.isStale = false;
         console.log('[Usage] Fetched via API');
-        if (_onUpdateCallback) _onUpdateCallback(data);
-        _maybeNotifyLimit(data);
+        if (_onUpdateCallback) _onUpdateCallback(data, entry.accountId);
+        _maybeNotifyLimit(entry, data);
         return data;
       } catch (apiErr) {
-        lastError = apiErr.message;
+        entry.lastError = apiErr.message;
         console.log('[Usage] API request failed:', apiErr.message);
       }
     } else {
-      lastError = 'No valid Claude OAuth token (missing or expired — run /login in a terminal)';
-      console.log('[Usage] ' + lastError);
+      entry.lastError = 'No valid Claude OAuth token (missing or expired — run /login in a terminal)';
+      console.log('[Usage] ' + entry.lastError);
     }
 
     // PTY fallback removed — launching `claude --dangerously-skip-permissions` just
     // to read usage data is a security risk. Serve cached data, flagged as stale.
-    isStale = true;
-    if (usageData) {
-      console.warn('[Usage] API unavailable, serving STALE cached data:', lastError);
-      return usageData;
+    entry.isStale = true;
+    if (entry.usageData) {
+      console.warn('[Usage] API unavailable, serving STALE cached data:', entry.lastError);
+      return entry.usageData;
     }
-    console.warn('[Usage] API unavailable and no cached data:', lastError);
+    console.warn('[Usage] API unavailable and no cached data:', entry.lastError);
     return null;
   } finally {
-    isFetching = false;
+    entry.isFetching = false;
   }
+}
+
+/**
+ * Point the poller at the account the UI is showing.
+ *
+ * Its figures are refreshed immediately: switching project tabs should not
+ * leave the previous account's numbers on screen until the next tick.
+ *
+ * @param {string|null} accountId
+ */
+function setFocusedAccount(accountId) {
+  const next = key(accountId);
+  if (next === focusedAccount) return;
+  focusedAccount = next;
+  fetchUsage(accountId).catch(e => console.error('[Usage]', e.message));
+}
+
+function getFocusedAccount() {
+  return focusedAccount === MACHINE ? null : focusedAccount;
 }
 
 /**
@@ -252,18 +325,19 @@ async function fetchUsage() {
 function startPeriodicFetch(intervalMs = 600000) {
   const { isMainWindowVisible } = require('../windows/MainWindow');
 
-  setTimeout(() => {
+  // Only the focused account is polled. Sweeping every known account on a
+  // timer would multiply API calls to keep numbers nobody is looking at warm;
+  // the others are refreshed on demand, when a tab or a panel asks for them.
+  const tick = () => {
     if (isMainWindowVisible()) {
-      fetchUsage().catch(e => console.error('[Usage]', e.message));
+      fetchUsage(getFocusedAccount()).catch(e => console.error('[Usage]', e.message));
     }
-  }, 5000);
+  };
+
+  setTimeout(tick, 5000);
 
   if (fetchInterval) clearInterval(fetchInterval);
-  fetchInterval = setInterval(() => {
-    if (isMainWindowVisible()) {
-      fetchUsage().catch(e => console.error('[Usage]', e.message));
-    }
-  }, intervalMs);
+  fetchInterval = setInterval(tick, intervalMs);
 }
 
 /**
@@ -282,13 +356,15 @@ function stopPeriodicFetch() {
  * the API last confirmed, which may be arbitrarily old.
  * @returns {Object}
  */
-function getUsageData() {
+function getUsageData(accountId) {
+  const entry = entryFor(accountId);
   return {
-    data: usageData,
-    lastFetch: lastFetch ? lastFetch.toISOString() : null,
-    isFetching,
-    stale: isStale,
-    error: lastError
+    accountId: entry.accountId,
+    data: entry.usageData,
+    lastFetch: entry.lastFetch ? entry.lastFetch.toISOString() : null,
+    isFetching: entry.isFetching,
+    stale: entry.isStale,
+    error: entry.lastError
   };
 }
 
@@ -296,20 +372,22 @@ function getUsageData() {
  * Staleness of the most recent fetch attempt.
  * @returns {{ stale: boolean, error: string|null, lastFetch: string|null }}
  */
-function getFetchState() {
+function getFetchState(accountId) {
+  const entry = entryFor(accountId);
   return {
-    stale: isStale,
-    error: lastError,
-    lastFetch: lastFetch ? lastFetch.toISOString() : null
+    stale: entry.isStale,
+    error: entry.lastError,
+    lastFetch: entry.lastFetch ? entry.lastFetch.toISOString() : null
   };
 }
 
 /**
  * Force refresh
+ * @param {string|null} [accountId]
  * @returns {Promise<Object>}
  */
-function refreshUsage() {
-  return fetchUsage();
+function refreshUsage(accountId) {
+  return fetchUsage(accountId);
 }
 
 /**
@@ -317,11 +395,12 @@ function refreshUsage() {
  */
 function onWindowShow() {
   const staleMinutes = 10;
-  // Renamed to avoid shadowing the module-level `isStale` (fetch-failure flag).
-  const isDataOld = !lastFetch || (Date.now() - lastFetch.getTime() > staleMinutes * 60 * 1000);
+  const entry = entryFor(getFocusedAccount());
+  // Renamed to avoid shadowing the per-entry `isStale` (fetch-failure flag).
+  const isDataOld = !entry.lastFetch || (Date.now() - entry.lastFetch.getTime() > staleMinutes * 60 * 1000);
 
-  if (isDataOld && !isFetching) {
-    fetchUsage().catch(e => console.error('[Usage]', e.message));
+  if (isDataOld && !entry.isFetching) {
+    fetchUsage(entry.accountId).catch(e => console.error('[Usage]', e.message));
   }
 }
 
@@ -344,7 +423,7 @@ function onLimit(cb) {
 
 const LIMIT_THRESHOLD = 0.95; // 95%
 
-function _maybeNotifyLimit(data) {
+function _maybeNotifyLimit(entry, data) {
   if (!_onLimitCallback || !Array.isArray(data?.buckets)) return;
   // Pick the most-pressured bucket, whichever ones the API sent
   const candidates = data.buckets
@@ -352,16 +431,19 @@ function _maybeNotifyLimit(data) {
     .sort((a, b) => b.utilization - a.utilization);
   if (!candidates.length) return;
   const top = candidates[0];
-  // De-dupe per reset window
-  const key = `${top.id}:${top.resetsAt || ''}`;
-  if (key === _lastLimitNotifiedReset) return;
-  _lastLimitNotifiedReset = key;
+  // De-dupe per reset window, per account: the de-dupe key lives on the entry,
+  // so one account hitting its limit cannot swallow the notification for
+  // another that hits the same bucket in the same window.
+  const dedupe = `${top.id}:${top.resetsAt || ''}`;
+  if (dedupe === entry.lastLimitNotifiedReset) return;
+  entry.lastLimitNotifiedReset = dedupe;
   try {
     _onLimitCallback({
       scope: top.id,
       label: top.label,
       utilization: top.utilization,
-      resetsAt: top.resetsAt
+      resetsAt: top.resetsAt,
+      accountId: entry.accountId
     });
   } catch (e) { console.error('[Usage] onLimit cb threw:', e.message); }
 }
@@ -375,6 +457,8 @@ module.exports = {
   refreshUsage,
   fetchUsage,
   invalidateCredentials,
+  setFocusedAccount,
+  getFocusedAccount,
   onWindowShow,
   onUpdate,
   onLimit

--- a/src/main/utils/claudeCredentials.js
+++ b/src/main/utils/claudeCredentials.js
@@ -13,6 +13,7 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+const crypto = require('crypto');
 
 const KEYCHAIN_SERVICE = 'Claude Code-credentials';
 
@@ -104,11 +105,121 @@ async function readAccessToken() {
   return oauth.accessToken;
 }
 
+// ── Per-account credential stores ───────────────────────────────────────────
+//
+// A project can be pinned to a specific account, so a spawned CLI must not read
+// the machine-wide login. `CLAUDE_SECURESTORAGE_CONFIG_DIR` scopes *only* the
+// credential store: `projects/`, `sessions/`, `.claude.json`, `skills/` and the
+// rest stay shared in ~/.claude, which is what keeps session history and MCP
+// config usable whichever account a project runs on.
+//
+// The CLI derives its Keychain service name from that directory —
+// `Claude Code-credentials-${sha256(NFC(dir)).slice(0, 8)}` — so each account
+// lands in its own Keychain entry and a token refresh can never clobber another
+// account. The seed file below only bootstraps a directory the CLI has never
+// used; from the first refresh onwards the Keychain entry is the record.
+
+const SECURESTORAGE_ENV = 'CLAUDE_SECURESTORAGE_CONFIG_DIR';
+
+/**
+ * Mirror of the CLI's Keychain service derivation for a credential directory.
+ * @param {string} dir
+ * @returns {string}
+ */
+function keychainServiceForDir(dir) {
+  const hash = crypto.createHash('sha256').update(dir.normalize('NFC')).digest('hex').slice(0, 8);
+  return `${KEYCHAIN_SERVICE}-${hash}`;
+}
+
+function seedPathForDir(dir) {
+  return path.join(dir, '.credentials.json');
+}
+
+/**
+ * Read the credentials a spawned CLI would use for this directory: the
+ * namespaced Keychain entry first, then the bootstrap seed.
+ * @param {string} dir
+ * @returns {Promise<Object|null>}
+ */
+async function readCredentialsForDir(dir) {
+  if (useKeychain()) {
+    try {
+      const raw = await keytar.getPassword(keychainServiceForDir(dir), keychainAccount());
+      if (raw) return JSON.parse(raw);
+    } catch (_) {
+      // Denied or unreadable — the seed below may still bootstrap the account.
+    }
+  }
+  try {
+    return JSON.parse(fs.readFileSync(seedPathForDir(dir), 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Bootstrap a credential directory so the next spawn can authenticate.
+ * @param {string} dir
+ * @param {Object} creds
+ */
+function writeSeedForDir(dir, creds) {
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const seed = seedPathForDir(dir);
+  const tmp = `${seed}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(creds, null, 2), { mode: 0o600 });
+  fs.renameSync(tmp, seed);
+}
+
+/**
+ * Drop the plaintext seed once the Keychain entry has taken over, so a stale
+ * copy of the tokens does not linger on disk.
+ * @param {string} dir
+ * @returns {Promise<boolean>} true when the seed was removed
+ */
+async function pruneSeedForDir(dir) {
+  if (!useKeychain()) return false;
+  const seed = seedPathForDir(dir);
+  if (!fs.existsSync(seed)) return false;
+  try {
+    const raw = await keytar.getPassword(keychainServiceForDir(dir), keychainAccount());
+    if (!raw) return false;
+  } catch (_) {
+    return false;
+  }
+  fs.unlinkSync(seed);
+  return true;
+}
+
+/**
+ * Forget a credential directory entirely — Keychain entry and seed.
+ * @param {string} dir
+ */
+async function deleteCredentialsForDir(dir) {
+  if (useKeychain()) {
+    try {
+      await keytar.deletePassword(keychainServiceForDir(dir), keychainAccount());
+    } catch (_) {
+      // Nothing stored, or the Keychain refused — the directory still goes.
+    }
+  }
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch (_) {
+    // Best effort.
+  }
+}
+
 module.exports = {
   KEYCHAIN_SERVICE,
+  SECURESTORAGE_ENV,
   getCredentialsPath,
   useKeychain,
   readCredentials,
   writeCredentials,
   readAccessToken,
+  keychainServiceForDir,
+  readCredentialsForDir,
+  writeSeedForDir,
+  pruneSeedForDir,
+  deleteCredentialsForDir,
 };

--- a/src/main/utils/claudeCredentials.js
+++ b/src/main/utils/claudeCredentials.js
@@ -98,7 +98,17 @@ async function writeCredentials(payload) {
  * @returns {Promise<string|null>}
  */
 async function readAccessToken() {
-  const creds = await readCredentials();
+  return tokenFromCredentials(await readCredentials());
+}
+
+/**
+ * The usable access token in a credentials payload, or null when it is absent
+ * or expired. Kept here so every store — machine-wide or per-account — applies
+ * the same expiry rule.
+ * @param {Object|null} creds
+ * @returns {string|null}
+ */
+function tokenFromCredentials(creds) {
   const oauth = creds?.claudeAiOauth;
   if (!oauth?.accessToken) return null;
   if (oauth.expiresAt && Date.now() > oauth.expiresAt) return null;
@@ -217,6 +227,7 @@ module.exports = {
   readCredentials,
   writeCredentials,
   readAccessToken,
+  tokenFromCredentials,
   keychainServiceForDir,
   readCredentialsForDir,
   writeSeedForDir,

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -3782,7 +3782,15 @@
     "switchError": "Failed to switch account",
     "renameError": "Failed to rename account",
     "removeError": "Failed to remove account",
-    "captureError": "Failed to save the current account"
+    "captureError": "Failed to save the current account",
+    "isDefault": "Default",
+    "makeDefault": "Make default",
+    "useDefault": "Default account",
+    "useDefaultNamed": "Default account ({name})",
+    "colorTitle": "Account colour",
+    "colorError": "Failed to save the account colour",
+    "boundProjects": "{count} project(s)",
+    "removeBlocked": "Still used by {count} project(s): {projects}. Move them to another account first."
   },
   "usage": {
     "stale": "Usage data may be out of date - the last refresh failed. {error}"

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -3790,7 +3790,12 @@
     "colorTitle": "Account colour",
     "colorError": "Failed to save the account colour",
     "boundProjects": "{count} project(s)",
-    "removeBlocked": "Still used by {count} project(s): {projects}. Move them to another account first."
+    "removeBlocked": "Still used by {count} project(s): {projects}. Move them to another account first.",
+    "rebindTitle": "Run this project on another account",
+    "rebindScope": "Only {project} moves. Your other projects keep the account they are on.",
+    "rebindScopeDefault": "This changes the default account, used by every project without one of its own.",
+    "limited": "Limit reached",
+    "useForProject": "Use here"
   },
   "usage": {
     "stale": "Usage data may be out of date - the last refresh failed. {error}"

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -3799,7 +3799,10 @@
     "usageBoundTitle": "Usage for {name}, this project’s account. Click to change it.",
     "usageDefaultTitle": "Usage for {name}, the default account. Click to pin this project to one.",
     "switchWhileRunningTitle": "Sessions are running",
-    "switchWhileRunning": "{count} session(s) are already running for this project and keep their current account. The change applies to sessions started from now on. Continue?"
+    "switchWhileRunning": "{count} session(s) are already running for this project and keep their current account. The change applies to sessions started from now on. Continue?",
+    "colorNone": "No colour",
+    "chooseForProjectTitle": "Claude account",
+    "chooseForProject": "Which account should {project} run as? You can change this later from its tab."
   },
   "usage": {
     "stale": "Usage data may be out of date - the last refresh failed. {error}"

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -3795,7 +3795,11 @@
     "rebindScope": "Only {project} moves. Your other projects keep the account they are on.",
     "rebindScopeDefault": "This changes the default account, used by every project without one of its own.",
     "limited": "Limit reached",
-    "useForProject": "Use here"
+    "useForProject": "Use here",
+    "usageBoundTitle": "Usage for {name}, this project’s account. Click to change it.",
+    "usageDefaultTitle": "Usage for {name}, the default account. Click to pin this project to one.",
+    "switchWhileRunningTitle": "Sessions are running",
+    "switchWhileRunning": "{count} session(s) are already running for this project and keep their current account. The change applies to sessions started from now on. Continue?"
   },
   "usage": {
     "stale": "Usage data may be out of date - the last refresh failed. {error}"

--- a/src/renderer/i18n/locales/es.json
+++ b/src/renderer/i18n/locales/es.json
@@ -3782,7 +3782,15 @@
     "switchError": "No se pudo cambiar de cuenta",
     "renameError": "No se pudo renombrar la cuenta",
     "removeError": "No se pudo eliminar la cuenta",
-    "captureError": "No se pudo guardar la cuenta actual"
+    "captureError": "No se pudo guardar la cuenta actual",
+    "isDefault": "Predeterminada",
+    "makeDefault": "Definir como predeterminada",
+    "useDefault": "Cuenta predeterminada",
+    "useDefaultNamed": "Cuenta predeterminada ({name})",
+    "colorTitle": "Color de la cuenta",
+    "colorError": "No se pudo guardar el color de la cuenta",
+    "boundProjects": "{count} proyecto(s)",
+    "removeBlocked": "Todavía la usan {count} proyecto(s): {projects}. Muévelos a otra cuenta primero."
   },
   "usage": {
     "stale": "Datos de uso posiblemente desactualizados - la última actualización falló. {error}"

--- a/src/renderer/i18n/locales/es.json
+++ b/src/renderer/i18n/locales/es.json
@@ -3799,7 +3799,10 @@
     "usageBoundTitle": "Uso de {name}, la cuenta de este proyecto. Haz clic para cambiarla.",
     "usageDefaultTitle": "Uso de {name}, la cuenta predeterminada. Haz clic para asignar una a este proyecto.",
     "switchWhileRunningTitle": "Sesiones en curso",
-    "switchWhileRunning": "{count} sesión(es) ya están en curso para este proyecto y conservan su cuenta actual. El cambio se aplicará a las sesiones que inicies después. ¿Continuar?"
+    "switchWhileRunning": "{count} sesión(es) ya están en curso para este proyecto y conservan su cuenta actual. El cambio se aplicará a las sesiones que inicies después. ¿Continuar?",
+    "colorNone": "Sin color",
+    "chooseForProjectTitle": "Cuenta de Claude",
+    "chooseForProject": "¿Con qué cuenta debe ejecutarse {project}? Puedes cambiarlo luego desde su pestaña."
   },
   "usage": {
     "stale": "Datos de uso posiblemente desactualizados - la última actualización falló. {error}"

--- a/src/renderer/i18n/locales/es.json
+++ b/src/renderer/i18n/locales/es.json
@@ -3790,7 +3790,12 @@
     "colorTitle": "Color de la cuenta",
     "colorError": "No se pudo guardar el color de la cuenta",
     "boundProjects": "{count} proyecto(s)",
-    "removeBlocked": "Todavía la usan {count} proyecto(s): {projects}. Muévelos a otra cuenta primero."
+    "removeBlocked": "Todavía la usan {count} proyecto(s): {projects}. Muévelos a otra cuenta primero.",
+    "rebindTitle": "Usar otra cuenta para este proyecto",
+    "rebindScope": "Solo cambia {project}. Tus otros proyectos conservan su cuenta.",
+    "rebindScopeDefault": "Esto cambia la cuenta predeterminada, usada por todos los proyectos sin una propia.",
+    "limited": "Límite alcanzado",
+    "useForProject": "Usar aquí"
   },
   "usage": {
     "stale": "Datos de uso posiblemente desactualizados - la última actualización falló. {error}"

--- a/src/renderer/i18n/locales/es.json
+++ b/src/renderer/i18n/locales/es.json
@@ -3795,7 +3795,11 @@
     "rebindScope": "Solo cambia {project}. Tus otros proyectos conservan su cuenta.",
     "rebindScopeDefault": "Esto cambia la cuenta predeterminada, usada por todos los proyectos sin una propia.",
     "limited": "Límite alcanzado",
-    "useForProject": "Usar aquí"
+    "useForProject": "Usar aquí",
+    "usageBoundTitle": "Uso de {name}, la cuenta de este proyecto. Haz clic para cambiarla.",
+    "usageDefaultTitle": "Uso de {name}, la cuenta predeterminada. Haz clic para asignar una a este proyecto.",
+    "switchWhileRunningTitle": "Sesiones en curso",
+    "switchWhileRunning": "{count} sesión(es) ya están en curso para este proyecto y conservan su cuenta actual. El cambio se aplicará a las sesiones que inicies después. ¿Continuar?"
   },
   "usage": {
     "stale": "Datos de uso posiblemente desactualizados - la última actualización falló. {error}"

--- a/src/renderer/i18n/locales/fr.json
+++ b/src/renderer/i18n/locales/fr.json
@@ -3795,7 +3795,11 @@
     "rebindScope": "Seul {project} change. Vos autres projets gardent leur compte.",
     "rebindScopeDefault": "Ceci change le compte par défaut, utilisé par tous les projets qui n’en ont pas.",
     "limited": "Limite atteinte",
-    "useForProject": "Utiliser ici"
+    "useForProject": "Utiliser ici",
+    "usageBoundTitle": "Usage de {name}, le compte de ce projet. Cliquez pour en changer.",
+    "usageDefaultTitle": "Usage de {name}, le compte par défaut. Cliquez pour lier ce projet à un compte.",
+    "switchWhileRunningTitle": "Sessions en cours",
+    "switchWhileRunning": "{count} session(s) tournent déjà pour ce projet et gardent leur compte actuel. Le changement s’appliquera aux sessions démarrées ensuite. Continuer ?"
   },
   "usage": {
     "stale": "Données d'usage peut-être obsolètes - la dernière actualisation a échoué. {error}"

--- a/src/renderer/i18n/locales/fr.json
+++ b/src/renderer/i18n/locales/fr.json
@@ -3799,7 +3799,10 @@
     "usageBoundTitle": "Usage de {name}, le compte de ce projet. Cliquez pour en changer.",
     "usageDefaultTitle": "Usage de {name}, le compte par défaut. Cliquez pour lier ce projet à un compte.",
     "switchWhileRunningTitle": "Sessions en cours",
-    "switchWhileRunning": "{count} session(s) tournent déjà pour ce projet et gardent leur compte actuel. Le changement s’appliquera aux sessions démarrées ensuite. Continuer ?"
+    "switchWhileRunning": "{count} session(s) tournent déjà pour ce projet et gardent leur compte actuel. Le changement s’appliquera aux sessions démarrées ensuite. Continuer ?",
+    "colorNone": "Aucune couleur",
+    "chooseForProjectTitle": "Compte Claude",
+    "chooseForProject": "Sur quel compte {project} doit-il tourner ? Modifiable ensuite depuis son onglet."
   },
   "usage": {
     "stale": "Données d'usage peut-être obsolètes - la dernière actualisation a échoué. {error}"

--- a/src/renderer/i18n/locales/fr.json
+++ b/src/renderer/i18n/locales/fr.json
@@ -3790,7 +3790,12 @@
     "colorTitle": "Couleur du compte",
     "colorError": "Impossible d’enregistrer la couleur du compte",
     "boundProjects": "{count} projet(s)",
-    "removeBlocked": "Encore utilisé par {count} projet(s) : {projects}. Déplacez-les vers un autre compte d’abord."
+    "removeBlocked": "Encore utilisé par {count} projet(s) : {projects}. Déplacez-les vers un autre compte d’abord.",
+    "rebindTitle": "Utiliser un autre compte pour ce projet",
+    "rebindScope": "Seul {project} change. Vos autres projets gardent leur compte.",
+    "rebindScopeDefault": "Ceci change le compte par défaut, utilisé par tous les projets qui n’en ont pas.",
+    "limited": "Limite atteinte",
+    "useForProject": "Utiliser ici"
   },
   "usage": {
     "stale": "Données d'usage peut-être obsolètes - la dernière actualisation a échoué. {error}"

--- a/src/renderer/i18n/locales/fr.json
+++ b/src/renderer/i18n/locales/fr.json
@@ -3782,7 +3782,15 @@
     "switchError": "Impossible de changer de compte",
     "renameError": "Impossible de renommer le compte",
     "removeError": "Impossible de supprimer le compte",
-    "captureError": "Impossible de sauvegarder le compte actuel"
+    "captureError": "Impossible de sauvegarder le compte actuel",
+    "isDefault": "Par défaut",
+    "makeDefault": "Définir par défaut",
+    "useDefault": "Compte par défaut",
+    "useDefaultNamed": "Compte par défaut ({name})",
+    "colorTitle": "Couleur du compte",
+    "colorError": "Impossible d’enregistrer la couleur du compte",
+    "boundProjects": "{count} projet(s)",
+    "removeBlocked": "Encore utilisé par {count} projet(s) : {projects}. Déplacez-les vers un autre compte d’abord."
   },
   "usage": {
     "stale": "Données d'usage peut-être obsolètes - la dernière actualisation a échoué. {error}"

--- a/src/renderer/i18n/locales/id.json
+++ b/src/renderer/i18n/locales/id.json
@@ -3795,7 +3795,11 @@
     "rebindScope": "Hanya {project} yang berpindah. Proyek lain tetap pada akunnya.",
     "rebindScopeDefault": "Ini mengubah akun default, yang dipakai semua proyek tanpa akun sendiri.",
     "limited": "Batas tercapai",
-    "useForProject": "Pakai di sini"
+    "useForProject": "Pakai di sini",
+    "usageBoundTitle": "Pemakaian {name}, akun proyek ini. Klik untuk menggantinya.",
+    "usageDefaultTitle": "Pemakaian {name}, akun default. Klik untuk menetapkan akun bagi proyek ini.",
+    "switchWhileRunningTitle": "Ada sesi berjalan",
+    "switchWhileRunning": "{count} sesi sudah berjalan untuk proyek ini dan tetap memakai akunnya. Perubahan berlaku untuk sesi berikutnya. Lanjutkan?"
   },
   "usage": {
     "stale": "Data penggunaan mungkin sudah tidak terbaru - pemuatan terakhir gagal. {error}"

--- a/src/renderer/i18n/locales/id.json
+++ b/src/renderer/i18n/locales/id.json
@@ -3790,7 +3790,12 @@
     "colorTitle": "Warna akun",
     "colorError": "Gagal menyimpan warna akun",
     "boundProjects": "{count} proyek",
-    "removeBlocked": "Masih dipakai {count} proyek: {projects}. Pindahkan ke akun lain dulu."
+    "removeBlocked": "Masih dipakai {count} proyek: {projects}. Pindahkan ke akun lain dulu.",
+    "rebindTitle": "Gunakan akun lain untuk proyek ini",
+    "rebindScope": "Hanya {project} yang berpindah. Proyek lain tetap pada akunnya.",
+    "rebindScopeDefault": "Ini mengubah akun default, yang dipakai semua proyek tanpa akun sendiri.",
+    "limited": "Batas tercapai",
+    "useForProject": "Pakai di sini"
   },
   "usage": {
     "stale": "Data penggunaan mungkin sudah tidak terbaru - pemuatan terakhir gagal. {error}"

--- a/src/renderer/i18n/locales/id.json
+++ b/src/renderer/i18n/locales/id.json
@@ -3799,7 +3799,10 @@
     "usageBoundTitle": "Pemakaian {name}, akun proyek ini. Klik untuk menggantinya.",
     "usageDefaultTitle": "Pemakaian {name}, akun default. Klik untuk menetapkan akun bagi proyek ini.",
     "switchWhileRunningTitle": "Ada sesi berjalan",
-    "switchWhileRunning": "{count} sesi sudah berjalan untuk proyek ini dan tetap memakai akunnya. Perubahan berlaku untuk sesi berikutnya. Lanjutkan?"
+    "switchWhileRunning": "{count} sesi sudah berjalan untuk proyek ini dan tetap memakai akunnya. Perubahan berlaku untuk sesi berikutnya. Lanjutkan?",
+    "colorNone": "Tanpa warna",
+    "chooseForProjectTitle": "Akun Claude",
+    "chooseForProject": "Akun mana yang dipakai {project}? Bisa diubah nanti dari tabnya."
   },
   "usage": {
     "stale": "Data penggunaan mungkin sudah tidak terbaru - pemuatan terakhir gagal. {error}"

--- a/src/renderer/i18n/locales/id.json
+++ b/src/renderer/i18n/locales/id.json
@@ -3782,7 +3782,15 @@
     "switchError": "Gagal mengganti akun",
     "renameError": "Gagal mengganti nama akun",
     "removeError": "Gagal menghapus akun",
-    "captureError": "Gagal menyimpan akun saat ini"
+    "captureError": "Gagal menyimpan akun saat ini",
+    "isDefault": "Default",
+    "makeDefault": "Jadikan default",
+    "useDefault": "Akun default",
+    "useDefaultNamed": "Akun default ({name})",
+    "colorTitle": "Warna akun",
+    "colorError": "Gagal menyimpan warna akun",
+    "boundProjects": "{count} proyek",
+    "removeBlocked": "Masih dipakai {count} proyek: {projects}. Pindahkan ke akun lain dulu."
   },
   "usage": {
     "stale": "Data penggunaan mungkin sudah tidak terbaru - pemuatan terakhir gagal. {error}"

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -3795,7 +3795,11 @@
     "rebindScope": "仅 {project} 会切换，其他项目保持原有账户。",
     "rebindScopeDefault": "这将更改默认账户，供所有未单独指定账户的项目使用。",
     "limited": "已达上限",
-    "useForProject": "在此使用"
+    "useForProject": "在此使用",
+    "usageBoundTitle": "{name} 的用量，该项目所用账户。点击可更改。",
+    "usageDefaultTitle": "{name} 的用量，默认账户。点击可为该项目指定账户。",
+    "switchWhileRunningTitle": "有会话正在运行",
+    "switchWhileRunning": "该项目已有 {count} 个会话在运行，它们将保留当前账户。更改仅对之后启动的会话生效。是否继续？"
   },
   "usage": {
     "stale": "使用情况数据可能已过时 - 上次刷新失败。 {error}"

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -3790,7 +3790,12 @@
     "colorTitle": "账户颜色",
     "colorError": "无法保存账户颜色",
     "boundProjects": "{count} 个项目",
-    "removeBlocked": "仍有 {count} 个项目在使用：{projects}。请先将它们移到其他账户。"
+    "removeBlocked": "仍有 {count} 个项目在使用：{projects}。请先将它们移到其他账户。",
+    "rebindTitle": "为该项目使用其他账户",
+    "rebindScope": "仅 {project} 会切换，其他项目保持原有账户。",
+    "rebindScopeDefault": "这将更改默认账户，供所有未单独指定账户的项目使用。",
+    "limited": "已达上限",
+    "useForProject": "在此使用"
   },
   "usage": {
     "stale": "使用情况数据可能已过时 - 上次刷新失败。 {error}"

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -3782,7 +3782,15 @@
     "switchError": "切换账号失败",
     "renameError": "账户重命名失败",
     "removeError": "删除账户失败",
-    "captureError": "保存当前账户失败"
+    "captureError": "保存当前账户失败",
+    "isDefault": "默认",
+    "makeDefault": "设为默认",
+    "useDefault": "默认账户",
+    "useDefaultNamed": "默认账户（{name}）",
+    "colorTitle": "账户颜色",
+    "colorError": "无法保存账户颜色",
+    "boundProjects": "{count} 个项目",
+    "removeBlocked": "仍有 {count} 个项目在使用：{projects}。请先将它们移到其他账户。"
   },
   "usage": {
     "stale": "使用情况数据可能已过时 - 上次刷新失败。 {error}"

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -3799,7 +3799,10 @@
     "usageBoundTitle": "{name} 的用量，该项目所用账户。点击可更改。",
     "usageDefaultTitle": "{name} 的用量，默认账户。点击可为该项目指定账户。",
     "switchWhileRunningTitle": "有会话正在运行",
-    "switchWhileRunning": "该项目已有 {count} 个会话在运行，它们将保留当前账户。更改仅对之后启动的会话生效。是否继续？"
+    "switchWhileRunning": "该项目已有 {count} 个会话在运行，它们将保留当前账户。更改仅对之后启动的会话生效。是否继续？",
+    "colorNone": "无颜色",
+    "chooseForProjectTitle": "Claude 账户",
+    "chooseForProject": "{project} 使用哪个账户运行？之后可从其标签页更改。"
   },
   "usage": {
     "stale": "使用情况数据可能已过时 - 上次刷新失败。 {error}"

--- a/src/renderer/services/TerminalService.js
+++ b/src/renderer/services/TerminalService.js
@@ -65,6 +65,9 @@ async function createTerminal(project, { runClaude = true, resumeSessionId = nul
     cwd: project.path,
     runClaude,
     skipPermissions,
+    // Only an explicit binding is sent: unbound projects run against the
+    // machine-wide login, which is what keeps `claude /login` capturable.
+    accountId: require('../state').getProjectAccount(project.id),
     ...(resumeSessionId ? { resumeSessionId } : {})
   });
 

--- a/src/renderer/state/accounts.state.js
+++ b/src/renderer/state/accounts.state.js
@@ -101,6 +101,29 @@ function projectFollowsDefault(projectId) {
   return !getProjectAccount(projectId);
 }
 
+/**
+ * The account whose usage figures apply to a project, and whether it got there
+ * by falling back.
+ *
+ * An unbound project runs against the machine-wide store, so the honest answer
+ * is whichever account owns that store — `liveId` — not the default. The two
+ * normally agree, since setDefault writes the default into it; they diverge
+ * after a manual `claude /login`, and naming the default then would attribute
+ * the numbers to an account that did not produce them.
+ *
+ * @param {string|null} projectId
+ * @returns {{account: Object|null, isDefault: boolean}}
+ */
+function getUsageAccountForProject(projectId) {
+  const bound = projectId ? getProjectAccount(projectId) : null;
+  if (bound) {
+    const account = getAccount(bound);
+    if (account) return { account, isDefault: false };
+  }
+  const { liveId, defaultId } = accountsState.get();
+  return { account: getAccount(liveId) || getAccount(defaultId), isDefault: true };
+}
+
 function getAccounts() {
   return accountsState.get().accounts;
 }
@@ -117,5 +140,6 @@ module.exports = {
   getAccounts,
   getAccountForProject,
   getDefaultAccount,
-  projectFollowsDefault
+  projectFollowsDefault,
+  getUsageAccountForProject
 };

--- a/src/renderer/state/accounts.state.js
+++ b/src/renderer/state/accounts.state.js
@@ -1,0 +1,121 @@
+/**
+ * Accounts State Module
+ *
+ * A mirror of the main process account list, kept in the renderer so views can
+ * resolve a project's account synchronously. ProjectBar and ProjectList redraw
+ * on every terminal stat change; an IPC round-trip per tab to colour it would
+ * be a round-trip per tab per redraw.
+ *
+ * The main process owns the data — this module never writes it, it only asks
+ * for a refresh and republishes what comes back.
+ */
+
+const { State } = require('./State');
+const { getProjectAccount } = require('./projects.state');
+
+const initialState = {
+  accounts: [],
+  defaultId: null,   // Account used by projects with no binding of their own
+  liveId: null,      // Account owning the machine-wide store (`claude /login`)
+  hasCredentials: false,
+  loaded: false
+};
+
+const accountsState = new State(initialState);
+
+let _accountIndex = null;
+
+function _invalidateIndex() {
+  _accountIndex = null;
+}
+
+function _getAccountIndex() {
+  if (!_accountIndex) {
+    _accountIndex = new Map();
+    for (const a of accountsState.get().accounts) _accountIndex.set(a.id, a);
+  }
+  return _accountIndex;
+}
+
+const _origSet = accountsState.set.bind(accountsState);
+accountsState.set = function (patch) { _invalidateIndex(); _origSet(patch); };
+
+/**
+ * Pull the account list from the main process.
+ * @returns {Promise<void>}
+ */
+async function loadAccounts() {
+  const api = window.electron_api?.accounts;
+  if (!api) return;
+  try {
+    const res = await api.list();
+    if (!res?.success) return;
+    const { accounts = [], defaultId = null, liveId = null, hasCredentials = false } = res.data || {};
+    accountsState.set({ accounts, defaultId, liveId, hasCredentials, loaded: true });
+  } catch (_) {
+    // Leave the previous list in place: a blank one would silently repaint
+    // every tab as unbound.
+  }
+}
+
+/**
+ * Subscribe to main-process account changes. Returns the unsubscribe function.
+ * @returns {Function}
+ */
+function watchAccounts() {
+  const api = window.electron_api?.accounts;
+  if (!api?.onChanged) return () => {};
+  return api.onChanged((payload) => {
+    if (!payload) return loadAccounts();
+    const { accounts = [], defaultId = null, liveId = null, hasCredentials = false } = payload;
+    accountsState.set({ accounts, defaultId, liveId, hasCredentials, loaded: true });
+  });
+}
+
+/**
+ * @param {string|null} accountId
+ * @returns {Object|null}
+ */
+function getAccount(accountId) {
+  if (!accountId) return null;
+  return _getAccountIndex().get(accountId) || null;
+}
+
+/**
+ * The account a project actually runs as: its own binding, else the default.
+ * @param {string} projectId
+ * @returns {Object|null}
+ */
+function getAccountForProject(projectId) {
+  const bound = getProjectAccount(projectId);
+  return getAccount(bound) || getAccount(accountsState.get().defaultId);
+}
+
+/**
+ * Whether a project runs on the default account rather than one of its own.
+ * The tab renders the colour either way; the menu uses this for its checkmark.
+ * @param {string} projectId
+ * @returns {boolean}
+ */
+function projectFollowsDefault(projectId) {
+  return !getProjectAccount(projectId);
+}
+
+function getAccounts() {
+  return accountsState.get().accounts;
+}
+
+function getDefaultAccount() {
+  return getAccount(accountsState.get().defaultId);
+}
+
+module.exports = {
+  accountsState,
+  loadAccounts,
+  watchAccounts,
+  getAccount,
+  getAccounts,
+  getAccountForProject,
+  getDefaultAccount,
+  projectFollowsDefault
+};

--- a/src/renderer/state/index.js
+++ b/src/renderer/state/index.js
@@ -13,6 +13,7 @@ const settingsState = require('./settings.state');
 const timeTrackingState = require('./timeTracking.state');
 const databaseState = require('./database.state');
 const workspaceState = require('./workspace.state');
+const accountsState = require('./accounts.state');
 const errorLogState = require('./errorLog.state');
 
 // Quick picker state (simple, doesn't need a module)
@@ -61,6 +62,10 @@ async function initializeState() {
   const { loadAgents } = require('../services/AgentService');
   const { loadContextPacks, loadPromptTemplates } = require('../services/ContextPromptService');
   await workspaceState.loadWorkspaces();
+  // Project tabs colour themselves from the account list, so it has to be in
+  // place before the first render rather than fetched per tab.
+  await accountsState.loadAccounts();
+  accountsState.watchAccounts();
   Promise.all([loadSkills(), loadAgents(), loadContextPacks(), loadPromptTemplates()]).catch(e => {
     console.error('Error loading skills/agents/library:', e);
   });
@@ -97,6 +102,9 @@ module.exports = {
 
   // Workspaces
   ...workspaceState,
+
+  // Claude accounts
+  ...accountsState,
 
   // Error Log
   ...errorLogState,

--- a/src/renderer/state/projects.state.js
+++ b/src/renderer/state/projects.state.js
@@ -1458,6 +1458,42 @@ function getProjectEditor(projectId) {
   return project?.preferredEditor || null;
 }
 
+/**
+ * Pin a project to a Claude account. Every terminal and chat session started
+ * for it then authenticates as that account instead of the default one.
+ * @param {string} projectId
+ * @param {string|null} accountId - null to fall back to the default account
+ */
+function setProjectAccount(projectId, accountId) {
+  const state = projectsState.get();
+  const projects = state.projects.map(p =>
+    p.id === projectId ? { ...p, accountId: accountId || undefined } : p
+  );
+  projectsState.set({ projects });
+  saveProjects();
+}
+
+/**
+ * Get the account a project is pinned to.
+ * @param {string} projectId
+ * @returns {string|null} - Account id, or null when it follows the default
+ */
+function getProjectAccount(projectId) {
+  const project = getProject(projectId);
+  return project?.accountId || null;
+}
+
+/**
+ * Projects pinned to an account — used to block deleting an account that is
+ * still in use rather than silently moving its projects elsewhere.
+ * @param {string} accountId
+ * @returns {Array<Object>}
+ */
+function getProjectsForAccount(accountId) {
+  if (!accountId) return [];
+  return projectsState.get().projects.filter(p => p.accountId === accountId);
+}
+
 // ── Project Settings (per-project overrides) ──
 
 /**
@@ -1672,6 +1708,9 @@ module.exports = {
   // Editor per project
   setProjectEditor,
   getProjectEditor,
+  setProjectAccount,
+  getProjectAccount,
+  getProjectsForAccount,
   // Project settings (per-project overrides)
   getProjectSettings,
   setProjectSettings,

--- a/src/renderer/ui/components/AccountMenu.js
+++ b/src/renderer/ui/components/AccountMenu.js
@@ -10,13 +10,73 @@
 const { showContextMenu } = require('./ContextMenu');
 const { showConfirm } = require('./Modal');
 const { sanitizeColor } = require('../../utils/color');
+const { escapeHtml } = require('../../utils/dom');
 const { t } = require('../../i18n');
 const {
   getAccounts,
   getDefaultAccount,
+  getAccountForProject,
   projectFollowsDefault
 } = require('../../state/accounts.state');
 const { setProjectAccount, getProjectAccount } = require('../../state/projects.state');
+
+/**
+ * Account colours, sharing the Kanban label hues so the app keeps one palette.
+ * A fixed list rather than a full colour picker: these are tags to tell two or
+ * three accounts apart at a glance, not a design surface, and every value here
+ * is known to read against the dark theme.
+ */
+const ACCOUNT_COLORS = [
+  '#ef4444', '#f97316', '#eab308', '#22c55e',
+  '#3b82f6', '#8b5cf6', '#ec4899', '#6b7280'
+];
+
+/**
+ * Swatch grid for picking an account colour.
+ *
+ * @param {Object} opts
+ * @param {number} opts.x
+ * @param {number} opts.y
+ * @param {string|null} opts.current
+ * @param {Function} opts.onPick - called with a hex string, or null to clear
+ */
+function showAccountColorPicker({ x, y, current, onPick }) {
+  document.querySelectorAll('.account-color-popover').forEach(el => el.remove());
+
+  const popover = document.createElement('div');
+  popover.className = 'account-color-popover';
+
+  const safeCurrent = sanitizeColor(current);
+  popover.innerHTML = `
+    ${ACCOUNT_COLORS.map(c => `
+      <button type="button" class="account-color-swatch${c === safeCurrent ? ' selected' : ''}"
+              data-color="${c}" style="background:${c}" title="${c}"></button>
+    `).join('')}
+    <button type="button" class="account-color-swatch account-color-swatch--none${safeCurrent ? '' : ' selected'}"
+            data-color="" title="${escapeHtml(t('accounts.colorNone') || 'No colour')}"></button>
+  `;
+
+  document.body.appendChild(popover);
+  const rect = popover.getBoundingClientRect();
+  popover.style.left = `${Math.min(x, window.innerWidth - rect.width - 8)}px`;
+  popover.style.top = `${Math.min(y, window.innerHeight - rect.height - 8)}px`;
+
+  const close = () => {
+    popover.remove();
+    document.removeEventListener('click', onOutside, true);
+  };
+  const onOutside = (e) => { if (!popover.contains(e.target)) close(); };
+
+  popover.onclick = (e) => {
+    const swatch = e.target.closest('.account-color-swatch');
+    if (!swatch) return;
+    e.stopPropagation();
+    close();
+    onPick(swatch.dataset.color || null);
+  };
+
+  setTimeout(() => document.addEventListener('click', onOutside, true), 0);
+}
 
 /**
  * ContextMenu injects `icon` as raw HTML, so the colour goes through
@@ -95,6 +155,9 @@ function showProjectAccountMenu({ projectId, x, y, onPicked }) {
     if (await applyProjectAccount(projectId, accountId) && onPicked) onPicked(accountId);
   };
 
+  // Flat, unlike the project menu's side panel: this one is opened from the
+  // usage chip, which is already a statement of the current account — the list
+  // only has to offer the alternatives.
   const items = [{
     label: fallback
       ? t('accounts.useDefaultNamed', { name: fallback.name })
@@ -114,4 +177,10 @@ function showProjectAccountMenu({ projectId, x, y, onPicked }) {
   showContextMenu({ x, y, items, target: projectId });
 }
 
-module.exports = { showProjectAccountMenu, applyProjectAccount, liveSessionCount };
+module.exports = {
+  showProjectAccountMenu,
+  showAccountColorPicker,
+  applyProjectAccount,
+  liveSessionCount,
+  ACCOUNT_COLORS
+};

--- a/src/renderer/ui/components/AccountMenu.js
+++ b/src/renderer/ui/components/AccountMenu.js
@@ -1,0 +1,117 @@
+/**
+ * AccountMenu
+ *
+ * The "which Claude account does this project run as" picker, shared by the
+ * project tab's context menu and the usage bar. One builder rather than two:
+ * the guard below is the kind of thing that gets added to one entry point and
+ * forgotten in the other.
+ */
+
+const { showContextMenu } = require('./ContextMenu');
+const { showConfirm } = require('./Modal');
+const { sanitizeColor } = require('../../utils/color');
+const { t } = require('../../i18n');
+const {
+  getAccounts,
+  getDefaultAccount,
+  projectFollowsDefault
+} = require('../../state/accounts.state');
+const { setProjectAccount, getProjectAccount } = require('../../state/projects.state');
+
+/**
+ * ContextMenu injects `icon` as raw HTML, so the colour goes through
+ * sanitizeColor before it reaches a style attribute.
+ */
+function dot(color) {
+  const safe = sanitizeColor(color);
+  return safe
+    ? `<span class="context-menu-dot" style="background:${safe}"></span>`
+    : '<span class="context-menu-dot context-menu-dot--none"></span>';
+}
+
+/**
+ * Sessions already running for this project, which keep the account they
+ * started with.
+ * @param {string} projectId
+ * @returns {number}
+ */
+function liveSessionCount(projectId) {
+  try {
+    const { getProjectIndex, getTerminalsForProject } = require('../../state');
+    const index = getProjectIndex(projectId);
+    if (index === -1 || index === undefined || index === null) return 0;
+    return (getTerminalsForProject(index) || []).length;
+  } catch (_) {
+    return 0;
+  }
+}
+
+/**
+ * Apply a binding change, warning first when it cannot take effect yet.
+ *
+ * The account is resolved when a CLI is spawned, so a running session keeps
+ * the one it started with. Saying so beats letting the user believe a live
+ * session just moved — the same reason settings refuses to delete an account
+ * that projects still point at instead of silently re-homing them.
+ *
+ * @param {string} projectId
+ * @param {string|null} accountId
+ * @returns {Promise<boolean>} whether the binding was changed
+ */
+async function applyProjectAccount(projectId, accountId) {
+  const live = liveSessionCount(projectId);
+  if (live > 0) {
+    const ok = await showConfirm({
+      title: t('accounts.switchWhileRunningTitle') || 'Sessions are running',
+      message: t('accounts.switchWhileRunning', { count: live })
+    });
+    if (!ok) return false;
+  }
+  setProjectAccount(projectId, accountId);
+  return true;
+}
+
+/**
+ * Show the account picker for a project.
+ *
+ * A checkmark marks the current choice, and the first entry names the account
+ * the project falls back to — so the menu states what the project uses, not
+ * only what it overrides.
+ *
+ * @param {Object} opts
+ * @param {string} opts.projectId
+ * @param {number} opts.x
+ * @param {number} opts.y
+ * @param {Function} [opts.onPicked] - called with the chosen account id (or null)
+ */
+function showProjectAccountMenu({ projectId, x, y, onPicked }) {
+  const accounts = getAccounts();
+  if (!accounts.length) return;
+
+  const bound = getProjectAccount(projectId);
+  const fallback = getDefaultAccount();
+
+  const pick = async (accountId) => {
+    if (await applyProjectAccount(projectId, accountId) && onPicked) onPicked(accountId);
+  };
+
+  const items = [{
+    label: fallback
+      ? t('accounts.useDefaultNamed', { name: fallback.name })
+      : t('accounts.useDefault'),
+    icon: projectFollowsDefault(projectId) ? '&#10003;' : dot(fallback?.color),
+    onClick: () => pick(null),
+  }, { separator: true }];
+
+  for (const account of accounts) {
+    items.push({
+      label: account.name,
+      icon: bound === account.id ? '&#10003;' : dot(account.color),
+      onClick: () => pick(account.id),
+    });
+  }
+
+  showContextMenu({ x, y, items, target: projectId });
+}
+
+module.exports = { showProjectAccountMenu, applyProjectAccount, liveSessionCount };

--- a/src/renderer/ui/components/AccountSwitchModal.js
+++ b/src/renderer/ui/components/AccountSwitchModal.js
@@ -1,13 +1,20 @@
 /**
  * AccountSwitchModal
- * Prompts the user to switch the active Claude OAuth account when the
- * current one hits a usage / rate limit. Returns the chosen account id
- * (or null if the user cancelled / opened the terminal to /login).
+ *
+ * Offered when a session hits a usage / rate limit. Accounts are chosen per
+ * project, so the fix is to re-bind *this* project to another account rather
+ * than swap a global one out from under every other tab — which is what this
+ * used to do, and what would now interrupt work that had nothing to do with
+ * the limit.
+ *
+ * Returns the chosen account id, or null if the user cancelled.
  */
 
 const { createModal, showModal, closeModal, showPrompt } = require('./Modal');
 const { escapeHtml } = require('../../utils/dom');
+const { sanitizeColor } = require('../../utils/color');
 const { t } = require('../../i18n');
+const { setProjectAccount } = require('../../state/projects.state');
 
 function formatRelative(iso) {
   if (!iso) return '';
@@ -22,28 +29,38 @@ function formatRelative(iso) {
   return `${Math.round(hrs / 24)}d ago`;
 }
 
-function buildAccountRow(account, isActive) {
+function buildAccountRow(account, isLimited) {
   const lastUsed = account.lastUsedAt ? formatRelative(account.lastUsedAt) : '';
+  const color = sanitizeColor(account.color);
+  const dot = color
+    ? `<span class="account-row-dot" style="background:${color}"></span>`
+    : '<span class="account-row-dot account-row-dot--none"></span>';
   return `
-    <button class="account-row${isActive ? ' active' : ''}" data-id="${account.id}" ${isActive ? 'disabled' : ''}>
+    <button class="account-row${isLimited ? ' active' : ''}" data-id="${account.id}" ${isLimited ? 'disabled' : ''}>
+      ${dot}
       <div class="account-row-main">
         <div class="account-row-name">${escapeHtml(account.name)}</div>
         <div class="account-row-meta">${escapeHtml(account.fingerprint?.slice(0, 8) || '')}${lastUsed ? ` &middot; ${escapeHtml(lastUsed)}` : ''}</div>
       </div>
-      <div class="account-row-status">${isActive ? escapeHtml(t('accounts.active') || 'Active') : escapeHtml(t('accounts.switch') || 'Switch')}</div>
+      <div class="account-row-status">${isLimited ? escapeHtml(t('accounts.limited') || 'Limit reached') : escapeHtml(t('accounts.useForProject') || 'Use here')}</div>
     </button>
   `;
 }
 
 /**
- * Show the switch modal. Returns the id of the account the caller should
- * switch to, or null.
+ * Offer to move this project onto another account. Returns the chosen account
+ * id, or null.
  *
  * @param {Object} opts
  * @param {string} [opts.reason]            Reason text shown above the list.
- * @param {string} [opts.activeAccountId]   Currently active account id (will be flagged).
+ * @param {string} [opts.activeAccountId]   The account that hit the limit.
+ * @param {string} [opts.projectId]         Project to re-bind. Without it the
+ *                                          choice falls back to the default
+ *                                          account, since there is nothing to
+ *                                          pin the decision to.
+ * @param {string} [opts.projectName]
  */
-async function showAccountSwitchModal({ reason, activeAccountId } = {}) {
+async function showAccountSwitchModal({ reason, activeAccountId, projectId = null, projectName = '' } = {}) {
   const api = window.electron_api;
   const list = await api.accounts.list();
   if (!list.success) {
@@ -51,7 +68,11 @@ async function showAccountSwitchModal({ reason, activeAccountId } = {}) {
     return null;
   }
   const accounts = list.data.accounts || [];
-  const activeId = activeAccountId || list.data.activeId;
+  const limitedId = activeAccountId || list.data.defaultId;
+
+  const scopeHtml = projectId
+    ? `<div class="account-switch-scope">${escapeHtml(t('accounts.rebindScope', { project: projectName || projectId }))}</div>`
+    : `<div class="account-switch-scope">${escapeHtml(t('accounts.rebindScopeDefault') || 'This will change the default account.')}</div>`;
 
   const reasonHtml = reason
     ? `<div class="account-switch-reason">${escapeHtml(reason)}</div>`
@@ -64,7 +85,7 @@ async function showAccountSwitchModal({ reason, activeAccountId } = {}) {
   `;
 
   const listHtml = accounts.length
-    ? `<div class="account-switch-list">${accounts.map(a => buildAccountRow(a, a.id === activeId)).join('')}</div>`
+    ? `<div class="account-switch-list">${accounts.map(a => buildAccountRow(a, a.id === limitedId)).join('')}</div>`
     : emptyHint;
 
   return new Promise((resolve) => {
@@ -77,10 +98,13 @@ async function showAccountSwitchModal({ reason, activeAccountId } = {}) {
 
     const modal = createModal({
       id: 'account-switch-modal',
-      title: t('accounts.switchTitle') || 'Switch Claude account',
+      title: projectId
+        ? (t('accounts.rebindTitle') || 'Run this project on another account')
+        : (t('accounts.switchTitle') || 'Switch Claude account'),
       size: 'small',
       content: `
         ${reasonHtml}
+        ${scopeHtml}
         ${listHtml}
         <div class="account-switch-actions">
           <button class="btn btn-secondary" data-extra="capture">${escapeHtml(t('accounts.captureCurrent') || 'Save current as new account')}</button>
@@ -101,11 +125,18 @@ async function showAccountSwitchModal({ reason, activeAccountId } = {}) {
         if (row.disabled) return;
         const id = row.dataset.id;
         row.disabled = true;
-        const res = await api.accounts.switch(id);
-        if (!res.success) {
-          row.disabled = false;
-          alert(res.error || 'Switch failed');
-          return;
+        // Re-bind this project only. Every other tab keeps running on the
+        // account it was already using; nothing else is interrupted by a limit
+        // that was not theirs.
+        if (projectId) {
+          setProjectAccount(projectId, id);
+        } else {
+          const res = await api.accounts.setDefault(id);
+          if (!res.success) {
+            row.disabled = false;
+            alert(res.error || 'Switch failed');
+            return;
+          }
         }
         closeModal(modal);
         finish(id);
@@ -126,6 +157,9 @@ async function showAccountSwitchModal({ reason, activeAccountId } = {}) {
           alert(res.error || 'Capture failed');
           return;
         }
+        // A freshly captured account is only useful here if the project moves
+        // onto it — otherwise the limit stands and the session cannot resume.
+        if (projectId && res.data?.id) setProjectAccount(projectId, res.data.id);
         closeModal(modal);
         finish(res.data?.id || null);
       };

--- a/src/renderer/ui/components/ChatView.js
+++ b/src/renderer/ui/components/ChatView.js
@@ -19,7 +19,7 @@ const {
 } = require('../../utils/toolRegistry');
 const { t } = require('../../i18n');
 const { formatDuration: fmtDur } = require('../../utils/toolRegistry');
-const { heartbeat, skillsAgentsState } = require('../../state');
+const { heartbeat, skillsAgentsState, getProjectAccount } = require('../../state');
 const { createTranscriptPruner } = require('./TranscriptPruner');
 
 // ── Background task cards re-render on store update ─────────────────
@@ -3258,6 +3258,9 @@ class ChatView extends BaseComponent {
         const startOpts = {
           cwd: project.path,
           projectId: project.id,
+          // Only an explicit binding is sent: unbound projects run against the
+          // machine-wide login, which is what keeps `claude /login` capturable.
+          accountId: getProjectAccount(project.id),
           prompt: enhancedText || '',
           // skipPermissions (cloud tabs, quick actions, per-project override) forces full bypass.
           // Otherwise honor the global execution mode: 'auto' uses SDK classifier checks,

--- a/src/renderer/ui/components/ChatView.js
+++ b/src/renderer/ui/components/ChatView.js
@@ -7086,15 +7086,22 @@ class ChatView extends BaseComponent {
 
   // ── IPC: Usage / rate limit reached → propose account switch ──
 
-  const unsubAccountLimit = api.chat.onAccountLimit(async ({ sessionId: sid, error, activeAccountId }) => {
+  const unsubAccountLimit = api.chat.onAccountLimit(async ({ sessionId: sid, error, activeAccountId, projectId }) => {
     if (sid !== sessionId) return;
     if (switchingAccount) return;
     switchingAccount = true;
     try {
       const { showAccountSwitchModal } = require('./AccountSwitchModal');
+      // The modal re-binds this project rather than swapping a global account:
+      // a limit hit here is no reason to move every other tab.
+      const limitedProject = projectId
+        ? require('../../state').getProject(projectId)
+        : null;
       const newId = await showAccountSwitchModal({
         reason: error || t('accounts.limitReached') || 'Usage limit reached on the active account.',
-        activeAccountId
+        activeAccountId,
+        projectId: projectId || null,
+        projectName: limitedProject?.name || ''
       });
       if (!newId) {
         appendError(error || t('chat.errorOccurred'));
@@ -7112,7 +7119,9 @@ class ChatView extends BaseComponent {
         sessionId = null;
         return;
       }
-      const restartOpts = { ...lastStartOpts, prompt: '', resumeSessionId: sessionId };
+      // The binding is read at spawn time, so the restart has to carry the new
+      // account explicitly — lastStartOpts still holds the one that ran out.
+      const restartOpts = { ...lastStartOpts, accountId: newId, prompt: '', resumeSessionId: sessionId };
       appendSystemNotice(t('accounts.switched') || 'Account switched. Resuming…', 'info');
       setStreaming(true);
       appendThinkingIndicator();

--- a/src/renderer/ui/components/ProjectBar.js
+++ b/src/renderer/ui/components/ProjectBar.js
@@ -27,15 +27,8 @@ const {
   isPathMissing,
 } = require('../../state');
 const { getWorkspacesForProject } = require('../../state/workspace.state');
-const {
-  accountsState,
-  getAccounts,
-  getAccountForProject,
-  getDefaultAccount,
-  projectFollowsDefault,
-} = require('../../state/accounts.state');
-const { setProjectAccount, getProjectAccount } = require('../../state/projects.state');
-const { showContextMenu } = require('./ContextMenu');
+const { accountsState, getAccountForProject } = require('../../state/accounts.state');
+const { showProjectAccountMenu } = require('./AccountMenu');
 const { escapeHtml, sanitizeColor } = require('../../utils');
 const { t } = require('../../i18n');
 
@@ -225,44 +218,11 @@ class ProjectBar extends BaseComponent {
   }
 
   /**
-   * Which Claude account this project runs as, and how to change it.
-   *
-   * Mirrors the per-project editor picker: a checkmark on the current choice
-   * and a "default" entry naming the account it resolves to, so the menu says
-   * what the project uses rather than only what it overrides.
+   * Which Claude account this project runs as, and how to change it. Shared
+   * with the usage bar so both entry points warn about running sessions.
    */
   _showAccountMenu(project, x, y) {
-    const accounts = getAccounts();
-    if (!accounts.length) return;
-
-    // ContextMenu injects `icon` as raw HTML, so the colour goes through
-    // sanitizeColor before it reaches a style attribute.
-    const dot = (color) => {
-      const safe = sanitizeColor(color);
-      return safe
-        ? `<span class="context-menu-dot" style="background:${safe}"></span>`
-        : '<span class="context-menu-dot context-menu-dot--none"></span>';
-    };
-
-    const bound = getProjectAccount(project.id);
-    const fallback = getDefaultAccount();
-    const items = [{
-      label: fallback
-        ? t('accounts.useDefaultNamed', { name: fallback.name })
-        : t('accounts.useDefault'),
-      icon: projectFollowsDefault(project.id) ? '&#10003;' : dot(fallback?.color),
-      onClick: () => setProjectAccount(project.id, null),
-    }, { separator: true }];
-
-    for (const account of accounts) {
-      items.push({
-        label: account.name,
-        icon: bound === account.id ? '&#10003;' : dot(account.color),
-        onClick: () => setProjectAccount(project.id, account.id),
-      });
-    }
-
-    showContextMenu({ x, y, items, target: project });
+    showProjectAccountMenu({ projectId: project.id, x, y });
   }
 
   _select(projectId) {

--- a/src/renderer/ui/components/ProjectBar.js
+++ b/src/renderer/ui/components/ProjectBar.js
@@ -27,6 +27,15 @@ const {
   isPathMissing,
 } = require('../../state');
 const { getWorkspacesForProject } = require('../../state/workspace.state');
+const {
+  accountsState,
+  getAccounts,
+  getAccountForProject,
+  getDefaultAccount,
+  projectFollowsDefault,
+} = require('../../state/accounts.state');
+const { setProjectAccount, getProjectAccount } = require('../../state/projects.state');
+const { showContextMenu } = require('./ContextMenu');
 const { escapeHtml, sanitizeColor } = require('../../utils');
 const { t } = require('../../i18n');
 
@@ -97,6 +106,9 @@ class ProjectBar extends BaseComponent {
     // Session count and its "working" state are on the tabs, so terminal
     // changes have to repaint the bar too.
     this.subscribe(terminalsState, () => this.render());
+    // Tabs are tinted by their account, so a colour or default change has to
+    // repaint the bar too.
+    this.subscribe(accountsState, () => this.render());
     this.render();
   }
 
@@ -138,6 +150,13 @@ class ProjectBar extends BaseComponent {
   }
 
   _renderTabHtml(project, isActive) {
+    // The account colour drives a CSS custom property rather than an inline
+    // background, so projects.css owns how strong the tint is and the active
+    // state stays distinguishable. project.color is a separate thing — the
+    // user's own dot, left where it was.
+    const accountColor = sanitizeColor(getAccountForProject(project.id)?.color);
+    const accountStyle = accountColor ? ` style="--account-color:${accountColor}"` : '';
+
     const color = sanitizeColor(project.color);
     const colorDot = color
       ? `<span class="project-tab-color" style="background:${color}"></span>`
@@ -163,7 +182,7 @@ class ProjectBar extends BaseComponent {
       ? `<span class="project-tab-missing" title="${escapeHtml(t('projects.pathMissingTitle'))}">!</span>`
       : '';
 
-    return `<div class="project-tab${isActive ? ' active' : ''}" data-project-id="${escapeHtml(project.id)}" role="tab" aria-selected="${isActive}" tabindex="${isActive ? '0' : '-1'}" draggable="true" title="${escapeHtml(project.path || project.name)}">
+    return `<div class="project-tab${isActive ? ' active' : ''}${accountColor ? ' has-account' : ''}"${accountStyle} data-project-id="${escapeHtml(project.id)}" role="tab" aria-selected="${isActive}" tabindex="${isActive ? '0' : '-1'}" draggable="true" title="${escapeHtml(project.path || project.name)}">
       ${colorDot}
       <span class="project-tab-icon">${icon}${workspaceBadge}</span>
       <span class="project-tab-name">${escapeHtml(project.name)}</span>
@@ -197,9 +216,53 @@ class ProjectBar extends BaseComponent {
     if (!tab) return;
     e.preventDefault();
     const project = getProject(tab.dataset.projectId);
-    if (project && this._callbacks.onContextMenu) {
+    if (!project) return;
+    if (this._callbacks.onContextMenu) {
       this._callbacks.onContextMenu(project, e.clientX, e.clientY);
+      return;
     }
+    this._showAccountMenu(project, e.clientX, e.clientY);
+  }
+
+  /**
+   * Which Claude account this project runs as, and how to change it.
+   *
+   * Mirrors the per-project editor picker: a checkmark on the current choice
+   * and a "default" entry naming the account it resolves to, so the menu says
+   * what the project uses rather than only what it overrides.
+   */
+  _showAccountMenu(project, x, y) {
+    const accounts = getAccounts();
+    if (!accounts.length) return;
+
+    // ContextMenu injects `icon` as raw HTML, so the colour goes through
+    // sanitizeColor before it reaches a style attribute.
+    const dot = (color) => {
+      const safe = sanitizeColor(color);
+      return safe
+        ? `<span class="context-menu-dot" style="background:${safe}"></span>`
+        : '<span class="context-menu-dot context-menu-dot--none"></span>';
+    };
+
+    const bound = getProjectAccount(project.id);
+    const fallback = getDefaultAccount();
+    const items = [{
+      label: fallback
+        ? t('accounts.useDefaultNamed', { name: fallback.name })
+        : t('accounts.useDefault'),
+      icon: projectFollowsDefault(project.id) ? '&#10003;' : dot(fallback?.color),
+      onClick: () => setProjectAccount(project.id, null),
+    }, { separator: true }];
+
+    for (const account of accounts) {
+      items.push({
+        label: account.name,
+        icon: bound === account.id ? '&#10003;' : dot(account.color),
+        onClick: () => setProjectAccount(project.id, account.id),
+      });
+    }
+
+    showContextMenu({ x, y, items, target: project });
   }
 
   _select(projectId) {

--- a/src/renderer/ui/components/ProjectBar.js
+++ b/src/renderer/ui/components/ProjectBar.js
@@ -218,11 +218,13 @@ class ProjectBar extends BaseComponent {
   }
 
   /**
-   * Which Claude account this project runs as, and how to change it. Shared
-   * with the usage bar so both entry points warn about running sessions.
+   * The project's normal actions menu — the same one the sidebar's "…" opens,
+   * account row included. A dedicated account popup made right-click mean
+   * something different here than everywhere else the project appears.
    */
   _showAccountMenu(project, x, y) {
-    showProjectAccountMenu({ projectId: project.id, x, y });
+    // Lazy: ProjectList pulls in the whole sidebar, and the bar renders first.
+    require('./ProjectList').openActionsMenu(project.id, x, y);
   }
 
   _select(projectId) {

--- a/src/renderer/ui/components/ProjectList.js
+++ b/src/renderer/ui/components/ProjectList.js
@@ -223,6 +223,42 @@ class ProjectList extends BaseComponent {
       const btn = e.target.closest('button');
       if (!btn) return;
       e.stopPropagation();
+      // Opens a panel to the side of the row rather than pushing the menu
+      // open: the menu keeps its shape, and the row it belongs to stays put
+      // and visible while you choose.
+      if (btn.classList.contains('btn-project-account')) {
+        if (document.getElementById('project-account-submenu')) {
+          document.getElementById('project-account-submenu').remove();
+          btn.classList.remove('expanded');
+          return;
+        }
+        const sub = document.createElement('div');
+        sub.id = 'project-account-submenu';
+        sub.className = 'more-actions-menu active project-account-submenu';
+        sub.innerHTML = self._buildAccountOptionsHtml(project);
+        document.body.appendChild(sub);
+
+        const menuRect = menu.getBoundingClientRect();
+        const rowRect = btn.getBoundingClientRect();
+        const subRect = sub.getBoundingClientRect();
+        // Flip to the left when there is no room: the menu is often opened
+        // near the right edge, from the project bar.
+        const flip = menuRect.right + subRect.width > window.innerWidth - 4;
+        sub.style.left = `${flip ? Math.max(4, menuRect.left - subRect.width + 2) : menuRect.right - 2}px`;
+        sub.style.top = `${Math.max(4, Math.min(rowRect.top - 4, window.innerHeight - subRect.height - 4))}px`;
+
+        sub.onclick = (ev) => {
+          const option = ev.target.closest('.btn-project-account-option');
+          if (!option) return;
+          ev.stopPropagation();
+          const accountId = option.dataset.accountId || null;
+          self.closeAllMoreActionsMenus();
+          require('./AccountMenu').applyProjectAccount(project.id, accountId);
+        };
+
+        btn.classList.add('expanded');
+        return;
+      }
       if (btn.dataset.extraAction) {
         self.closeAllMoreActionsMenus();
         opts.onExtraAction?.(btn.dataset.extraAction);
@@ -253,6 +289,9 @@ class ProjectList extends BaseComponent {
   }
 
   closeAllMoreActionsMenus() {
+    // The account panel hangs off the menu but lives on <body>, so closing the
+    // menu has to take it down too or it is left floating on its own.
+    document.getElementById('project-account-submenu')?.remove();
     document.querySelectorAll('.more-actions-menu.active').forEach(menu => menu.classList.remove('active'));
     if (this._moreActionsCloseHandler) {
       document.removeEventListener('click', this._moreActionsCloseHandler, true);
@@ -376,6 +415,40 @@ class ProjectList extends BaseComponent {
    * @param {Object} project
    * @returns {string} menu items HTML
    */
+  /**
+   * The account choices shown when the menu's account row is expanded, each
+   * with its colour dot so a row is recognisable as the account tinting the
+   * project's tab. A checkmark marks the current choice.
+   * @param {Object} project
+   * @returns {string}
+   */
+  _buildAccountOptionsHtml(project) {
+    const {
+      getAccounts, getDefaultAccount, projectFollowsDefault
+    } = require('../../state/accounts.state');
+    const { getProjectAccount } = require('../../state/projects.state');
+
+    const bound = getProjectAccount(project.id);
+    const fallback = getDefaultAccount();
+    const row = (label, color, selected, accountId) => {
+      const safe = sanitizeColor(color);
+      return `
+      <button class="more-actions-item btn-project-account-option${selected ? ' selected' : ''}"
+              data-account-id="${escapeHtml(accountId || '')}">
+        <span class="account-menu-dot"${safe ? ` style="background: ${safe}"` : ''}></span>
+        ${escapeHtml(label)}
+        ${selected ? '<span class="account-option-check">&#10003;</span>' : ''}
+      </button>`;
+    };
+
+    return row(
+      fallback ? t('accounts.useDefaultNamed', { name: fallback.name }) : (t('accounts.useDefault') || 'Default account'),
+      fallback?.color,
+      projectFollowsDefault(project.id),
+      null
+    ) + getAccounts().map(a => row(a.name, a.color, bound === a.id, a.id)).join('');
+  }
+
   _buildMenuItemsHtml(project) {
     const projectIndex = getProjectIndex(project.id);
     const typeHandler = registry.get(project.type);
@@ -402,6 +475,26 @@ class ProjectList extends BaseComponent {
         ${t('projects.locatePath')}
       </button>`;
     }
+    // Which Claude account this project runs as. Listed with the project's own
+    // settings rather than under an action group: it is a property of the
+    // project, not something you do to it.
+    try {
+      const { getAccounts, getAccountForProject } = require('../../state/accounts.state');
+      if (getAccounts().length > 1) {
+        const account = getAccountForProject(project.id);
+        const accountColor = sanitizeColor(account?.color);
+        menuItemsHtml += `
+      <div class="more-actions-section-label">${escapeHtml(t('accounts.chooseForProjectTitle') || 'Claude account')}</div>
+      <button class="more-actions-item btn-project-account" data-project-id="${escapeHtml(project.id)}">
+        <span class="account-menu-dot"${accountColor ? ` style="background: ${accountColor}"` : ''}></span>
+        ${escapeHtml(account?.name || t('accounts.useDefault') || 'Default account')}
+        <span class="more-actions-chevron">&#8250;</span>
+      </button>`;
+      }
+    } catch (_) {
+      // Accounts unavailable — the menu simply does not offer the choice.
+    }
+
     const typeMenuItems = typeHandler.getMenuItems ? typeHandler.getMenuItems(typeCtx) : '';
     if (typeMenuItems) {
       menuItemsHtml += typeMenuItems;
@@ -1166,6 +1259,17 @@ class ProjectList extends BaseComponent {
         };
         setTimeout(() => document.addEventListener('click', closeMenu, true), 0);
         return;
+      }
+
+      // Right-clicking the row itself picks the Claude account it runs as —
+      // the same menu the project tab offers, so the choice is reachable from
+      // wherever the project is on screen.
+      // Right-clicking a row opens the same actions menu as its "…" button,
+      // so the project offers one menu wherever it is on screen.
+      const projectRow = e.target.closest('.project-item[data-project-id]');
+      if (projectRow) {
+        e.preventDefault();
+        self.openActionsMenu(projectRow.dataset.projectId, e.clientX, e.clientY);
       }
     };
 

--- a/src/renderer/ui/panels/SettingsPanel.js
+++ b/src/renderer/ui/panels/SettingsPanel.js
@@ -12,6 +12,7 @@ const { t, setLanguage, getCurrentLanguage, getAvailableLanguages } = require('.
 // ── Module-level constants ──
 
 const { BUILTIN_TOOLS } = require('../../utils/toolRegistry');
+const { getProjectsForAccount } = require('../../state/projects.state');
 
 // ── Module-level pure helpers ──
 
@@ -2139,7 +2140,7 @@ class SettingsPanel extends BasePanel {
         listEl.innerHTML = `<div class="settings-desc" style="padding: 12px 16px; color: var(--danger);">${escapeHtml(res.error || 'Failed to load accounts')}</div>`;
         return;
       }
-      const { accounts, activeId, hasCredentials } = res.data;
+      const { accounts, defaultId, hasCredentials } = res.data;
       if (!accounts.length) {
         listEl.innerHTML = `
           <div class="settings-desc" style="padding: 12px 16px;">
@@ -2148,21 +2149,29 @@ class SettingsPanel extends BasePanel {
         if (captureBtn) captureBtn.disabled = !hasCredentials;
         return;
       }
-      listEl.innerHTML = accounts.map(a => `
-        <div class="account-row${a.id === activeId ? ' active' : ''}" data-id="${a.id}">
+      const { sanitizeColor } = require('../../utils');
+      listEl.innerHTML = accounts.map(a => {
+        const color = sanitizeColor(a.color);
+        const bound = getProjectsForAccount(a.id);
+        return `
+        <div class="account-row${a.id === defaultId ? ' active' : ''}" data-id="${a.id}">
+          <input type="color" class="account-row-color" data-action="color" data-id="${a.id}"
+                 value="${color || '#888888'}"
+                 title="${escapeHtml(t('accounts.colorTitle') || 'Account colour')}"
+                 aria-label="${escapeHtml(t('accounts.colorTitle') || 'Account colour')}">
           <div class="account-row-main">
             <div class="account-row-name">${escapeHtml(a.name)}</div>
-            <div class="account-row-meta">${escapeHtml((a.fingerprint || '').slice(0, 8))}${a.lastUsedAt ? ` &middot; ${escapeHtml(new Date(a.lastUsedAt).toLocaleString())}` : ''}</div>
+            <div class="account-row-meta">${escapeHtml((a.fingerprint || '').slice(0, 8))}${bound.length ? ` &middot; ${escapeHtml(t('accounts.boundProjects', { count: bound.length }))}` : ''}</div>
           </div>
           <div class="account-row-buttons">
-            ${a.id === activeId
-              ? `<span class="account-row-status">${escapeHtml(t('accounts.active') || 'Active')}</span>`
-              : `<button class="btn btn-secondary btn-sm" data-action="switch" data-id="${a.id}">${escapeHtml(t('accounts.switch') || 'Switch')}</button>`}
+            ${a.id === defaultId
+              ? `<span class="account-row-status">${escapeHtml(t('accounts.isDefault') || 'Default')}</span>`
+              : `<button class="btn btn-secondary btn-sm" data-action="set-default" data-id="${a.id}">${escapeHtml(t('accounts.makeDefault') || 'Make default')}</button>`}
             <button class="btn btn-secondary btn-sm" data-action="rename" data-id="${a.id}">${escapeHtml(t('common.rename') || 'Rename')}</button>
             <button class="btn btn-secondary btn-sm" data-action="remove" data-id="${a.id}">${escapeHtml(t('common.delete') || 'Delete')}</button>
           </div>
-        </div>
-      `).join('');
+        </div>`;
+      }).join('');
       if (captureBtn) captureBtn.disabled = !hasCredentials;
     };
 
@@ -2172,10 +2181,10 @@ class SettingsPanel extends BasePanel {
       const action = btn.dataset.action;
       const id = btn.dataset.id;
       const { showError } = require('../components/Toast');
-      if (action === 'switch') {
+      if (action === 'set-default') {
         btn.disabled = true;
         try {
-          const r = await this.api.accounts.switch(id);
+          const r = await this.api.accounts.setDefault(id);
           if (!r?.success) {
             showError(r?.error || t('accounts.switchError'), 5000);
             return;
@@ -2206,6 +2215,17 @@ class SettingsPanel extends BasePanel {
           showError(err?.message || t('accounts.renameError'), 5000);
         }
       } else if (action === 'remove') {
+        // Refuse while projects still run as this account: silently dropping
+        // them onto another one is the last thing you want with billing
+        // attached. The user unbinds them first, from the tab menu.
+        const bound = getProjectsForAccount(id);
+        if (bound.length) {
+          showError(t('accounts.removeBlocked', {
+            count: bound.length,
+            projects: bound.map(p => p.name).join(', ')
+          }), 8000);
+          return;
+        }
         const { showConfirm } = require('../components/Modal');
         const ok = await showConfirm({
           title: t('common.delete') || 'Delete',
@@ -2222,6 +2242,21 @@ class SettingsPanel extends BasePanel {
         } catch (err) {
           showError(err?.message || t('accounts.removeError'), 5000);
         }
+      }
+    };
+
+    // The colour swatch is an <input>, so it never reaches the click handler
+    // above. `change` rather than `input`: the native picker fires continuously
+    // while dragging, and each event is an IPC write plus a broadcast.
+    listEl.onchange = async (e) => {
+      const input = e.target.closest('input[data-action="color"]');
+      if (!input) return;
+      const { showError } = require('../components/Toast');
+      try {
+        const r = await this.api.accounts.setColor(input.dataset.id, input.value);
+        if (!r?.success) showError(r?.error || t('accounts.colorError'), 5000);
+      } catch (err) {
+        showError(err?.message || t('accounts.colorError'), 5000);
       }
     };
 

--- a/src/renderer/ui/panels/SettingsPanel.js
+++ b/src/renderer/ui/panels/SettingsPanel.js
@@ -2155,10 +2155,11 @@ class SettingsPanel extends BasePanel {
         const bound = getProjectsForAccount(a.id);
         return `
         <div class="account-row${a.id === defaultId ? ' active' : ''}" data-id="${a.id}">
-          <input type="color" class="account-row-color" data-action="color" data-id="${a.id}"
-                 value="${color || '#888888'}"
-                 title="${escapeHtml(t('accounts.colorTitle') || 'Account colour')}"
-                 aria-label="${escapeHtml(t('accounts.colorTitle') || 'Account colour')}">
+          <button type="button" class="account-row-color${color ? '' : ' account-row-color--none'}"
+                  data-action="color" data-id="${a.id}" data-color="${color || ''}"
+                  ${color ? `style="background:${color}"` : ''}
+                  title="${escapeHtml(t('accounts.colorTitle') || 'Account colour')}"
+                  aria-label="${escapeHtml(t('accounts.colorTitle') || 'Account colour')}"></button>
           <div class="account-row-main">
             <div class="account-row-name">${escapeHtml(a.name)}</div>
             <div class="account-row-meta">${escapeHtml((a.fingerprint || '').slice(0, 8))}${bound.length ? ` &middot; ${escapeHtml(t('accounts.boundProjects', { count: bound.length }))}` : ''}</div>
@@ -2181,7 +2182,35 @@ class SettingsPanel extends BasePanel {
       const action = btn.dataset.action;
       const id = btn.dataset.id;
       const { showError } = require('../components/Toast');
-      if (action === 'set-default') {
+      if (action === 'color') {
+        // A fixed palette rather than the native picker: these are tags to tell
+        // accounts apart, and every preset is known to read on the dark theme.
+        const { showAccountColorPicker } = require('../components/AccountMenu');
+        const rect = btn.getBoundingClientRect();
+        // From the attribute, not style.background: the browser normalises the
+        // latter to rgb(), which would never match a hex preset.
+        const current = btn.dataset.color || null;
+        showAccountColorPicker({
+          x: rect.left,
+          y: rect.bottom + 4,
+          current,
+          onPick: async (hex) => {
+            // Paint the swatch straight away. The row is rebuilt when the
+            // accounts-changed broadcast lands, but that is a main-process
+            // round-trip: without this the colour you just picked appears to
+            // do nothing.
+            btn.dataset.color = hex || '';
+            btn.style.background = hex || '';
+            btn.classList.toggle('account-row-color--none', !hex);
+            try {
+              const r = await this.api.accounts.setColor(id, hex);
+              if (!r?.success) showError(r?.error || t('accounts.colorError'), 5000);
+            } catch (err) {
+              showError(err?.message || t('accounts.colorError'), 5000);
+            }
+          }
+        });
+      } else if (action === 'set-default') {
         btn.disabled = true;
         try {
           const r = await this.api.accounts.setDefault(id);
@@ -2242,21 +2271,6 @@ class SettingsPanel extends BasePanel {
         } catch (err) {
           showError(err?.message || t('accounts.removeError'), 5000);
         }
-      }
-    };
-
-    // The colour swatch is an <input>, so it never reaches the click handler
-    // above. `change` rather than `input`: the native picker fires continuously
-    // while dragging, and each event is an IPC write plus a broadcast.
-    listEl.onchange = async (e) => {
-      const input = e.target.closest('input[data-action="color"]');
-      if (!input) return;
-      const { showError } = require('../components/Toast');
-      try {
-        const r = await this.api.accounts.setColor(input.dataset.id, input.value);
-        if (!r?.success) showError(r?.error || t('accounts.colorError'), 5000);
-      } catch (err) {
-        showError(err?.message || t('accounts.colorError'), 5000);
       }
     };
 

--- a/styles/fivem.css
+++ b/styles/fivem.css
@@ -331,6 +331,73 @@
   box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.15);
 }
 
+/* Account picker. A native <select> is not usable here: macOS draws its popup
+   itself and ignores option styling, so the colour dot would be lost. This is a
+   button plus a panel, wearing .wizard-input so it matches the fields above. */
+.wizard-account-field {
+  position: relative;
+}
+
+.wizard-account-btn {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  text-align: left;
+  cursor: pointer;
+  padding-right: 38px;
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23888' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 14px center;
+  background-size: 12px 12px;
+}
+
+.wizard-account-dot {
+  flex: 0 0 auto;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--text-muted);
+}
+
+.wizard-account-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wizard-account-panel {
+  position: absolute;
+  z-index: 20;
+  left: 0;
+  right: 0;
+  margin-top: 4px;
+  padding: 4px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+}
+
+.wizard-account-option {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  padding: 8px 10px;
+  border: none;
+  border-radius: 5px;
+  background: none;
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.wizard-account-option:hover {
+  background: var(--bg-hover);
+}
+
 .wizard-input:hover {
   border-color: color-mix(in srgb, var(--text-muted) 30%, transparent);
 }

--- a/styles/layout.css
+++ b/styles/layout.css
@@ -133,27 +133,47 @@ body.platform-darwin .titlebar-drag {
    the bars follow the active tab. Tinted with the account colour so it ties
    back to the project tab carrying the same one. Hidden when no project is
    bound: the titlebar then means what it always did. */
+/* The button stretches to the strip's full height and centres the pill inside
+   it, so the pill's midline matches the buckets' whatever drives the strip
+   height. Aligning the pill itself against the container left it sitting high. */
 .usage-account {
   display: flex;
   align-items: center;
-  align-self: center;
-  gap: 4px;
-  max-width: 120px;
-  padding: 2px 8px;
+  align-self: stretch;
+  margin: 0 10px 0 0;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.usage-account-pill {
+  display: block;
+  /* Aligned on the labels, not on the strip's midline. Each bucket puts a 3px
+     gap and a 3px bar under its label, so the label sits 3px above the block's
+     centre — and a pill centred on the block reads as sitting too low next to
+     SESSION. Shifting by exactly that offset lines the two texts up. */
+  transform: translateY(-3px);
+  max-width: 130px;
+  padding: 3px 9px;
   border-radius: 999px;
   border: 1px solid color-mix(in srgb, var(--account-color) 45%, transparent);
   background: color-mix(in srgb, var(--account-color) 16%, transparent);
   color: var(--text-primary);
-  font-size: var(--font-2xs);
-  font-family: inherit;
+  /* Matched to .usage-label rather than a token: the pill sits in the same row
+     as SESSION / SEMAINE and has to read as one of them, not as a control. */
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.8px;
+  line-height: 1.4;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  cursor: pointer;
   transition: background 0.15s, border-color 0.15s;
 }
 
-.usage-account:hover:not(:disabled) {
+.usage-account:hover:not(:disabled) .usage-account-pill {
   background: color-mix(in srgb, var(--account-color) 28%, transparent);
   border-color: var(--account-color);
 }
@@ -165,7 +185,7 @@ body.platform-darwin .titlebar-drag {
 /* Running on the default rather than a binding of its own: dashed, and dimmed,
    so "this project has not chosen" reads differently from "this project runs
    on X" without hiding which account the figures belong to. */
-.usage-account--default {
+.usage-account--default .usage-account-pill {
   border-style: dashed;
   color: var(--text-secondary);
   background: color-mix(in srgb, var(--account-color) 8%, transparent);

--- a/styles/layout.css
+++ b/styles/layout.css
@@ -145,9 +145,30 @@ body.platform-darwin .titlebar-drag {
   background: color-mix(in srgb, var(--account-color) 16%, transparent);
   color: var(--text-primary);
   font-size: var(--font-2xs);
+  font-family: inherit;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.usage-account:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--account-color) 28%, transparent);
+  border-color: var(--account-color);
+}
+
+.usage-account:disabled {
+  cursor: default;
+}
+
+/* Running on the default rather than a binding of its own: dashed, and dimmed,
+   so "this project has not chosen" reads differently from "this project runs
+   on X" without hiding which account the figures belong to. */
+.usage-account--default {
+  border-style: dashed;
+  color: var(--text-secondary);
+  background: color-mix(in srgb, var(--account-color) 8%, transparent);
 }
 
 /* ── Usage Item ── */

--- a/styles/layout.css
+++ b/styles/layout.css
@@ -128,6 +128,28 @@ body.platform-darwin .titlebar-drag {
   50% { opacity: 0.4; }
 }
 
+/* ── Usage account ──
+   Names the account the figures belong to, since projects pick their own and
+   the bars follow the active tab. Tinted with the account colour so it ties
+   back to the project tab carrying the same one. Hidden when no project is
+   bound: the titlebar then means what it always did. */
+.usage-account {
+  display: flex;
+  align-items: center;
+  align-self: center;
+  gap: 4px;
+  max-width: 120px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--account-color) 45%, transparent);
+  background: color-mix(in srgb, var(--account-color) 16%, transparent);
+  color: var(--text-primary);
+  font-size: var(--font-2xs);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 /* ── Usage Item ── */
 .usage-item {
   display: flex;

--- a/styles/modals.css
+++ b/styles/modals.css
@@ -2227,11 +2227,37 @@ mark.qp-hl {
   line-height: 1.5;
 }
 
+/* States plainly what the choice touches. The old modal swapped a global
+   account without saying so; now that only this project moves, saying which
+   one is the difference between an informed click and a guess. */
+.account-switch-scope {
+  font-size: var(--font-xs);
+  color: var(--text-muted);
+  padding: 0 2px;
+  margin-bottom: 10px;
+  line-height: 1.5;
+}
+
 .account-switch-list {
   display: flex;
   flex-direction: column;
   gap: 6px;
   margin-bottom: 12px;
+}
+
+/* Same swatch as the project tab tint, so a row is recognisable as the
+   account colouring the tab it will move. */
+.account-switch-list .account-row-dot {
+  flex: 0 0 auto;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  margin-right: 8px;
+}
+
+.account-switch-list .account-row-dot--none {
+  border: 1px solid var(--border-color);
+  background: transparent;
 }
 
 .account-switch-list .account-row {

--- a/styles/projects.css
+++ b/styles/projects.css
@@ -2294,6 +2294,48 @@ body.compact-projects .project-item:not(.active):hover {
   transform: scale(1) translateY(0);
 }
 
+/* Account colour dot in the actions menu. Its own class rather than the
+   customize badge, which is absolutely positioned to sit on the corner of a
+   preview and lands nowhere useful on its own. */
+.account-menu-dot {
+  flex: 0 0 auto;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.35);
+}
+
+/* Account row in the project actions menu: expands in place rather than
+   opening a second floating panel over the first. */
+.more-actions-chevron {
+  margin-left: auto;
+  padding-left: 10px;
+  color: var(--text-muted);
+  transition: transform 0.15s ease;
+}
+
+.more-actions-item.expanded .more-actions-chevron {
+  color: var(--text-primary);
+}
+
+/* Account panel: positioned in JS beside the row it belongs to, so the menu
+   keeps its shape instead of growing under the cursor. */
+.project-account-submenu {
+  position: fixed;
+  z-index: 10001;
+  min-width: 200px;
+}
+
+.btn-project-account-option.selected {
+  color: var(--accent);
+}
+
+.account-option-check {
+  margin-left: auto;
+  padding-left: 10px;
+}
+
 /* Items */
 .context-menu-item {
   display: flex;

--- a/styles/projects.css
+++ b/styles/projects.css
@@ -99,6 +99,39 @@ body[data-active-tab="tasks"] .project-bar {
   font-weight: 600;
 }
 
+/* Claude account tint — the tab carries --account-color, set inline from the
+   account bound to the project (or the default one). Mixed rather than applied
+   flat: a saturated fill would fight the .active state, which still has to read
+   as the selected tab whatever account it belongs to. The inset bar keeps the
+   account legible at the low background alpha. */
+.project-tab.has-account {
+  background: color-mix(in srgb, var(--account-color) 14%, transparent);
+  box-shadow: inset 2px 0 0 var(--account-color);
+}
+
+.project-tab.has-account:hover {
+  background: color-mix(in srgb, var(--account-color) 22%, var(--bg-hover));
+}
+
+.project-tab.has-account.active {
+  background: color-mix(in srgb, var(--account-color) 26%, var(--bg-active));
+  border-color: var(--account-color);
+  color: var(--text-primary);
+}
+
+/* Colour swatch in the tab's account menu. */
+.context-menu-dot {
+  display: inline-block;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+}
+
+.context-menu-dot--none {
+  border: 1px solid var(--border-color);
+  background: transparent;
+}
+
 /* Overview tab — only screens with an all-projects view have one, so it is not
    a second selector competing with the project tabs. */
 .project-tab--overview {

--- a/styles/settings.css
+++ b/styles/settings.css
@@ -2952,6 +2952,24 @@
   background: var(--accent-dim);
 }
 
+/* Colour swatch. The native colour input is stripped of its chrome so it reads
+   as a swatch rather than a form control in a list of rows. */
+.account-row-color {
+  flex: 0 0 auto;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: 1px solid var(--border-color);
+  border-radius: 50%;
+  background: none;
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+}
+
+.account-row-color::-webkit-color-swatch-wrapper { padding: 0; }
+.account-row-color::-webkit-color-swatch { border: none; border-radius: 50%; }
+
 .account-row-main {
   flex: 1;
   min-width: 0;

--- a/styles/settings.css
+++ b/styles/settings.css
@@ -2952,8 +2952,10 @@
   background: var(--accent-dim);
 }
 
-/* Colour swatch. The native colour input is stripped of its chrome so it reads
-   as a swatch rather than a form control in a list of rows. */
+/* Colour swatch opening a fixed palette. A plain button rather than
+   <input type="color">: the OS picker is a lot of machinery for choosing
+   between eight tags, and it lets through values that vanish on a dark
+   background. */
 .account-row-color {
   flex: 0 0 auto;
   width: 22px;
@@ -2963,12 +2965,55 @@
   border-radius: 50%;
   background: none;
   cursor: pointer;
-  appearance: none;
-  -webkit-appearance: none;
+  transition: transform 0.12s, border-color 0.12s;
 }
 
-.account-row-color::-webkit-color-swatch-wrapper { padding: 0; }
-.account-row-color::-webkit-color-swatch { border: none; border-radius: 50%; }
+.account-row-color:hover { transform: scale(1.12); border-color: var(--text-secondary); }
+
+/* No colour set: a hollow ring, not a black dot pretending to be one. */
+.account-row-color--none {
+  background:
+    linear-gradient(45deg, transparent 44%, var(--text-muted) 44%,
+                    var(--text-muted) 56%, transparent 56%);
+}
+
+/* ── Palette popover ── */
+.account-color-popover {
+  position: fixed;
+  z-index: 10000;
+  display: grid;
+  grid-template-columns: repeat(3, auto);
+  gap: 8px;
+  padding: 10px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+}
+
+.account-color-swatch {
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: 2px solid transparent;
+  border-radius: 50%;
+  cursor: pointer;
+  transition: transform 0.12s;
+}
+
+.account-color-swatch:hover { transform: scale(1.15); }
+
+.account-color-swatch.selected {
+  border-color: var(--text-primary);
+  box-shadow: 0 0 0 2px var(--bg-tertiary) inset;
+}
+
+.account-color-swatch--none {
+  background:
+    linear-gradient(45deg, transparent 44%, var(--text-muted) 44%,
+                    var(--text-muted) 56%, transparent 56%);
+  border: 2px solid var(--border-color);
+}
 
 .account-row-main {
   flex: 1;

--- a/tests/ipc/usage.ipc.test.js
+++ b/tests/ipc/usage.ipc.test.js
@@ -86,8 +86,20 @@ describe('refresh-usage', () => {
 
     const result = await handlers['refresh-usage']();
 
-    expect(result).toEqual({ success: true, data: mockData });
+    // accountId rides along: figures are per account now, and the renderer
+    // drops an answer for a tab it has already left.
+    expect(result).toEqual({ success: true, data: mockData, accountId: null });
     expect(mockUsageService.refreshUsage).toHaveBeenCalledTimes(1);
+  });
+
+  test('fetches the account it was asked for', async () => {
+    const mockData = { dailyUsage: 12, maxDaily: 100 };
+    mockUsageService.refreshUsage.mockResolvedValue(mockData);
+
+    const result = await handlers['refresh-usage']({}, 'acct-team');
+
+    expect(mockUsageService.refreshUsage).toHaveBeenCalledWith('acct-team');
+    expect(result).toEqual({ success: true, data: mockData, accountId: 'acct-team' });
   });
 
   test('returns error on service failure', async () => {

--- a/tests/services/AccountManager.test.js
+++ b/tests/services/AccountManager.test.js
@@ -105,7 +105,7 @@ describe('macOS Keychain store', () => {
     expect(account.name).toBe('Max 20x');
     const list = await AccountManager.listAccounts();
     expect(list.accounts).toHaveLength(1);
-    expect(list.activeId).toBe(account.id);
+    expect(list.liveId).toBe(account.id);
   });
 
   test('refuses to capture the same token twice', async () => {
@@ -154,11 +154,11 @@ describe('macOS Keychain store', () => {
     const team = await AccountManager.captureCurrent('Team');
 
     await AccountManager.switchTo(max.id);
-    expect((await AccountManager.listAccounts()).activeId).toBe(max.id);
+    expect((await AccountManager.listAccounts()).liveId).toBe(max.id);
     expect(JSON.parse(mockKeychain.get(MOCK_KEY)).claudeAiOauth.subscriptionType).toBe('max');
 
     await AccountManager.switchTo(team.id);
-    expect((await AccountManager.listAccounts()).activeId).toBe(team.id);
+    expect((await AccountManager.listAccounts()).liveId).toBe(team.id);
     expect(JSON.parse(mockKeychain.get(MOCK_KEY)).claudeAiOauth.subscriptionType).toBe('team');
   });
 
@@ -213,13 +213,13 @@ describe('file store (Windows / Linux)', () => {
 });
 
 describe('syncActiveFromDisk', () => {
-  test('matches on fingerprint even when activeId points elsewhere', async () => {
+  test('matches on fingerprint even when liveId points elsewhere', async () => {
     mockKeychain.set(MOCK_KEY, JSON.stringify(creds('tok-max')));
     const max = await AccountManager.captureCurrent('Max 20x');
     mockKeychain.set(MOCK_KEY, JSON.stringify(creds('tok-team', 'team')));
     const team = await AccountManager.captureCurrent('Team');
 
-    // activeId is Team, but the live store holds Max's untouched token.
+    // liveId is Team, but the live store holds Max's untouched token.
     mockKeychain.set(MOCK_KEY, JSON.stringify(creds('tok-max')));
     const synced = await AccountManager.syncActiveFromDisk();
 
@@ -227,7 +227,7 @@ describe('syncActiveFromDisk', () => {
     expect(synced.id).not.toBe(team.id);
   });
 
-  test('falls back to activeId once a refresh invalidates the fingerprint', async () => {
+  test('falls back to liveId once a refresh invalidates the fingerprint', async () => {
     mockKeychain.set(MOCK_KEY, JSON.stringify(creds('tok-team', 'team')));
     const team = await AccountManager.captureCurrent('Team');
 
@@ -238,7 +238,7 @@ describe('syncActiveFromDisk', () => {
     // The stored fingerprint tracks the new token, so the next call matches
     // exactly rather than relying on the fallback again.
     const list = await AccountManager.listAccounts();
-    expect(list.activeId).toBe(team.id);
+    expect(list.liveId).toBe(team.id);
   });
 
   test('follows a rotation that keeps the same refresh token', async () => {
@@ -257,7 +257,7 @@ describe('syncActiveFromDisk', () => {
     await AccountManager.captureCurrent('Team');
 
     // A manual `claude /login` onto an account this app has never seen. It is
-    // nobody's, so attributing it to activeId would destroy Team's snapshot.
+    // nobody's, so attributing it to liveId would destroy Team's snapshot.
     mockKeychain.set(MOCK_KEY, JSON.stringify(creds('tok-solo', 'pro')));
 
     expect(await AccountManager.syncActiveFromDisk()).toBeNull();

--- a/tests/services/AccountManagerBinding.test.js
+++ b/tests/services/AccountManagerBinding.test.js
@@ -1,0 +1,259 @@
+/**
+ * AccountManager — per-project bindings.
+ *
+ * Covers what changes once a project can pin itself to an account: the
+ * defaultId / liveId split, per-account credential directories, and the
+ * environment overlay a spawn inherits.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const crypto = require('crypto');
+
+jest.mock('../../src/main/utils/paths', () => {
+  const fsMock = require('fs');
+  const osMock = require('os');
+  const pathMock = require('path');
+  const root = fsMock.mkdtempSync(pathMock.join(osMock.tmpdir(), 'ct-acct-bind-'));
+  return {
+    dataDir: pathMock.join(root, 'data'),
+    claudeDir: pathMock.join(root, 'claude'),
+    _root: root
+  };
+});
+
+// The real keytar would hit the developer's login keychain.
+const mockKeychain = new Map();
+jest.mock('keytar', () => ({
+  getPassword: jest.fn(async (service, account) => mockKeychain.get(`${service}:${account}`) ?? null),
+  setPassword: jest.fn(async (service, account, secret) => { mockKeychain.set(`${service}:${account}`, secret); }),
+  deletePassword: jest.fn(async (service, account) => mockKeychain.delete(`${service}:${account}`))
+}));
+
+const paths = require('../../src/main/utils/paths');
+const AccountManager = require('../../src/main/services/AccountManager');
+const { SECURESTORAGE_ENV, keychainServiceForDir } = require('../../src/main/utils/claudeCredentials');
+
+const MACHINE_KEY = `Claude Code-credentials:${os.userInfo().username}`;
+
+const realPlatform = process.platform;
+const setPlatform = (value) => {
+  Object.defineProperty(process, 'platform', { value, configurable: true });
+};
+
+const creds = (accessToken, subscriptionType = 'max') => ({
+  claudeAiOauth: {
+    accessToken,
+    refreshToken: `refresh-${accessToken}`,
+    expiresAt: 1893456000000,
+    refreshTokenExpiresAt: 1900000000000,
+    subscriptionType
+  }
+});
+
+const seedPath = (id) => path.join(paths.dataDir, 'accounts', 'config', id, '.credentials.json');
+const namespacedKey = (dir) => `${keychainServiceForDir(dir)}:${os.userInfo().username}`;
+
+beforeAll(() => {
+  process.env.CLAUDE_CONFIG_DIR = path.join(paths._root, 'claude-config');
+});
+
+afterAll(() => {
+  setPlatform(realPlatform);
+  delete process.env.CLAUDE_CONFIG_DIR;
+  fs.rmSync(paths._root, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  mockKeychain.clear();
+  fs.rmSync(path.join(paths.dataDir, 'accounts'), { recursive: true, force: true });
+  fs.rmSync(path.join(paths._root, 'claude-config'), { recursive: true, force: true });
+  setPlatform('darwin');
+});
+
+const capture = async (name, token, plan = 'max') => {
+  mockKeychain.set(MACHINE_KEY, JSON.stringify(creds(token, plan)));
+  return AccountManager.captureCurrent(name);
+};
+
+describe('default vs live', () => {
+  test('the first captured account becomes the default', async () => {
+    const max = await capture('Max 20x', 'tok-max');
+    const list = await AccountManager.listAccounts();
+    expect(list.defaultId).toBe(max.id);
+    expect(list.liveId).toBe(max.id);
+  });
+
+  test('a later capture does not steal the default', async () => {
+    const max = await capture('Max 20x', 'tok-max');
+    const team = await capture('Team', 'tok-team', 'team');
+
+    const list = await AccountManager.listAccounts();
+    expect(list.defaultId).toBe(max.id);
+    // It is what `claude /login` last wrote, though.
+    expect(list.liveId).toBe(team.id);
+  });
+
+  test('setDefault puts the account in the machine-wide store', async () => {
+    const max = await capture('Max 20x', 'tok-max');
+    const team = await capture('Team', 'tok-team', 'team');
+
+    await AccountManager.setDefault(max.id);
+
+    // Unbound work reads the machine-wide store, so a default that only moved
+    // a pointer would be a default nothing actually used.
+    expect(JSON.parse(mockKeychain.get(MACHINE_KEY)).claudeAiOauth.subscriptionType).toBe('max');
+    const list = await AccountManager.listAccounts();
+    expect(list.defaultId).toBe(max.id);
+    expect(list.liveId).toBe(max.id);
+    expect(team.id).not.toBe(list.defaultId);
+  });
+
+  test('setDefault rejects an unknown account', async () => {
+    await expect(AccountManager.setDefault('nope')).rejects.toThrow(/not found/);
+  });
+});
+
+describe('index migration', () => {
+  test('an activeId index becomes both defaultId and liveId', async () => {
+    const max = await capture('Max 20x', 'tok-max');
+
+    // Rewrite the index in the pre-binding shape.
+    const indexFile = path.join(paths.dataDir, 'accounts', 'index.json');
+    const index = JSON.parse(fs.readFileSync(indexFile, 'utf8'));
+    delete index.defaultId;
+    delete index.liveId;
+    index.activeId = max.id;
+    fs.writeFileSync(indexFile, JSON.stringify(index, null, 2));
+
+    const list = await AccountManager.listAccounts();
+    expect(list.defaultId).toBe(max.id);
+    expect(list.liveId).toBe(max.id);
+  });
+});
+
+describe('colour', () => {
+  test('updateAccount patches one field without blanking the other', async () => {
+    const max = await capture('Max 20x', 'tok-max');
+
+    await AccountManager.updateAccount(max.id, { color: '#ff5733' });
+    expect((await AccountManager.updateAccount(max.id, { name: 'Perso' })).color).toBe('#ff5733');
+
+    const stored = (await AccountManager.listAccounts()).accounts[0];
+    expect(stored.name).toBe('Perso');
+    expect(stored.color).toBe('#ff5733');
+  });
+
+  test('a colour can be cleared', async () => {
+    const max = await capture('Max 20x', 'tok-max');
+    await AccountManager.updateAccount(max.id, { color: '#ff5733' });
+    expect((await AccountManager.updateAccount(max.id, { color: null })).color).toBeNull();
+  });
+});
+
+describe('per-account credential store', () => {
+  test('capture seeds the account directory', async () => {
+    const max = await capture('Max 20x', 'tok-max');
+    expect(fs.existsSync(seedPath(max.id))).toBe(true);
+    expect(JSON.parse(fs.readFileSync(seedPath(max.id), 'utf8')).claudeAiOauth.accessToken).toBe('tok-max');
+  });
+
+  test('accountEnv points a spawn at that directory', async () => {
+    const max = await capture('Max 20x', 'tok-max');
+
+    const env = await AccountManager.accountEnv(max.id);
+    expect(env[SECURESTORAGE_ENV]).toBe(AccountManager.accountConfigDir(max.id));
+  });
+
+  test('each account gets a distinct directory, and so a distinct keychain entry', async () => {
+    const max = await capture('Max 20x', 'tok-max');
+    const team = await capture('Team', 'tok-team', 'team');
+
+    const dirMax = AccountManager.accountConfigDir(max.id);
+    const dirTeam = AccountManager.accountConfigDir(team.id);
+    expect(dirMax).not.toBe(dirTeam);
+    // This is what stops a refresh in one account clobbering the other.
+    expect(keychainServiceForDir(dirMax)).not.toBe(keychainServiceForDir(dirTeam));
+    expect(keychainServiceForDir(dirMax)).not.toBe('Claude Code-credentials');
+  });
+
+  test('the keychain service matches the CLI derivation', async () => {
+    const dir = AccountManager.accountConfigDir('abc123');
+    const expected = crypto.createHash('sha256').update(dir.normalize('NFC')).digest('hex').slice(0, 8);
+    expect(keychainServiceForDir(dir)).toBe(`Claude Code-credentials-${expected}`);
+  });
+
+  test('no binding means no overlay, so unbound work keeps the machine login', async () => {
+    await capture('Max 20x', 'tok-max');
+    // Deliberately no fallback to the default: it is what keeps
+    // `claude /login`, and therefore capturing an account, working.
+    expect(await AccountManager.accountEnv(null)).toBeNull();
+  });
+
+  test('an unknown account yields no overlay rather than a broken spawn', async () => {
+    expect(await AccountManager.accountEnv('nope')).toBeNull();
+  });
+
+  test('the seed is dropped once the CLI has written the keychain entry', async () => {
+    const max = await capture('Max 20x', 'tok-max');
+    const dir = AccountManager.accountConfigDir(max.id);
+    expect(fs.existsSync(seedPath(max.id))).toBe(true);
+
+    // The CLI refreshes and writes to its namespaced entry.
+    mockKeychain.set(namespacedKey(dir), JSON.stringify(creds('tok-max-v2')));
+    await AccountManager.ensureAccountStore(max.id);
+
+    expect(fs.existsSync(seedPath(max.id))).toBe(false);
+  });
+
+  test('a refresh in a bound account leaves the machine-wide store alone', async () => {
+    const max = await capture('Max 20x', 'tok-max');
+    const team = await capture('Team', 'tok-team', 'team');
+    await AccountManager.setDefault(max.id);
+
+    mockKeychain.set(namespacedKey(AccountManager.accountConfigDir(team.id)), JSON.stringify(creds('tok-team-v2', 'team')));
+    await AccountManager.ensureAccountStore(team.id);
+
+    expect(JSON.parse(mockKeychain.get(MACHINE_KEY)).claudeAiOauth.subscriptionType).toBe('max');
+  });
+
+  test('removing an account takes its store with it', async () => {
+    const max = await capture('Max 20x', 'tok-max');
+    await capture('Team', 'tok-team', 'team');
+    const dir = AccountManager.accountConfigDir(max.id);
+    mockKeychain.set(namespacedKey(dir), JSON.stringify(creds('tok-max')));
+
+    await AccountManager.removeAccount(max.id);
+
+    expect(fs.existsSync(dir)).toBe(false);
+    expect(mockKeychain.has(namespacedKey(dir))).toBe(false);
+  });
+
+  test('removing the default hands the role to a surviving account', async () => {
+    const max = await capture('Max 20x', 'tok-max');
+    const team = await capture('Team', 'tok-team', 'team');
+    await AccountManager.setDefault(max.id);
+
+    await AccountManager.removeAccount(max.id);
+
+    expect((await AccountManager.listAccounts()).defaultId).toBe(team.id);
+  });
+});
+
+describe('file store platforms', () => {
+  beforeEach(() => setPlatform('linux'));
+
+  test('the seed alone provisions the directory when there is no keychain', async () => {
+    const credPath = path.join(paths._root, 'claude-config', '.credentials.json');
+    fs.mkdirSync(path.dirname(credPath), { recursive: true });
+    fs.writeFileSync(credPath, JSON.stringify(creds('tok-max')));
+
+    const max = await AccountManager.captureCurrent('Max 20x');
+    const env = await AccountManager.accountEnv(max.id);
+
+    expect(env[SECURESTORAGE_ENV]).toBe(AccountManager.accountConfigDir(max.id));
+    // No keychain to take over, so the seed has to stay.
+    expect(fs.existsSync(seedPath(max.id))).toBe(true);
+  });
+});

--- a/tests/services/UsageServicePerAccount.test.js
+++ b/tests/services/UsageServicePerAccount.test.js
@@ -1,0 +1,188 @@
+/**
+ * UsageService — per-account figures.
+ *
+ * Projects pick their own account, so usage is no longer one set of numbers.
+ * These pin the parts that would silently report the wrong account: cache
+ * isolation, per-account limit de-duplication, and which credential store a
+ * token is read from.
+ */
+
+// One fake response per token, so a request proves which account was queried.
+// `mock`-prefixed: jest.mock factories are hoisted above other consts.
+const mockBodyByToken = new Map();
+const mockRequestedTokens = [];
+
+jest.mock('https', () => ({
+  get: jest.fn((opts, cb) => {
+    const { EventEmitter } = require('events');
+    const token = String(opts.headers.Authorization || '').replace('Bearer ', '');
+    mockRequestedTokens.push(token);
+    const res = new EventEmitter();
+    res.statusCode = mockBodyByToken.has(token) ? 200 : 401;
+    process.nextTick(() => {
+      res.emit('data', mockBodyByToken.get(token) ?? 'no such token');
+      res.emit('end');
+    });
+    cb(res);
+    return { on: jest.fn(), destroy: jest.fn() };
+  })
+}));
+
+jest.mock('../../src/main/utils/claudeCredentials', () => ({
+  readAccessToken: jest.fn(async () => 'tok-machine'),
+  readCredentialsForDir: jest.fn(async (dir) => ({
+    claudeAiOauth: { accessToken: `tok-${dir.split('/').pop()}`, expiresAt: 4102444800000 }
+  })),
+  tokenFromCredentials: jest.fn((creds) => creds?.claudeAiOauth?.accessToken ?? null)
+}));
+
+jest.mock('../../src/main/services/AccountManager', () => ({
+  accountConfigDir: (id) => `/tmp/accounts/config/${id}`
+}));
+
+jest.mock('../../src/main/windows/MainWindow', () => ({ isMainWindowVisible: () => true }), { virtual: true });
+
+const UsageService = require('../../src/main/services/UsageService');
+
+const usageBody = (utilization, resetsAt = '2026-10-01T00:00:00Z') => JSON.stringify({
+  five_hour: { utilization, resets_at: resetsAt }
+});
+
+beforeEach(() => {
+  mockBodyByToken.clear();
+  mockRequestedTokens.length = 0;
+  UsageService.invalidateCredentials();
+  UsageService.onUpdate(null);
+  UsageService.onLimit(null);
+});
+
+describe('per-account isolation', () => {
+  test('each account keeps its own figures', async () => {
+    mockBodyByToken.set('tok-acct-max', usageBody(0.10));
+    mockBodyByToken.set('tok-acct-team', usageBody(0.80));
+
+    await UsageService.fetchUsage('acct-max');
+    await UsageService.fetchUsage('acct-team');
+
+    // The whole point: one account's numbers must never answer for another.
+    expect(UsageService.getUsageData('acct-max').data.buckets[0].utilization).toBe(0.10);
+    expect(UsageService.getUsageData('acct-team').data.buckets[0].utilization).toBe(0.80);
+  });
+
+  test('a bound account is read from its own credential directory', async () => {
+    mockBodyByToken.set('tok-acct-team', usageBody(0.42));
+
+    await UsageService.fetchUsage('acct-team');
+
+    // Not the machine-wide login: the figures have to come from the store the
+    // account's own CLI authenticates against.
+    expect(mockRequestedTokens).toEqual(['tok-acct-team']);
+  });
+
+  test('no account id means the machine-wide login', async () => {
+    mockBodyByToken.set('tok-machine', usageBody(0.33));
+
+    await UsageService.fetchUsage(null);
+
+    expect(mockRequestedTokens).toEqual(['tok-machine']);
+    expect(UsageService.getUsageData().data.buckets[0].utilization).toBe(0.33);
+  });
+
+  test('an account with no data does not inherit another one', async () => {
+    mockBodyByToken.set('tok-acct-max', usageBody(0.55));
+    await UsageService.fetchUsage('acct-max');
+
+    expect(UsageService.getUsageData('acct-team').data).toBeNull();
+  });
+
+  test('a failed fetch marks only that account stale', async () => {
+    mockBodyByToken.set('tok-acct-max', usageBody(0.20));
+    await UsageService.fetchUsage('acct-max');
+    await UsageService.fetchUsage('acct-team'); // 401, no body registered
+
+    expect(UsageService.getFetchState('acct-max').stale).toBe(false);
+    expect(UsageService.getFetchState('acct-team').stale).toBe(true);
+  });
+});
+
+describe('limit notifications', () => {
+  test('two accounts crossing the same bucket both notify', async () => {
+    const alerts = [];
+    UsageService.onLimit(a => alerts.push(a));
+    mockBodyByToken.set('tok-acct-max', usageBody(0.97));
+    mockBodyByToken.set('tok-acct-team', usageBody(0.98));
+
+    await UsageService.fetchUsage('acct-max');
+    await UsageService.fetchUsage('acct-team');
+
+    // A shared de-dupe key let the first account swallow the second's alert:
+    // same bucket id, same reset window.
+    expect(alerts.map(a => a.accountId)).toEqual(['acct-max', 'acct-team']);
+  });
+
+  test('the same account does not notify twice in one window', async () => {
+    const alerts = [];
+    UsageService.onLimit(a => alerts.push(a));
+    mockBodyByToken.set('tok-acct-max', usageBody(0.97));
+
+    await UsageService.fetchUsage('acct-max');
+    await UsageService.fetchUsage('acct-max');
+
+    expect(alerts).toHaveLength(1);
+  });
+
+  test('a new reset window notifies again', async () => {
+    const alerts = [];
+    UsageService.onLimit(a => alerts.push(a));
+
+    mockBodyByToken.set('tok-acct-max', usageBody(0.97, '2026-10-01T00:00:00Z'));
+    await UsageService.fetchUsage('acct-max');
+    mockBodyByToken.set('tok-acct-max', usageBody(0.99, '2026-10-02T00:00:00Z'));
+    await UsageService.fetchUsage('acct-max');
+
+    expect(alerts).toHaveLength(2);
+  });
+});
+
+describe('invalidation', () => {
+  test('clears one account and leaves the others', async () => {
+    mockBodyByToken.set('tok-acct-max', usageBody(0.10));
+    mockBodyByToken.set('tok-acct-team', usageBody(0.80));
+    await UsageService.fetchUsage('acct-max');
+    await UsageService.fetchUsage('acct-team');
+
+    UsageService.invalidateCredentials('acct-max');
+
+    expect(UsageService.getUsageData('acct-max').data).toBeNull();
+    expect(UsageService.getUsageData('acct-team').data.buckets[0].utilization).toBe(0.80);
+  });
+
+  test('with no argument it clears every account', async () => {
+    mockBodyByToken.set('tok-acct-max', usageBody(0.10));
+    mockBodyByToken.set('tok-acct-team', usageBody(0.80));
+    await UsageService.fetchUsage('acct-max');
+    await UsageService.fetchUsage('acct-team');
+
+    UsageService.invalidateCredentials();
+
+    expect(UsageService.getUsageData('acct-max').data).toBeNull();
+    expect(UsageService.getUsageData('acct-team').data).toBeNull();
+  });
+});
+
+describe('focus', () => {
+  test('the focused account is what the poller refreshes', async () => {
+    mockBodyByToken.set('tok-acct-team', usageBody(0.44));
+
+    UsageService.setFocusedAccount('acct-team');
+    expect(UsageService.getFocusedAccount()).toBe('acct-team');
+
+    // Switching focus fetches immediately rather than leaving the previous
+    // account's numbers up until the next tick.
+    await new Promise(r => setTimeout(r, 10));
+    expect(mockRequestedTokens).toContain('tok-acct-team');
+
+    UsageService.setFocusedAccount(null);
+    expect(UsageService.getFocusedAccount()).toBeNull();
+  });
+});

--- a/tests/state/accountsUsageLabel.test.js
+++ b/tests/state/accountsUsageLabel.test.js
@@ -1,0 +1,89 @@
+/**
+ * getUsageAccountForProject — what the usage bar names.
+ *
+ * The figures always belong to someone, so the label always has an answer:
+ * the project's own account when it has one, otherwise whoever owns the
+ * machine-wide store its CLI actually reads.
+ */
+
+const projects = [];
+const state = { projects };
+
+jest.mock('../../src/renderer/state/projects.state', () => ({
+  getProjectAccount: jest.fn((id) => (projects.find(p => p.id === id) || {}).accountId || null),
+  projectsState: { get: () => state, subscribe: jest.fn() }
+}));
+
+const {
+  accountsState,
+  getUsageAccountForProject
+} = require('../../src/renderer/state/accounts.state');
+
+const MAX = { id: 'a-max', name: 'Max 20x', color: '#ff5733' };
+const TEAM = { id: 'a-team', name: 'Team', color: '#3b82f6' };
+
+beforeEach(() => {
+  projects.length = 0;
+  accountsState.set({
+    accounts: [MAX, TEAM],
+    defaultId: MAX.id,
+    liveId: MAX.id,
+    hasCredentials: true,
+    loaded: true
+  });
+});
+
+test('a bound project names its own account', () => {
+  projects.push({ id: 'p1', accountId: TEAM.id });
+
+  const { account, isDefault } = getUsageAccountForProject('p1');
+
+  expect(account.name).toBe('Team');
+  expect(isDefault).toBe(false);
+});
+
+test('an unbound project still names an account, flagged as the default', () => {
+  projects.push({ id: 'p1' });
+
+  const { account, isDefault } = getUsageAccountForProject('p1');
+
+  // The tab is tinted either way; a blank label next to a coloured tab was the
+  // inconsistency this replaced.
+  expect(account.name).toBe('Max 20x');
+  expect(isDefault).toBe(true);
+});
+
+test('no project at all falls back to the machine-wide account', () => {
+  const { account, isDefault } = getUsageAccountForProject(null);
+
+  expect(account.name).toBe('Max 20x');
+  expect(isDefault).toBe(true);
+});
+
+test('an unbound project names the live account, not the default, when they differ', () => {
+  projects.push({ id: 'p1' });
+  // A manual `claude /login` moved the machine-wide store off the default.
+  accountsState.set({ defaultId: MAX.id, liveId: TEAM.id });
+
+  const { account } = getUsageAccountForProject('p1');
+
+  // The figures come from the machine-wide store, so naming the default would
+  // attribute them to an account that did not produce them.
+  expect(account.name).toBe('Team');
+});
+
+test('a binding to a deleted account falls back rather than blanking', () => {
+  projects.push({ id: 'p1', accountId: 'gone' });
+
+  const { account, isDefault } = getUsageAccountForProject('p1');
+
+  expect(account.name).toBe('Max 20x');
+  expect(isDefault).toBe(true);
+});
+
+test('no accounts at all yields nothing to name', () => {
+  accountsState.set({ accounts: [], defaultId: null, liveId: null });
+  projects.push({ id: 'p1' });
+
+  expect(getUsageAccountForProject('p1').account).toBeNull();
+});


### PR DESCRIPTION
## Summary

Multi-account support is currently a machine-wide switch: picking an account changes it for every tab at once. This makes the account a property of each project — a project pinned to one runs every chat and terminal it opens as that account, while unpinned work keeps using the machine-wide login.

It builds on #79 (macOS Keychain support), which made accounts usable on darwin in the first place.

## Changes

**Credential isolation.** `CLAUDE_SECURESTORAGE_CONFIG_DIR` scopes *only* the credential store, so `projects/`, `sessions/`, `.claude.json`, `skills/` and `plugins/` stay shared in `~/.claude`. Using `CLAUDE_CONFIG_DIR` instead would have fragmented session history per account and broken resuming a session under another one. The CLI derives its Keychain service name from that directory (`Claude Code-credentials-${sha256(NFC(dir)).slice(0,8)}`), so each account lands in its own entry and a refresh in one cannot clobber another. `keychainServiceForDir` mirrors that derivation so the app reads the same entry back.

**`activeId` splits in two.** It meant both "what new work uses" and "who owns the machine-wide store". Those are now `defaultId` and `liveId`; the old key migrates into both. Only an explicit binding is injected into a spawn — unbound work deliberately keeps reading the machine-wide store, which is what keeps `claude /login`, and therefore capturing an account, working. `setDefault` is what makes the default real, by putting that account into that store.

**Accounts gain a colour**, from a fixed palette rather than a native colour input. It tints the project tab and appears wherever the account is named.

**Usage is tracked per account.** Everything that was a module-level singleton in `UsageService` — figures, token cache, staleness, the limit de-dupe key — is keyed by account. The de-dupe key mattering on its own: shared, one account crossing a bucket silenced every other account crossing the same bucket in the same reset window. Only the focused account is polled.

**The rate-limit modal re-binds the project** rather than swapping a global account, which under per-project bindings would move every other tab over a limit that was not theirs.

**The picker is reachable** from the project tab, the project row, its "…" menu, the usage chip, and the creation wizard.

## Screenshots

Captured from an isolated sandbox — every account and project name below is invented.

Project tabs tinted by the account they run as, and the usage chip naming the account the figures belong to (dashed while the project follows the default):

![Usage chip and tinted project tabs](https://raw.githubusercontent.com/bleleve/claude-terminal/pr-assets/.github/pr-assets/01-usage-chip.png)

The account is a row of the project's own menu, opening its alternatives to the side:

![Account row in the project menu](https://raw.githubusercontent.com/bleleve/claude-terminal/pr-assets/.github/pr-assets/02-account-menu.png)

Colours come from a fixed palette, and a row states how many projects still point at the account:

![Claude accounts in settings](https://raw.githubusercontent.com/bleleve/claude-terminal/pr-assets/.github/pr-assets/03-accounts-settings.png)

## Testing

```
npm test              # 86 suites, 2290 tests passed
npm run build:renderer
```

36 new tests. Several pin decisions that are easy to regress: `accountEnv(null)` returns nothing rather than falling back to the default; a refresh landing in a bound account's namespaced entry leaves the machine-wide store untouched; `keychainServiceForDir` matches the CLI's own derivation, since the whole isolation rests on the two agreeing.

Manually exercised on macOS in an isolated sandbox (`scripts/dev-sandbox.js`, added here) with invented accounts and projects.

## Known consequence

MCP server logins are stored in the same credential blob as the Claude login — `AccountManager` already documents this, and the CLI reads `mcpOAuth` through the same secure store. Scoping the store per account therefore scopes MCP authentication too: a project bound to a second account may have to re-authenticate its MCP servers, even though `.claude.json` itself stays shared. Verified by reading the bundled CLI, not observed at runtime. If it is unwanted, carrying `mcpOAuth` over when seeding an account's store would fix it in a few lines.

## Not addressed

- Windows and Linux are untested here; the file-store path is covered by unit tests only.
- `CLAUDE_SECURESTORAGE_CONFIG_DIR` is undocumented. A start-up probe with a clean fallback would be prudent before relying on it long-term.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


