### PR TITLE
fix(release): compute mac sha512 from the authenticated asset download

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,10 +117,24 @@ jobs:
           for i in $(seq 0 $(( COUNT - 1 ))); do
             NAME=$(jq -r ".[$i].name" dmg_list.json)
             SIZE=$(jq -r ".[$i].size" dmg_list.json)
-            DOWNLOAD_URL=$(jq -r ".[$i].browser_download_url" dmg_list.json)
+            ASSET_API_URL=$(jq -r ".[$i].url" dmg_list.json)
 
-            # Download DMG to compute sha512
-            curl -sL "$DOWNLOAD_URL" -o "$NAME"
+            # Download DMG to compute sha512.
+            # Must go through the authenticated API asset endpoint, NOT
+            # browser_download_url: electron-builder creates the release as a
+            # draft, and a draft's browser_download_url is not public. An
+            # unauthenticated curl there silently retrieves GitHub's 9-byte
+            # "Not Found" body instead of the DMG, so every architecture ends up
+            # sharing sha512(b"Not Found") and electron-updater rejects the
+            # download it just made. The job still exits 0, so nothing warns.
+            gh api -H "Accept: application/octet-stream" "$ASSET_API_URL" > "$NAME"
+
+            ACTUAL_SIZE=$(stat -c%s "$NAME")
+            if [ "$ACTUAL_SIZE" != "$SIZE" ]; then
+              echo "::error::$NAME downloaded as $ACTUAL_SIZE bytes, expected $SIZE"
+              exit 1
+            fi
+
             SHA512=$(sha512sum "$NAME" | awk '{print $1}' | xxd -r -p | base64 -w0)
             rm "$NAME"
 
@@ -128,6 +142,15 @@ jobs:
             echo "    sha512: $SHA512" >> merged.yml
             echo "    size: $SIZE" >> merged.yml
           done
+
+          # Distinct binaries cannot share a hash — if they do, the downloads
+          # failed and produced identical error bodies.
+          DISTINCT=$(grep '    sha512:' merged.yml | sort -u | wc -l)
+          if [ "$DISTINCT" != "$COUNT" ]; then
+            echo "::error::$COUNT DMGs produced only $DISTINCT distinct sha512 values"
+            cat merged.yml
+            exit 1
+          fi
 
           # Use the x64 DMG as default path/sha512 (electron-updater picks the right one from files array)
           X64_NAME=$(jq -r '[.[] | select(.name | contains("arm64") | not)] | .[0].name' dmg_list.json)


### PR DESCRIPTION
Fixes #125

`merge-mac-yml` downloads each DMG through `browser_download_url` to hash it. electron-builder creates the release as a **draft**, and a draft's `browser_download_url` is not publicly readable, so the unauthenticated `curl` writes GitHub's 9-byte `Not Found` body to disk instead of the DMG.

Every architecture therefore ends up sharing the same hash:

```
sha512("Not Found") = k1s9UW6Zb20llIuopUwbf3D38OP1F+Nkgf3wGWwsXPwoQfhuiR89+VF3Rrf7YF20fN3tG4/3jZSC3apiHbQ6NA==
```

I hit this on a build of my fork. The merge step overwrote arm64's real `MoZ1nspa…` with that value and gave x64 the exact same one, despite the two DMGs differing in size by 10 MB:

```yaml
files:
  - url: Claude-Terminal-1.3.0-BLE.1-arm64.dmg
    sha512: k1s9UW6Zb20ll…      # was MoZ1nspa… before the merge step
    size: 257823891
  - url: Claude-Terminal-1.3.0-BLE.1.dmg
    sha512: k1s9UW6Zb20ll…      # identical, 10 MB larger
    size: 268456008
```

Since `release.yml` is the same here, this should affect every release whose `latest-mac.yml` went through the merge job. Worth checking a published one — the per-file `sha512` values in `latest-mac.yml` should differ between the arm64 and x64 entries.

The failure mode is quiet: the job exits 0, and manual downloads are unaffected because they never consult the yml. The only symptom is electron-updater rejecting a download it just completed, which surfaces as a failed auto-update rather than a failed build.

## Changes

- Fetch through the authenticated API asset endpoint (`.url`, not `.browser_download_url`), which works for drafts. `GH_TOKEN` is already in the step's env, so no new secret.
- Fail if a downloaded file's size disagrees with the size the API reported.
- Fail if distinct binaries hash identically — the exact condition that reproduces this.

## Verification

Re-running the job against the same release *after* publishing it (assets public, so the old code path happened to work) produced hashes matching exactly what electron-builder had computed at build time on each runner — `MoZ1nspa…` for arm64 and `1B31F1p7…` for x64.