### PR TITLE
fix(tabs): drop the login errors already saved as session names

### DIFF
--- a/src/main/services/ChatService.js
+++ b/src/main/services/ChatService.js
@@ -10,6 +10,7 @@ const { app } = require('electron');
 const { execFileSync } = require('child_process');
 const ModelCatalogService = require('./ModelCatalogService');
 const AccountManager = require('./AccountManager');
+const { isCliFailureText } = require('../../shared/cli-failure-text');
 
 let sdkPromise = null;
 let resolvedRuntime = null;
@@ -71,30 +72,6 @@ const MAX_TOUCHED_FILES = 200;
  * dispatch, report back) never reaches it. An explicit maxTurns still wins.
  */
 const RESTRICTED_SESSION_MAX_TURNS = 40;
-
-/**
- * Signatures of a CLI failure that the SDK hands back as ordinary assistant
- * text instead of as a stream error.
- *
- * The short haiku helpers (tab naming, prompt enhancement, commit messages)
- * read the first text block and use it verbatim, so an expired login turns a
- * tab into "Not logged in · Please run /login" — persisted to
- * session-names.json and broadcast to the remote UI. Text matching any of these
- * is refused so each caller falls back to what it already had.
- *
- * Deliberately anchored on the CLI's own phrasing: a title *about* login
- * ("Fix /login redirect") has to keep going through.
- */
-const CLI_FAILURE_TEXT = [
-  /^api error:/i,
-  /^not logged in\b/i,
-  /^invalid api key\b/i,
-  /\bplease run \/login\b/i,
-  /\bplease run `?claude (login|auth)\b/i,
-  /\bsession (has )?expired\b/i,
-  /\bcredit balance (is )?too low\b/i,
-  /\busage limit reached\b/i,
-];
 
 /**
  * Note a file this session wrote, for `_sessionContext`.
@@ -1672,13 +1649,14 @@ class ChatService {
    * Does this haiku answer look like the CLI reporting a failure rather than
    * doing the job it was asked?
    *
+   * The patterns live in `src/shared/cli-failure-text.js` because the renderer
+   * asks the same question of the names this guard was added too late to stop.
+   *
    * @param {string} text  the assistant text block, unnormalized
    * @returns {boolean}
    */
   _isCliFailureText(text) {
-    const trimmed = (text || '').trim();
-    if (!trimmed) return false;
-    return CLI_FAILURE_TEXT.some(re => re.test(trimmed));
+    return isCliFailureText(text);
   }
 
   /**

--- a/src/renderer/services/TerminalSessionService.js
+++ b/src/renderer/services/TerminalSessionService.js
@@ -6,6 +6,7 @@
  */
 
 const { fs, path } = window.electron_nodeModules;
+const { isCliFailureText } = require('../../shared/cli-failure-text');
 
 // Debounce timer for saves
 let saveTimer = null;
@@ -42,6 +43,16 @@ async function loadSessionData() {
 
     // Validate structure
     if (!data || typeof data !== 'object' || !data.projects) return null;
+
+    // Names written before the naming guard existed: a lapsed login was saved
+    // as the tab's own title, so every restart restores a tab called "Not
+    // logged in · Please run /login". Clearing it restores the default (the
+    // project name); a name the user typed is theirs, whatever it says.
+    for (const session of Object.values(data.projects)) {
+      for (const tab of (session?.tabs || [])) {
+        if (!tab.nameCustom && isCliFailureText(tab.name)) tab.name = null;
+      }
+    }
 
     return data;
   } catch (e) {

--- a/src/renderer/ui/components/TerminalManager.js
+++ b/src/renderer/ui/components/TerminalManager.js
@@ -6,6 +6,7 @@
 
 const { BaseComponent } = require('../../core/BaseComponent');
 const { matchesSessionQuery } = require('../../utils/sessionSearch');
+const { isCliFailureText } = require('../../../shared/cli-failure-text');
 const { isSidebarNavigation } = require('../navigationMode');
 
 const { Terminal } = require('@xterm/xterm');
@@ -2669,6 +2670,19 @@ class TerminalManager extends BaseComponent {
     } catch {
       this._namesCache = {};
     }
+    // Names written before the naming guard existed: a lapsed login was saved
+    // as the session's own title. Dropping the entry falls the list back to the
+    // session's first prompt. Custom names are the user's and are left alone.
+    let healed = false;
+    for (const [sessionId, entry] of Object.entries(this._namesCache)) {
+      const custom = typeof entry === 'object' && !!entry?.custom;
+      const name = typeof entry === 'string' ? entry : entry?.name;
+      if (!custom && isCliFailureText(name)) {
+        delete this._namesCache[sessionId];
+        healed = true;
+      }
+    }
+    if (healed) await this._saveSessionNames();
     return this._namesCache;
   }
 

--- a/src/shared/cli-failure-text.js
+++ b/src/shared/cli-failure-text.js
@@ -1,0 +1,42 @@
+/**
+ * Signatures of a CLI failure that the SDK hands back as ordinary assistant
+ * text instead of as a stream error.
+ *
+ * The short haiku helpers (tab naming, prompt enhancement, commit messages)
+ * read the first text block and use it verbatim, so an expired login turns a
+ * tab into "Not logged in · Please run /login" — persisted to
+ * session-names.json and broadcast to the remote UI. Text matching any of these
+ * is refused so each caller falls back to what it already had.
+ *
+ * Deliberately anchored on the CLI's own phrasing: a title *about* login
+ * ("Fix /login redirect") has to keep going through.
+ *
+ * Shared, because two sides need the same answer: the main process refuses the
+ * text before it becomes a name, and the renderer drops the names written
+ * before that guard existed.
+ */
+const CLI_FAILURE_TEXT = [
+  /^api error:/i,
+  /^not logged in\b/i,
+  /^invalid api key\b/i,
+  /\bplease run \/login\b/i,
+  /\bplease run `?claude (login|auth)\b/i,
+  /\bsession (has )?expired\b/i,
+  /\bcredit balance (is )?too low\b/i,
+  /\busage limit reached\b/i,
+];
+
+/**
+ * Does this text look like the CLI reporting a failure rather than doing the
+ * job it was asked?
+ *
+ * @param {string} text  an assistant text block, or a name persisted from one
+ * @returns {boolean}
+ */
+function isCliFailureText(text) {
+  const trimmed = (text || '').trim();
+  if (!trimmed) return false;
+  return CLI_FAILURE_TEXT.some(re => re.test(trimmed));
+}
+
+module.exports = { CLI_FAILURE_TEXT, isCliFailureText };

--- a/tests/features/SessionNameHealing.test.js
+++ b/tests/features/SessionNameHealing.test.js
@@ -1,0 +1,102 @@
+/**
+ * session-names.json is what the Resume list reads, so a name poisoned by a
+ * CLI failure survives there long after the tab it came from is gone. The
+ * naming guard cannot reach those — they were written before it existed — so
+ * the loader drops them on the way in and rewrites the file once.
+ */
+
+// xterm's WebGL addon probes navigator/UA at require time; not exercised here.
+jest.mock('@xterm/addon-webgl', () => ({ WebglAddon: class { onContextLoss() {} dispose() {} } }));
+
+let TerminalManager;
+
+beforeAll(() => {
+  window.electron_api = {
+    ...window.electron_api,
+    terminal: {
+      create: jest.fn(async () => ({ success: true, id: 1 })),
+      input: jest.fn(),
+      resize: jest.fn(),
+      kill: jest.fn(),
+      onData: jest.fn(() => () => {}),
+      onExit: jest.fn(() => () => {}),
+    },
+  };
+  ({ TerminalManager } = require('../../src/renderer/ui/components/TerminalManager'));
+});
+
+let tm;
+let written;
+
+/** Stand the loader up over a fake session-names.json. */
+const withNamesOnDisk = (names) => {
+  tm = new TerminalManager();
+  tm._namesCache = null;
+  tm._fsp = {
+    readFile: jest.fn(async () => JSON.stringify(names)),
+    writeFile: jest.fn(async (_path, data) => { written = JSON.parse(data); }),
+  };
+  return tm;
+};
+
+beforeEach(() => {
+  written = null;
+  document.body.innerHTML = `
+    <div id="terminals-tabs"></div>
+    <div id="terminals-container"></div>
+    <div id="empty-terminals"></div>
+    <div id="terminals-filter"></div>`;
+});
+
+describe('_loadSessionNames healing', () => {
+  test('drops a generated name that is really a CLI failure', async () => {
+    const tm = withNamesOnDisk({
+      's1': { name: 'Not logged in · Please run /login', custom: false },
+      's2': { name: 'Refonte left menu', custom: false },
+    });
+
+    const names = await tm._loadSessionNames();
+
+    expect(names.s1).toBeUndefined();
+    expect(names.s2.name).toBe('Refonte left menu');
+  });
+
+  test('drops a bare-string entry too — those predate the custom flag', async () => {
+    const tm = withNamesOnDisk({ 's1': 'Not logged in · Please run /login' });
+
+    expect(await tm._loadSessionNames()).toEqual({});
+  });
+
+  test('keeps a name the user chose, whatever it says', async () => {
+    const tm = withNamesOnDisk({
+      's1': { name: 'Not logged in · Please run /login', custom: true },
+    });
+
+    const names = await tm._loadSessionNames();
+
+    expect(names.s1.name).toBe('Not logged in · Please run /login');
+  });
+
+  test('rewrites the file once, and only when something was dropped', async () => {
+    const poisoned = withNamesOnDisk({
+      's1': { name: 'Not logged in · Please run /login', custom: false },
+      's2': { name: 'Refonte left menu', custom: false },
+    });
+    await poisoned._loadSessionNames();
+    expect(poisoned._fsp.writeFile).toHaveBeenCalledTimes(1);
+    expect(written).toEqual({ 's2': { name: 'Refonte left menu', custom: false } });
+
+    const clean = withNamesOnDisk({ 's2': { name: 'Refonte left menu', custom: false } });
+    await clean._loadSessionNames();
+    expect(clean._fsp.writeFile).not.toHaveBeenCalled();
+  });
+
+  test('the cache is served on the second call, without re-reading', async () => {
+    const tm = withNamesOnDisk({ 's1': { name: 'Refonte left menu', custom: false } });
+
+    await tm._loadSessionNames();
+    await tm._loadSessionNames();
+
+    expect(tm._fsp.readFile).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/services/TerminalSessionService.test.js
+++ b/tests/services/TerminalSessionService.test.js
@@ -1,0 +1,73 @@
+/**
+ * Restoring terminal sessions must not bring a CLI failure back as a tab title.
+ *
+ * Before the naming guard, a lapsed login was persisted as the tab's own name,
+ * so the tab came back called "Not logged in · Please run /login" on every
+ * launch — the guard stops new ones, it cannot undo the ones already on disk.
+ */
+
+jest.mock('../../src/renderer/state/settings.state', () => ({
+  getSetting: () => true, // restoreTerminalSessions
+}));
+
+const { loadSessionData } = require('../../src/renderer/services/TerminalSessionService');
+
+const readFile = window.electron_nodeModules.fs.promises.readFile;
+
+const onDisk = (projects) =>
+  readFile.mockResolvedValue(JSON.stringify({ version: 1, projects }));
+
+beforeEach(() => {
+  readFile.mockReset();
+});
+
+describe('loadSessionData name healing', () => {
+  test('clears a generated name that is really a CLI failure', async () => {
+    onDisk({
+      p1: {
+        tabs: [
+          { cwd: '/repo', mode: 'chat', name: 'Not logged in · Please run /login', nameCustom: false },
+          { cwd: '/repo', mode: 'chat', name: 'Refonte left menu', nameCustom: false },
+        ],
+      },
+    });
+
+    const data = await loadSessionData();
+
+    // Cleared, not deleted — restore falls back to the project name.
+    expect(data.projects.p1.tabs[0].name).toBeNull();
+    expect(data.projects.p1.tabs[1].name).toBe('Refonte left menu');
+  });
+
+  test('keeps a name the user typed, whatever it says', async () => {
+    onDisk({
+      p1: {
+        tabs: [{ cwd: '/repo', name: 'Not logged in · Please run /login', nameCustom: true }],
+      },
+    });
+
+    const data = await loadSessionData();
+
+    expect(data.projects.p1.tabs[0].name).toBe('Not logged in · Please run /login');
+  });
+
+  test('heals every project and tolerates one with no tabs', async () => {
+    onDisk({
+      p1: { tabs: [{ name: 'API Error: 401 Invalid API key · Please run /login', nameCustom: false }] },
+      p2: { tabs: [{ name: 'Credit balance is too low', nameCustom: false }] },
+      p3: {},
+    });
+
+    const data = await loadSessionData();
+
+    expect(data.projects.p1.tabs[0].name).toBeNull();
+    expect(data.projects.p2.tabs[0].name).toBeNull();
+    expect(data.projects.p3.tabs).toBeUndefined();
+  });
+
+  test('returns null when there is nothing saved', async () => {
+    readFile.mockRejectedValue(Object.assign(new Error('missing'), { code: 'ENOENT' }));
+
+    expect(await loadSessionData()).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #130. Follow-up to #129, which fixed #128.

#129 stopped the naming session from turning a lapsed login into a tab title. It could only stop new ones — the names written before it are still on disk, and nothing reads them critically, so a tab called `Not logged in · Please run /login` keeps coming back at every launch and keeps sitting in the Resume list. Eleven such entries on one machine, all `custom: false`.

## What changes

Both loaders now refuse the text on the way in, using the patterns #129 already established.

| Loader | File | What it does |
|---|---|---|
| `TerminalManager._loadSessionNames` | `session-names.json` | drops the entry, so the list falls back to the session's own first prompt, and rewrites the file once so the next launch has nothing left to heal |
| `TerminalSessionService.loadSessionData` | `terminal-sessions.json` | clears the tab's name, restoring the default of the project name |

`tabs.json` needs nothing: it is a snapshot rewritten every 3 s from live state.

Neither touches a name the user chose. `custom` / `nameCustom` is theirs whatever it says — a session about the login flow is a perfectly ordinary thing to name that way.

## The shared module

`CLI_FAILURE_TEXT` and the trim-and-test moved from `ChatService` to `src/shared/cli-failure-text.js`, unchanged, because both sides now ask the same question and the renderer cannot reach into the main process. `_isCliFailureText` stays as a one-line delegate, so its existing tests keep covering the patterns.

## Tests

`npm test` — 102 suites, 2550 tests, all passing. 9 new ones:

- `tests/features/SessionNameHealing.test.js` — the poisoned entry is dropped, a bare-string entry (which predates the `custom` flag) too, a custom name is kept whatever it says, the file is rewritten once and only when something was actually dropped, and the cache is still served on the second call.
- `tests/services/TerminalSessionService.test.js` — the name is cleared rather than deleted, a custom name survives, every project is healed, a project with no tabs is tolerated.

## Verified

On the machine from #130: 11 entries in `session-names.json` and 3 in `terminal-sessions.json`, all cleared on the next launch, with the sessions falling back to their first prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)