### PR TITLE
fix(chat): stop the CLI's login error from becoming a tab name

### DIFF
--- a/src/main/services/ChatService.js
+++ b/src/main/services/ChatService.js
@@ -49,6 +49,30 @@ const MAX_TOUCHED_FILES = 200;
 const RESTRICTED_SESSION_MAX_TURNS = 40;
 
 /**
+ * Signatures of a CLI failure that the SDK hands back as ordinary assistant
+ * text instead of as a stream error.
+ *
+ * The short haiku helpers (tab naming, prompt enhancement, commit messages)
+ * read the first text block and use it verbatim, so an expired login turns a
+ * tab into "Not logged in · Please run /login" — persisted to
+ * session-names.json and broadcast to the remote UI. Text matching any of these
+ * is refused so each caller falls back to what it already had.
+ *
+ * Deliberately anchored on the CLI's own phrasing: a title *about* login
+ * ("Fix /login redirect") has to keep going through.
+ */
+const CLI_FAILURE_TEXT = [
+  /^api error:/i,
+  /^not logged in\b/i,
+  /^invalid api key\b/i,
+  /\bplease run \/login\b/i,
+  /\bplease run `?claude (login|auth)\b/i,
+  /\bsession (has )?expired\b/i,
+  /\bcredit balance (is )?too low\b/i,
+  /\busage limit reached\b/i,
+];
+
+/**
  * Note a file this session wrote, for `_sessionContext`.
  * Silent on anything unexpected — this is bookkeeping on the hot stream path and
  * must never be able to break the conversation.
@@ -1503,6 +1527,19 @@ class ChatService {
   // ── Persistent haiku naming session ──
 
   /**
+   * Does this haiku answer look like the CLI reporting a failure rather than
+   * doing the job it was asked?
+   *
+   * @param {string} text  the assistant text block, unnormalized
+   * @returns {boolean}
+   */
+  _isCliFailureText(text) {
+    const trimmed = (text || '').trim();
+    if (!trimmed) return false;
+    return CLI_FAILURE_TEXT.some(re => re.test(trimmed));
+  }
+
+  /**
    * Ensure the persistent haiku naming session is running.
    * One long-lived session serves ALL tab rename requests. Pending requests are
    * tracked in a FIFO queue so concurrent calls always receive THEIR response.
@@ -1596,6 +1633,12 @@ class ChatService {
             if (rawText === null) {
               // Session died before our turn — bubble up retry signal
               resolve({ retry: true });
+              return;
+            }
+            if (this._isCliFailureText(rawText)) {
+              // The CLI answered with its own failure, not a title. Leave the
+              // tab on the truncated-prompt name the renderer already applied.
+              resolve({ name: null });
               return;
             }
             const name = (rawText || '').trim()
@@ -1749,7 +1792,8 @@ class ChatService {
               return;
             }
             const enhanced = (rawText || '').trim();
-            resolve({ text: enhanced || text });
+            // A CLI failure would otherwise replace the user's own prompt.
+            resolve({ text: this._isCliFailureText(enhanced) ? text : (enhanced || text) });
           };
 
           pending.push(slot);
@@ -2050,7 +2094,10 @@ class ChatService {
         }
       }
 
-      return text.trim() || null;
+      // Null on a CLI failure so callers (commit message, PR description) drop
+      // to their heuristic fallback instead of committing the error text.
+      const out = text.trim();
+      return out && !this._isCliFailureText(out) ? out : null;
     } catch (err) {
       console.warn('[ChatService] runHaikuPrompt failed:', err.message);
       return null;

--- a/tests/services/ChatService.test.js
+++ b/tests/services/ChatService.test.js
@@ -363,3 +363,41 @@ describe('ChatService lifecycle status', () => {
     expect(lifecycle[0].status).toBe('success');
   });
 });
+
+// ── CLI failure text guard ──
+
+describe('ChatService._isCliFailureText', () => {
+  test.each([
+    'Not logged in · Please run /login',
+    'API Error: 401 Invalid API key · Please run /login',
+    'Invalid API key · Please run /login',
+    'Your session has expired. Please run /login to sign in again.',
+    'Voice mode requires a Claude.ai account. Please run /login to sign in.',
+    'Not logged in. Run `claude auth login` to authenticate.',
+    'Credit balance is too low',
+    'Claude usage limit reached',
+  ])('refuses CLI failure text: %s', (text) => {
+    expect(chatService._isCliFailureText(text)).toBe(true);
+  });
+
+  test.each([
+    'Fix /login redirect',
+    'Refonte left menu',
+    'Migrate auth session store',
+    'Debug expired token refresh',
+    'API error handling middleware',
+  ])('lets a real title through: %s', (text) => {
+    expect(chatService._isCliFailureText(text)).toBe(false);
+  });
+
+  test('ignores surrounding whitespace', () => {
+    expect(chatService._isCliFailureText('  Not logged in · Please run /login\n')).toBe(true);
+  });
+
+  test('empty and nullish text is not a failure', () => {
+    expect(chatService._isCliFailureText('')).toBe(false);
+    expect(chatService._isCliFailureText('   ')).toBe(false);
+    expect(chatService._isCliFailureText(null)).toBe(false);
+    expect(chatService._isCliFailureText(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #128

## The bug

A chat tab regularly ends up named `Not logged in · Please run /login`. The name is persisted, restored on the next launch, and shown that way under Resume.

`ChatService` keeps one long-lived Haiku session for tab naming, and `generateTabName` uses the first text block of the reply verbatim as the title. The CLI does not report every authentication failure as a stream error — it answers with one as ordinary assistant text. These are literals in the SDK binary:

```
"API Error: 401 Invalid API key · Please run /login"
"Your session has expired. Please run /login to sign in again."
```

So a lapsed login *is* the naming session's answer. It overwrites the truncated-prompt name the renderer had already applied, and `updateTerminalTabName` persists it to `session-names.json` and `terminal-sessions.json` and broadcasts it to the remote UI. Seven such entries on one machine, all `custom: false`, all on `mode: "chat"` tabs.

## The fix

`_isCliFailureText` — one guard, applied at the three points that consume a Haiku text block verbatim:

| Call site | Before | After |
|---|---|---|
| `generateTabName` | the tab is renamed to the error | `null` → the tab keeps its truncated-prompt name |
| `enhancePrompt` | the user's own prompt is replaced by the error | the original prompt is kept |
| `runHaikuPrompt` | the error becomes the commit message / PR description | `null` → the heuristic generator takes over |

The last one is why the guard is not scoped to naming alone: `runHaikuPrompt` backs `commitMessageGenerator` and `prDescriptionGenerator`, so that failure mode writes the error into git history.

## Why these patterns

The risk in a filter like this is the false positive — silently dropping a legitimate title. So the patterns are anchored on the CLI's own phrasing rather than on keywords:

- `/^api error:/i` keeps the colon. `API error handling middleware` is a plausible title and still gets through; `API Error: 401 …` does not.
- `/\bplease run \/login\b/i` rather than `/login`. `Fix /login redirect` is a plausible title; nothing but the CLI says *please run* `/login`.
- The remaining patterns (`^not logged in`, `^invalid api key`, `session (has )?expired`, `credit balance too low`, `usage limit reached`) cover the other auth and quota texts the binary carries.

A false positive costs a fallback name, never a wrong one — which is the right way round for a guard whose whole job is to prefer saying nothing.

## Verification

- 83 suites / 2269 tests green, 15 new — every failure string found in the SDK binary is refused, and five realistic titles chosen to sit next to those patterns (`Fix /login redirect`, `API error handling middleware`, `Debug expired token refresh`, …) all pass through.
- Main-process only; no renderer rebuild needed.
