### PR TITLE
fix(usage): stop re-reading the credential store on every usage poll

### DIFF
--- a/src/main/services/UsageService.js
+++ b/src/main/services/UsageService.js
@@ -4,7 +4,7 @@
  */
 
 const https = require('https');
-const { readAccessToken, readCredentialsForDir, tokenFromCredentials } = require('../utils/claudeCredentials');
+const { readCredentials, readCredentialsForDir, tokenFromCredentials } = require('../utils/claudeCredentials');
 
 // Per-account state.
 //
@@ -49,7 +49,8 @@ function entryFor(accountId) {
       isStale: false,
       lastLimitNotifiedReset: null,
       tokenCache: null,
-      tokenCacheTime: 0
+      tokenCacheUntil: 0,
+      rejectedToken: null
     };
     entries.set(k, entry);
   }
@@ -61,9 +62,34 @@ const OAUTH_BETA_HEADER = 'oauth-2025-04-20';
 
 // ── OAuth API (primary) ──
 
-// Token cache TTL, to avoid hitting the credential store (and, on macOS, the
-// Keychain) on every poll.
-const TOKEN_CACHE_TTL = 30000; // 30s
+// Token cache lifetimes.
+//
+// Reading the store is not free on macOS: the credentials live in the login
+// Keychain, in an item created by the Claude CLI whose ACL does not list this
+// app, so every read that misses the cache raises a system password prompt. The
+// renderer polls usage once a minute, so any TTL shorter than that expired
+// before every single tick — and because the window need only be visible, not
+// focused, the prompts were raised behind it and surfaced in a batch the moment
+// the app came back to the front.
+//
+// A token is therefore held until it actually expires, and an absent or
+// unreadable one is cached too, so a refusal is not retried a minute later.
+const TOKEN_CACHE_MAX = 6 * 60 * 60 * 1000;   // cap for a long-lived token
+const TOKEN_CACHE_BACKOFF = 15 * 60 * 1000;   // no token, or store unreadable
+const TOKEN_EXPIRY_MARGIN = 60 * 1000;        // re-read shortly before expiry
+
+/**
+ * The credentials an account authenticates with: its own store when it is
+ * bound to one, the machine-wide login otherwise.
+ *
+ * @param {string|null} accountId
+ * @returns {Promise<Object|null>}
+ */
+function readCredentialsFor(accountId) {
+  if (!accountId) return readCredentials();
+  const { accountConfigDir } = require('./AccountManager');
+  return readCredentialsForDir(accountConfigDir(accountId));
+}
 
 /**
  * Read the OAuth access token for an account.
@@ -79,20 +105,32 @@ const TOKEN_CACHE_TTL = 30000; // 30s
 async function readOAuthToken(accountId) {
   const entry = entryFor(accountId);
   const now = Date.now();
-  if (entry.tokenCache !== null && now - entry.tokenCacheTime < TOKEN_CACHE_TTL) {
-    return entry.tokenCache;
-  }
+  if (now < entry.tokenCacheUntil) return entry.tokenCache;
+
+  let token = null;
+  let expiresAt = null;
   try {
-    if (accountId) {
-      const { accountConfigDir } = require('./AccountManager');
-      entry.tokenCache = tokenFromCredentials(await readCredentialsForDir(accountConfigDir(accountId)));
-    } else {
-      entry.tokenCache = await readAccessToken();
-    }
+    const creds = await readCredentialsFor(accountId);
+    token = tokenFromCredentials(creds);
+    expiresAt = creds?.claudeAiOauth?.expiresAt ?? null;
   } catch (e) {
-    entry.tokenCache = null;
+    // Store unreadable: Keychain access refused, or the file is malformed.
+    // Treated as no token, and backed off, rather than retried on every tick.
   }
-  entry.tokenCacheTime = now;
+
+  if (token !== null && token === entry.rejectedToken) {
+    // The store still holds the token the API just refused. Reading it again
+    // buys nothing until the CLI writes a new one.
+    entry.tokenCache = null;
+    entry.tokenCacheUntil = now + TOKEN_CACHE_BACKOFF;
+    return null;
+  }
+
+  entry.rejectedToken = null;
+  entry.tokenCache = token;
+  entry.tokenCacheUntil = token
+    ? Math.min(expiresAt !== null ? expiresAt - TOKEN_EXPIRY_MARGIN : Infinity, now + TOKEN_CACHE_MAX)
+    : now + TOKEN_CACHE_BACKOFF;
   return entry.tokenCache;
 }
 
@@ -100,7 +138,7 @@ async function readOAuthToken(accountId) {
  * Drop cached tokens and figures — for one account, or all of them.
  *
  * The numbers belong to the account they were fetched for, so serving them for
- * another would be a plain lie, and the 30s token cache would keep querying the
+ * another would be a plain lie, and the cached token would keep querying the
  * outgoing one. Called with no id after a change to the machine-wide store,
  * which every unbound project reads.
  *
@@ -109,7 +147,8 @@ async function readOAuthToken(accountId) {
 function invalidateCredentials(accountId) {
   const reset = (entry) => {
     entry.tokenCache = null;
-    entry.tokenCacheTime = 0;
+    entry.tokenCacheUntil = 0;
+    entry.rejectedToken = null;
     entry.usageData = null;
     entry.lastFetch = null;
     entry.isStale = false;
@@ -229,7 +268,9 @@ function fetchUsageFromAPI(token) {
       res.on('data', chunk => body += chunk);
       res.on('end', () => {
         if (res.statusCode !== 200) {
-          return reject(new Error(`API ${res.statusCode}: ${body.slice(0, 200)}`));
+          const err = new Error(`API ${res.statusCode}: ${body.slice(0, 200)}`);
+          err.statusCode = res.statusCode;
+          return reject(err);
         }
         try {
           const json = JSON.parse(body);
@@ -278,6 +319,13 @@ async function fetchUsage(accountId) {
         return data;
       } catch (apiErr) {
         entry.lastError = apiErr.message;
+        // A refused token is worth one re-read: the CLI may have rotated it.
+        // readOAuthToken() stops re-reading once the store gives back this same
+        // token, so this cannot turn into a Keychain prompt loop on macOS.
+        if (apiErr.statusCode === 401 || apiErr.statusCode === 403) {
+          entry.rejectedToken = token;
+          entry.tokenCacheUntil = 0;
+        }
         console.log('[Usage] API request failed:', apiErr.message);
       }
     } else {

--- a/tests/services/UsageService.test.js
+++ b/tests/services/UsageService.test.js
@@ -102,3 +102,133 @@ describe('readBuckets', () => {
     expect(readBuckets({ limits: null })).toEqual([]);
   });
 });
+
+/**
+ * Guards the OAuth token cache.
+ *
+ * On macOS the machine-wide credentials live in the login Keychain, in an item
+ * created by the Claude CLI whose ACL does not list this app, so every read of
+ * the store is a system password prompt. The renderer polls usage once a
+ * minute; the cache used to hold the token for 30 seconds, so it expired before
+ * every single tick and the prompts piled up behind the window. These tests pin
+ * the read count.
+ */
+describe('OAuth token cache', () => {
+  const CREDENTIALS_MODULE = '../../src/main/utils/claudeCredentials';
+  const HOUR = 3600 * 1000;
+
+  let readCredentials;
+  let httpsGet;
+
+  /** Load a fresh UsageService over a mocked credential store and https. */
+  function load(statuses = [200]) {
+    const queue = [...statuses];
+    readCredentials = jest.fn();
+    httpsGet = jest.fn((options, callback) => {
+      const statusCode = queue.length > 1 ? queue.shift() : (queue[0] ?? 200);
+      const body = statusCode === 200 ? JSON.stringify({ limits: [] }) : 'unauthorized';
+      const res = {
+        statusCode,
+        on: (event, fn) => {
+          if (event === 'data') fn(body);
+          if (event === 'end') fn();
+          return res;
+        }
+      };
+      callback(res);
+      return { on: jest.fn(), destroy: jest.fn() };
+    });
+
+    jest.resetModules();
+    // Only the store read is faked; tokenFromCredentials stays real, since the
+    // expiry rule it applies is part of what these tests exercise.
+    jest.doMock(CREDENTIALS_MODULE, () => ({
+      ...jest.requireActual(CREDENTIALS_MODULE),
+      readCredentials
+    }));
+    jest.doMock('https', () => ({ get: httpsGet }));
+    return require('../../src/main/services/UsageService');
+  }
+
+  const validCreds = (accessToken = 'token-a') =>
+    ({ claudeAiOauth: { accessToken, expiresAt: Date.now() + HOUR } });
+
+  afterEach(() => {
+    jest.dontMock(CREDENTIALS_MODULE);
+    jest.dontMock('https');
+    jest.resetModules();
+  });
+
+  test('reads the credential store once across repeated polls', async () => {
+    const usage = load();
+    readCredentials.mockResolvedValue(validCreds());
+
+    await usage.fetchUsage();
+    await usage.fetchUsage();
+    await usage.fetchUsage();
+
+    expect(readCredentials).toHaveBeenCalledTimes(1);
+    expect(httpsGet).toHaveBeenCalledTimes(3);
+  });
+
+  test('does not ask again on the next poll when the store is unreadable', async () => {
+    const usage = load();
+    readCredentials.mockRejectedValue(new Error('User canceled the operation.'));
+
+    expect(await usage.fetchUsage()).toBeNull();
+    expect(await usage.fetchUsage()).toBeNull();
+
+    expect(readCredentials).toHaveBeenCalledTimes(1);
+    expect(httpsGet).not.toHaveBeenCalled();
+  });
+
+  test('does not ask again on the next poll when the stored token has expired', async () => {
+    const usage = load();
+    readCredentials.mockResolvedValue({
+      claudeAiOauth: { accessToken: 'stale', expiresAt: Date.now() - 1000 }
+    });
+
+    await usage.fetchUsage();
+    await usage.fetchUsage();
+
+    expect(readCredentials).toHaveBeenCalledTimes(1);
+    expect(httpsGet).not.toHaveBeenCalled();
+  });
+
+  test('re-reads once when the API refuses the token, then stops', async () => {
+    const usage = load([401]);
+    readCredentials.mockResolvedValue(validCreds());
+
+    await usage.fetchUsage(); // reads the store, gets a 401
+    await usage.fetchUsage(); // re-reads once in case the CLI rotated it
+    await usage.fetchUsage(); // store still holds the refused token: no read
+
+    expect(readCredentials).toHaveBeenCalledTimes(2);
+    expect(httpsGet).toHaveBeenCalledTimes(1);
+  });
+
+  test('picks up a token the CLI rotated after the API refused the old one', async () => {
+    const usage = load([401, 200]);
+    readCredentials
+      .mockResolvedValueOnce(validCreds('token-a'))
+      .mockResolvedValue(validCreds('token-b'));
+
+    await usage.fetchUsage();
+    await usage.fetchUsage();
+
+    expect(httpsGet).toHaveBeenCalledTimes(2);
+    expect(httpsGet.mock.calls[0][0].headers.Authorization).toBe('Bearer token-a');
+    expect(httpsGet.mock.calls[1][0].headers.Authorization).toBe('Bearer token-b');
+  });
+
+  test('re-reads the store after an account switch', async () => {
+    const usage = load();
+    readCredentials.mockResolvedValue(validCreds());
+
+    await usage.fetchUsage();
+    usage.invalidateCredentials();
+    await usage.fetchUsage();
+
+    expect(readCredentials).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/services/UsageServicePerAccount.test.js
+++ b/tests/services/UsageServicePerAccount.test.js
@@ -29,7 +29,12 @@ jest.mock('https', () => ({
 }));
 
 jest.mock('../../src/main/utils/claudeCredentials', () => ({
-  readAccessToken: jest.fn(async () => 'tok-machine'),
+  // The machine-wide store is read whole rather than through readAccessToken:
+  // the service caches a token until its own expiresAt, which only the full
+  // credentials carry.
+  readCredentials: jest.fn(async () => ({
+    claudeAiOauth: { accessToken: 'tok-machine', expiresAt: 4102444800000 }
+  })),
   readCredentialsForDir: jest.fn(async (dir) => ({
     claudeAiOauth: { accessToken: `tok-${dir.split('/').pop()}`, expiresAt: 4102444800000 }
   })),


### PR DESCRIPTION
Fixes #134.

On macOS the Claude CLI keeps its OAuth credentials in the login Keychain, in an
item whose ACL trusts the CLI and not this app, so **every read of that store is
a system password prompt**. The usage poll runs once a minute (`renderer.js`,
`startMonitor(60000)`) while the token cache held a token for 30 s, so the cache
expired before every single tick and each tick raised a prompt.

The poll only requires the window to be *visible*, not focused, so those prompts
were raised behind it and surfaced as a batch the moment the app came back to
the front — which is why it reads as "it asks for my password every time I focus
it". `showMainWindow() -> onWindowShow()` adds one more read on top.

## What changed

All in `src/main/services/UsageService.js`:

- **A token is held until its own `expiresAt`** (capped at 6 h) instead of 30 s,
  so a poll no longer misses the cache. That needs the full credentials rather
  than `readAccessToken()`, which discards the expiry — hence `readCredentials`
  / `readCredentialsForDir` + the existing `tokenFromCredentials`.
- **An absent, expired or unreadable token is cached too**, with a 15 min
  backoff. The old `tokenCache !== null` guard never cached those, so a refused
  Keychain prompt was retried a minute later, forever. This is the half that
  made the prompt feel relentless rather than merely frequent.
- **A 401/403 drops the cached token for one re-read**, so a token the CLI
  rotated early is still picked up behind the longer cache. `fetchUsageFromAPI`
  now attaches `statusCode` to its error so the caller can tell a refused token
  from a 500. If the store still returns the token the API just refused, it
  backs off instead of re-reading, so this cannot become a prompt loop.

Per-account behaviour is unchanged: the cache stays keyed by account, a bound
account is still read from its own credential directory, and
`invalidateCredentials()` still forces a re-read after a switch.

## Effect

Reads of the credential store go from about 60 an hour to one per token
lifetime.

## Tests

Six new cases in `tests/services/UsageService.test.js`, over a mocked credential
store and `https`, asserting the read count rather than the behaviour around it:

- one store read across three polls
- no second read after an unreadable store, or an expired token
- exactly one re-read after a 401, then backoff
- a token the CLI rotated is picked up after a 401
- an account switch still forces a re-read

All six fail on `main` and pass here.

`tests/services/UsageServicePerAccount.test.js` needed its machine-wide mock
updated from `readAccessToken` to `readCredentials`, since that path now reads
the whole credentials to get the expiry.

```
Test Suites: 3 failed, 97 passed, 100 total
Tests:       18 failed, 2469 passed, 2487 total
```

The 3 failures (`MarkdownRenderer`, `chatTaskWidget`, `TerminalModeSwitch`) are
identical on `main` at the same commit — 18 failing there too, untouched by this
branch.

## Not covered here

`Always Allow` still will not hold across updates: the shipped bundle is
ad-hoc/linker-signed with no `mac.identity` in `electron-builder.config.js`, so
the Keychain grant hangs off a `cdhash` that changes with every build. That is
described at the end of #134 and wants its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
