### PR TITLE
fix(tasks): stop every background task in the drawer from reading "0m"

### DIFF
--- a/src/renderer/ui/components/ChatView.js
+++ b/src/renderer/ui/components/ChatView.js
@@ -7402,7 +7402,6 @@ class ChatView extends BaseComponent {
 
   const { backgroundTasksState, listTasks: listAllTasks, getTask: getStoredTask } =
     require('../../state/backgroundTasks.state');
-  const { formatDuration: fmtTaskDuration } = require('../../utils/format');
 
   let tasksTicker = null;
   // Tasks already announced to the user, so the drawer opens on the moment a
@@ -7440,6 +7439,8 @@ class ChatView extends BaseComponent {
     const row = (task) => {
       const live = task.status === 'running';
       const end = live ? Date.now() : (task.endedAt || Date.now());
+      // Seconds, which is what `fmtDur` counts in. The identically named
+      // export from utils/format counts milliseconds and reads these as "0m".
       const secs = Math.max(0, Math.round((end - task.startedAt) / 1000));
       const tokens = taskTokens(task.usage);
       return `
@@ -7448,7 +7449,7 @@ class ChatView extends BaseComponent {
             <div class="chat-task-row-desc">${escapeHtml(task.description || taskTypeLabel(task))}</div>
             <div class="chat-task-row-meta">
               <span class="chat-task-row-type">${escapeHtml(taskTypeLabel(task))}</span>
-              <span class="chat-task-row-time">${escapeHtml(fmtTaskDuration(secs))}</span>
+              <span class="chat-task-row-time">${escapeHtml(fmtDur(secs))}</span>
               ${tokens ? `<span class="chat-task-row-tokens">${escapeHtml(tokens)}</span>` : ''}
             </div>
           </div>

--- a/tests/ui/chatTasksDrawer.test.js
+++ b/tests/ui/chatTasksDrawer.test.js
@@ -1,0 +1,121 @@
+/**
+ * Background tasks drawer — the duration each row reports.
+ *
+ * ChatView holds two same-named duration helpers: `fmtDur` counts seconds,
+ * `utils/format`'s export counts milliseconds. The drawer computes seconds, so
+ * handing them to the millisecond one read every task as "0m" until it had run
+ * for the better part of a day.
+ */
+
+/** api mock: `on*` captures its callback, everything else resolves to a bare success. */
+function makeApiMock(listeners) {
+  const ns = () => new Proxy({}, {
+    get: (_t, method) => (...args) => {
+      if (typeof method === 'string' && method.startsWith('on')) {
+        listeners[method] = args[0];
+        return () => {};
+      }
+      return Promise.resolve({ success: true, messages: [] });
+    }
+  });
+  return new Proxy({}, { get: () => ns() });
+}
+
+let uuidSeq = 0;
+Object.defineProperty(global, 'crypto', {
+  value: { ...(global.crypto || {}), randomUUID: () => `uuid-${++uuidSeq}` },
+  configurable: true,
+});
+
+describe('background tasks drawer', () => {
+  let listeners, wrapper, view, sessionId, store, now;
+
+  /** The clock both the store and the drawer read. */
+  const advance = (ms) => { now += ms; };
+
+  // State notifies its subscribers on the next frame, so the drawer has not
+  // re-rendered yet when the store call returns.
+  const flush = () => new Promise(r => setTimeout(r, 0));
+
+  const timeOf = (taskId) =>
+    wrapper.querySelector(`.chat-task-row[data-task-id="${taskId}"] .chat-task-row-time`)?.textContent;
+
+  const start = async (taskId, extra = {}) => {
+    store.taskStarted({ taskId, sessionId, taskType: 'shell', description: `task ${taskId}`, ...extra });
+    await flush();
+  };
+
+  beforeEach(async () => {
+    jest.resetModules();
+    listeners = {};
+    window.electron_api = makeApiMock(listeners);
+    document.body.innerHTML = '';
+    wrapper = document.createElement('div');
+    document.body.appendChild(wrapper);
+    const { createChatView } = require('../../src/renderer/ui/components/ChatView');
+    view = createChatView(wrapper, { id: 'p1', name: 'Test', path: '/tmp/test' });
+    // A real send opens the session, so the tasks below carry the id the
+    // drawer filters on instead of bypassing that guard.
+    view.sendMessage('go');
+    await new Promise(r => setTimeout(r, 0));
+    sessionId = view.getSessionId();
+    expect(sessionId).toBeTruthy();
+
+    // Same module instance the drawer resolved, since both requires follow the
+    // same resetModules.
+    store = require('../../src/renderer/state/backgroundTasks.state');
+    now = 1_700_000_000_000;
+    jest.spyOn(Date, 'now').mockImplementation(() => now);
+  });
+
+  afterEach(() => {
+    Date.now.mockRestore?.();
+    try { store?.reset(); } catch (_) { /* teardown is best effort */ }
+    try { view?.destroy?.(); } catch (_) { /* teardown is best effort */ }
+  });
+
+  it('opens on the first task and counts it in seconds', async () => {
+    await start('t1');
+
+    expect(wrapper.querySelector('.chat-tasks-drawer').hidden).toBe(false);
+    expect(timeOf('t1')).toBe('0s');
+  });
+
+  it('reports a running task in minutes and seconds, not "0m"', async () => {
+    await start('t1');
+    advance(95_000);
+    await start('t2'); // a second task re-renders the drawer off the moved clock
+
+    expect(timeOf('t1')).toBe('1m 35s');
+  });
+
+  it('freezes a finished task at the time it actually took', async () => {
+    await start('t1');
+    advance(100_000);
+    store.taskEnded({ taskId: 't1', sessionId, status: 'completed' });
+    await flush();
+
+    expect(timeOf('t1')).toBe('1m 40s');
+
+    // Still the elapsed span, not a clock that keeps running after the end.
+    advance(60_000);
+    await start('t2');
+    expect(timeOf('t1')).toBe('1m 40s');
+  });
+
+  it('reports hours for a long run', async () => {
+    await start('t1');
+    advance(2 * 3_600_000 + 5 * 60_000);
+    await start('t2');
+
+    expect(timeOf('t1')).toBe('2h 5m');
+  });
+
+  it('leaves another session\'s tasks out', async () => {
+    store.taskStarted({ taskId: 'other', sessionId: 'someone-else', description: 'not mine' });
+    await start('t1');
+
+    expect(timeOf('other')).toBeUndefined();
+    expect(timeOf('t1')).toBe('0s');
+  });
+});


### PR DESCRIPTION
Fixes #131

## The bug

The background tasks drawer reports `0m` on every row, running or finished. On a real session: 1 running, 248 finished, all `0m` — one workflow row shows `0m` beside `1983.5k` tokens.

`ChatView.js` carries two duration helpers with the same name, in different units:

| Helper | Import | Unit |
|---|---|---|
| `fmtDur` | `utils/toolRegistry` (`ChatView.js:21`) | seconds |
| `fmtTaskDuration` | `utils/format` (`ChatView.js:7405`) | milliseconds |

The drawer computes seconds and hands them to the millisecond one:

```js
const secs = Math.max(0, Math.round((end - task.startedAt) / 1000));
...
<span class="chat-task-row-time">${escapeHtml(fmtTaskDuration(secs))}</span>
```

A ten-minute task arrives as `600`, is read as 600 ms, and `formatDuration` returns the literal `"0m"` (`alwaysShowMinutes` defaults to `true`). The threshold for a row to say `1m` is 60000 s, i.e. 16 h 40 min; `1h` needs 41 days. Every other caller of that export passes milliseconds, so the drawer was the single wrong caller.

## The fix

The row formats with `fmtDur`, the seconds-based helper already in scope — the same one the inline background-task cards use for their elapsed time — and the millisecond import goes with it.

| Elapsed | Before | After |
|---|---|---|
| 0 s | `0m` | `0s` |
| 45 s | `0m` | `45s` |
| 95 s | `0m` | `1m 35s` |
| 2 h 5 min | `0m` | `2h 5m` |

Leaving one duration helper in the file rather than two identically named ones is half the point: that collision is what made the call easy to get wrong. Sub-minute rows now read in seconds, which is what a bash task usually shows.

## Verification

- 102 suites / 2551 tests green, 5 new (`tests/ui/chatTasksDrawer.test.js`): the drawer mounted for real, fed through `backgroundTasks.state`, asserting `0s` / `1m 35s` / `2h 5m`, that a finished task freezes at what it took rather than following the clock, and that another session's tasks stay out. All 5 fail on `main`.
- Renderer change, so `npm run build:renderer` is needed for a local run.