### PR TITLE
fix(release): stop one macOS arch from cancelling the other

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,10 @@ jobs:
 
   build-macos:
     strategy:
+      # The two architectures are independent artifacts. Cancelling one because
+      # the other tripped just loses a good build and skips merge-mac-yml, which
+      # needs both legs to produce a latest-mac.yml covering arm64 and x64.
+      fail-fast: false
       matrix:
         include:
           - runner: macos-latest

--- a/tests/features/ControlTowerGrid.test.js
+++ b/tests/features/ControlTowerGrid.test.js
@@ -7,6 +7,12 @@ const ControlTowerPanel = require('../../src/renderer/ui/panels/ControlTowerPane
 const { addTerminal, clearAllTerminals } = require('../../src/renderer/state/terminals.state');
 const { projectsState } = require('../../src/renderer/state/projects.state');
 
+// Every case here mounts the full panel and awaits several render passes, which
+// takes ~11 s for the file on the slowest CI runner (macos-15-intel) and trips
+// Jest's 5 s default on whichever case happens to run first. Raised for this
+// file only — a global bump would hide genuine hangs elsewhere.
+jest.setTimeout(30000);
+
 // Let pending promises (async _scanTerminals) settle
 const flush = () => new Promise(r => setTimeout(r, 0));
 


### PR DESCRIPTION
Fixes #126
Fixes #127

Two independent problems that compounded on a release build of my fork and cost two full attempts before anything shipped.

## `fail-fast` on the macOS matrix

`build-macos` has no `fail-fast` setting, so a failure on either leg cancels the sibling that is building fine. That also skips `merge-mac-yml`, which `needs: build-macos`, leaving `latest-mac.yml` covering a single architecture.

Net effect: a transient hiccup on x64 costs the arm64 artifact *and* the update metadata for both. The two architectures are independent artifacts and shouldn't cancel each other.

## Jest timeout on the slowest runner

`ControlTowerGrid.test.js` mounts the full panel and awaits several render passes per case. The file takes ~11 s on `macos-15-intel`, so whichever case runs first trips Jest's 5 s default:

```
● ControlTowerPanel grid view › renders one grid card per tracked terminal session
  thrown: "Exceeded timeout of 5000 ms for a test."

Test Suites: 1 failed, 98 passed, 99 total
Tests:       1 failed, 2519 passed, 2520 total
```

The same commit passes all 2520 tests on Linux and Windows, and the file runs in 1.5 s locally on Apple Silicon — this is runner speed, not a regression. Raised to 30 s for this file only; a global `testTimeout` would hide genuine hangs elsewhere.

The two commits are independent, so feel free to take only one.