### PR TITLE
fix(artifacts): hide the Artifacts screen while it cannot be populated

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,6 +104,14 @@
           </svg>
           <span data-i18n="ui.tabClaude">Claude</span>
         </button>
+        <!-- Hidden, not removed. The screen lists `published` artifacts only, and
+             the sole producer of that kind is the Agent SDK's `Artifact` tool, which
+             a Claude Terminal chat session is never offered: the tool is absent from
+             every headless SDK session. The gallery is empty by construction, so the
+             entry point is withdrawn until it can hold something. Everything behind
+             it stays: the panel, the store, the IPC layer, the artifact_* MCP tools,
+             and the chat's Documents tab, which still shows what a conversation
+             produced. Restore this button the day `published` can exist.
         <button class="nav-tab" data-tab="artifacts" title="Artifacts" data-i18n-title="ui.tooltipArtifacts">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <path d="M12 2l8 4.5v9L12 20l-8-4.5v-9L12 2z"/>
@@ -112,6 +120,7 @@
           </svg>
           <span data-i18n="artifacts.tabTitle">Artifacts</span>
         </button>
+        -->
         <button class="nav-tab" data-tab="dashboard" title="Dashboard" data-i18n-title="ui.tooltipDashboard">
           <svg viewBox="0 0 24 24" fill="currentColor">
             <path d="M3 13h8V3H3v10zm0 8h8v-6H3v6zm10 0h8V11h-8v10zm0-18v6h8V3h-8z"/>

--- a/renderer.js
+++ b/renderer.js
@@ -3766,7 +3766,11 @@ document.querySelectorAll('.nav-tab[data-tab]').forEach(tab => {
 // ========== PINNED TABS SYSTEM ==========
 // Canonical order — must mirror the grouping in index.html, since the groups
 // carry meaning (whether the project tab drives the screen).
-const _ALL_TABS_ORDER = ['claude', 'artifacts', 'dashboard', 'files', 'git', 'session-replay', 'tasks', 'control-tower', 'workspace', 'memory', 'timetracking', 'database', 'skills', 'agents', 'plugins', 'mcp', 'workflows', 'errorlog', 'connectivity'];
+// 'artifacts' is deliberately absent: its nav button is commented out in
+// index.html because the screen cannot be populated (see the note there). Both
+// the customize modal and the More dropdown are built from this list, so
+// leaving it in would offer a tab that no longer exists in the DOM.
+const _ALL_TABS_ORDER = ['claude', 'dashboard', 'files', 'git', 'session-replay', 'tasks', 'control-tower', 'workspace', 'memory', 'timetracking', 'database', 'skills', 'agents', 'plugins', 'mcp', 'workflows', 'errorlog', 'connectivity'];
 
 function applyPinnedTabs() {
   const pinned = settingsState.get().pinnedTabs || _ALL_TABS_ORDER;

--- a/resources/mcp-servers/tools/sidebar.js
+++ b/resources/mcp-servers/tools/sidebar.js
@@ -46,7 +46,9 @@ function saveSettings(settings) {
 const ALL_TABS = [
   'claude', 'git', 'database', 'mcp', 'plugins', 'skills',
   'agents', 'workflows', 'tasks', 'control-tower', 'dashboard', 'timetracking',
-  'session-replay', 'memory', 'workspace', 'artifacts', 'errorlog', 'connectivity',
+  // 'artifacts' is omitted on purpose: its sidebar button is hidden, so there is
+  // nothing to navigate to. TAB_LABELS keeps its entry for when it comes back.
+  'session-replay', 'memory', 'workspace', 'errorlog', 'connectivity',
 ];
 
 const TAB_LABELS = {

--- a/src/renderer/state/settings.state.js
+++ b/src/renderer/state/settings.state.js
@@ -70,7 +70,7 @@ const defaultSettings = {
   enhancePrompts: false, // Opt-in: reformulate prompts via Haiku for better prompt engineering before sending
   // Every tab is pinned by default: the grouped sidebar fits without overflow,
   // so the More menu is now opt-in rather than the default state.
-  pinnedTabs: ['claude', 'dashboard', 'files', 'git', 'session-replay', 'tasks', 'artifacts', 'control-tower', 'workspace', 'memory', 'timetracking', 'database', 'skills', 'agents', 'plugins', 'mcp', 'workflows', 'errorlog', 'connectivity'],
+  pinnedTabs: ['claude', 'dashboard', 'files', 'git', 'session-replay', 'tasks', 'control-tower', 'workspace', 'memory', 'timetracking', 'database', 'skills', 'agents', 'plugins', 'mcp', 'workflows', 'errorlog', 'connectivity'],
   activeTab: 'claude', // Last active sidebar tab (restored on restart)
   openProjectIds: [], // Projects with a tab in the project bar, in tab order (restored on restart)
   navigationMode: null, // 'tabs' | 'sidebar' | null = never chosen, ask once on next launch
@@ -146,11 +146,12 @@ function _migrateSettings(saved) {
     saved.activeTab = 'connectivity';
   }
 
-  // Workspaces, Error Log and Artifacts were never in the default pinned set,
-  // so nobody could have deliberately unpinned them. The grouped sidebar has
-  // room now.
+  // Workspaces and Error Log were never in the default pinned set, so nobody
+  // could have deliberately unpinned them. The grouped sidebar has room now.
+  // Artifacts is no longer back-filled: its nav button is hidden, so pinning it
+  // would only widen the More dropdown with a tab that cannot be opened.
   if (Array.isArray(saved.pinnedTabs)) {
-    for (const id of ['workspace', 'errorlog', 'artifacts']) {
+    for (const id of ['workspace', 'errorlog']) {
       if (!saved.pinnedTabs.includes(id)) saved.pinnedTabs.push(id);
     }
     // Files is new, so an existing array cannot have deliberately excluded it.

--- a/tests/state/settings.test.js
+++ b/tests/state/settings.test.js
@@ -151,6 +151,20 @@ describe('loadSettings', () => {
     expect(getSetting('accentColor')).toBe('#d97706');
   });
 
+  test('back-fills workspace and errorlog into a saved pin list, but not artifacts', async () => {
+    window.electron_nodeModules.fs.promises.access.mockResolvedValue(undefined);
+    window.electron_nodeModules.fs.promises.readFile.mockResolvedValue(
+      JSON.stringify({ pinnedTabs: ['claude', 'git'] })
+    );
+
+    await loadSettings();
+
+    const tabs = getSetting('pinnedTabs');
+    expect(tabs).toContain('workspace');
+    expect(tabs).toContain('errorlog');
+    expect(tabs).not.toContain('artifacts');
+  });
+
   test('handles missing file gracefully', async () => {
     const enoent = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
     window.electron_nodeModules.fs.promises.access.mockRejectedValue(enoent);
@@ -496,6 +510,14 @@ describe('setting default values', () => {
     expect(tabs).toContain('claude');
     expect(tabs).toContain('git');
     expect(tabs).toContain('dashboard');
+  });
+
+  // The Artifacts nav button is commented out in index.html: the screen lists
+  // `published` artifacts only, and nothing in a Claude Terminal session can
+  // produce that kind. Pinning a tab whose button is absent would leave the
+  // customize modal offering a screen that cannot be opened.
+  test('pinnedTabs leaves out the hidden artifacts tab', () => {
+    expect(getSetting('pinnedTabs')).not.toContain('artifacts');
   });
 
   test('parallelMaxAgents defaults to 3', () => {


### PR DESCRIPTION
## The screen cannot fill

`00107bd` scoped the Artifacts screen to the published gallery, on the reasoning that a published artifact and a chat extract are two different things and should not be listed together. That reasoning holds. What it did not account for is that the `published` kind has a single producer:

```
Artifact tool call in the transcript  ->  fromArtifactTool()  ->  kind: 'published'  ->  Artifacts screen
```

`ArtifactService.js` has no other path to that kind. And the `Artifact` tool is never offered to a Claude Terminal chat session, because we drive the Agent SDK headless.

So the screen is empty by construction, in every project, for every user. It is not a filter that happens to match nothing right now; there is no input that can ever reach it.

## Evidence

On the machine where this surfaced:

| Check | Result |
|---|---|
| Artifacts in the store | 102 |
| of kind `published` | **0** |
| Sessions that ever published successfully | 6 |
| ... where a publish happened after the session reached Claude Terminal | **0** |

In all six, the last successful `Artifact` call predates the first `mcp__claude-terminal__*` call in the same transcript. The publishes come from the sessions' earlier interactive phase; the moment a session is resumed here, the tool is gone.

Ruling out the obvious explanations, each with a headless probe reading the `system/init` tool list:

- `--settings '{"enableArtifact": true}'` forced: still absent.
- Org policy cache (`~/.claude/policy-limits.json`) moved aside: still absent.
- `CLAUDE_CODE_ENTRYPOINT` set to `cli`, `sdk-ts`, `mcp`, or unset: absent in all four.
- OAuth scopes compared across three credential slots (max 20x, team x2): identical.

The gate in the CLI is `{ enableKey: "enableArtifact", legacyDisableKey: "disableArtifact", envDisableVar: "CLAUDE_CODE_DISABLE_ARTIFACT", defaultOn: true }`, so it is on by default and no local settings layer is switching it off. A headless session simply lists 29 built-ins and `Artifact` is not among them.

## What this does

Withdraws the entry point, and only that.

- `index.html`: the nav button is commented out **in place**, with the reason written next to it.
- `renderer.js`: `artifacts` leaves `_ALL_TABS_ORDER`, which is what builds the customize modal and the More dropdown. Leaving it would offer a tab whose button is no longer in the DOM.
- `settings.state.js`: out of the default pin set, and out of the back-fill loop that was force-adding it to existing users' saved lists.
- `sidebar.js`: out of `ui_navigate`'s tab list, so the MCP tool stops advertising a screen with no button. `TAB_LABELS` keeps its entry.

## What this does not do

Nothing is deleted. `ArtifactsPanel.js`, `ArtifactService.js`, `artifact-store.js`, the IPC layer, the `artifact_*` MCP tools, the CSS and the tests all stay. Extracts keep being captured and stay searchable, and the chat's **Documents** tab still shows what a conversation produced, which is where they belonged all along.

A stale `artifacts` left in a user's saved `pinnedTabs` or `tabsOrder` is harmless: `applyPinnedTabs()` walks the DOM, and `_applyTabsOrder()` already skips ids with no element.

Restoring the screen is uncommenting the button and putting the id back in those four lists.

## Tests

`tests/state/settings.test.js` gains two: the default pin set leaves `artifacts` out, and the back-fill adds `workspace` and `errorlog` to a saved list without re-adding `artifacts`. Full suite: 2543 passed, 100 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
