### PR TITLE
feat(chrome): let chat sessions drive the browser via the Claude extension

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,7 @@ Remote UI (PWA for mobile)
 | `git.ipc.js` | 69 | Status, branches, pull/push/merge/rebase, clone, stash, cherry-pick, revert, tag, blame, worktree, AI commit message, PR description, inline diff |
 | `github.ipc.js` | 26 | OAuth Device Flow, workflow runs, PRs, issues, reviews, GitHub Enterprise, repo search |
 | `chat.ipc.js` | 17 | Agent SDK streaming sessions, permissions, interrupt, model/effort/permission-mode switching, tab name generation, fork/rewind, skill/agent generation, session recap |
+| `chrome.ipc.js` | 4 | Claude in Chrome: status, install/remove native messaging host, open the extension page |
 | `dialog.ipc.js` | 21 | Window controls, file/folder dialogs, open in explorer/editor/browser, notifications, updates, startup, clipboard |
 | `explorer.ipc.js` | 3 | File explorer watcher (start/stop/onChanges) |
 | `mcp.ipc.js` | 2 | Start/stop MCP server processes |
@@ -111,7 +112,7 @@ Remote UI (PWA for mobile)
 | `fivem.ipc.js` | - | Delegated to `src/project-types/fivem/` |
 | `index.js` | - | Orchestrator - registers all handlers |
 
-**Total: 266 IPC handlers across 27 files.**
+**Total: 270 IPC handlers across 27 files.**
 
 ### Services (`src/main/services/`)
 
@@ -126,6 +127,7 @@ Remote UI (PWA for mobile)
 | `McpRegistryService.js` | MCP server registry browsing (`registry.modelcontextprotocol.io/v0.1`), pagination, caching |
 | `PluginService.js` | Read plugin metadata, PTY-based `/plugin install` |
 | `UpdaterService.js` | electron-updater, 30 min periodic checks, stale cache cleanup |
+| `ChromeBridgeService.js` | Claude in Chrome: detects the browser extension, installs the native messaging host (adopting Claude Code's rather than clobbering it), and hands chat sessions the `claude-in-chrome` MCP server |
 | `HooksService.js` | 15 Claude hook types, non-destructive install, auto-backup/repair |
 | `HookEventServer.js` | HTTP server on `127.0.0.1:0`, receives POST from hook handler |
 | `RemoteServer.js` | WebSocket + HTTP for PWA, dynamic port, 6-digit PIN auth, broadcast updates |
@@ -479,6 +481,7 @@ OS credential store (via keytar)       # GitHub token (Windows Credential Manage
 - **Remote control:** WS server with PIN auth, QR code, PWA in `remote-ui/`
 - **Model, effort and permission mode are per conversation:** the chat footer's chip (model · effort, right) and mode picker (left, as Claude Desktop places it) change the current tab only. The stored `chatModel` / `effortLevel` / `executionMode` are the defaults a new tab starts from, moved only through each menu's "Use for new conversations" row — a pick never writes them, so the last choice in one tab cannot silently become every later tab's. The model menu lists models only: the CLI's `default` alias is read for the model it points at (`recommendedModelId`, surfaced as the catalog's `recommended`) and then dropped (`dropDefaultAlias`), so an unpinned tab shows that model **by name** instead of a "Default (recommended)" row that stood for whichever model the CLI favoured that week. `chatModel: null` still means "nothing pinned"; pinning always stores a concrete id. Modes are the SDK's (`default`, `acceptEdits`, `plan`, `bypassPermissions`, `auto`), mapped to the legacy `executionMode` spellings in `src/shared/permission-modes.js`; `ChatService.setPermissionMode` switches mid-session and moves the app-side auto-approval with it. Fable is a hand-curated premium tier (`PREMIUM_FAMILIES` in `src/shared/model-options.js`, hand-curated because the CLI catalog says nothing about it): violet chip and composer border, "Premium" badge in the menu, a tag on the tab, and a dismissible notice above the composer when a new tab inherits it. What the UI says about it is that the family draws on its own usage limit — the model-scoped `limits` entry the usage API returns beside `session` and `weekly_all` — and that this also counts toward overall usage; on a subscription it is not billed on top, so no string may say it is. `max` effort turns the effort segment warning-coloured. Every (re)start and every mid-session switch leaves a line in the transcript
 - **Cloud sync:** self-hosted Docker relay, per-entity toggles, file watcher, conflict diff modal
+- **Claude in Chrome:** opt-in (`chromeBridgeEnabled`). Adds the `claude-in-chrome` MCP server — 22 browser tools — to chat sessions by spawning the bundled SDK binary with `--claude-in-chrome-mcp`; Chrome reaches it through a native messaging host manifest whose name (`com.anthropic.claude_code_browser_extension`) is fixed by the extension and therefore shared with Claude Code, so an existing working manifest is adopted, never overwritten
 - **Parallel tasks:** git worktrees per sub-task, AI merge agent, persisted run state
 - **Workflows:** LiteGraph editor, 21 nodes / 6 trigger types, AI assistant for graph editing, webhook/cron/hook triggers
 - **Workspace:** cross-project KB with advisor chat, concept links, `@workspace` mention

--- a/src/main/ipc/chrome.ipc.js
+++ b/src/main/ipc/chrome.ipc.js
@@ -1,0 +1,55 @@
+/**
+ * Claude in Chrome IPC Handlers
+ * Bridges the renderer settings UI with ChromeBridgeService.
+ */
+
+const { ipcMain, shell } = require('electron');
+const chromeBridgeService = require('../services/ChromeBridgeService');
+
+function registerChromeHandlers() {
+  // Full status for the settings panel: platform support, extension presence,
+  // native host state. `force` bypasses the extension-detection cache, which the
+  // renderer passes after sending the user off to install it.
+  ipcMain.handle('chrome-status', async (_event, { force = false } = {}) => {
+    try {
+      return { success: true, status: await chromeBridgeService.getStatus(force) };
+    } catch (err) {
+      console.error('[chrome-status] Error:', err.message);
+      return { success: false, error: err.message };
+    }
+  });
+
+  // Install (or adopt) the native messaging host. Called when the user enables
+  // the toggle, so the browser side is ready before the first session needs it.
+  ipcMain.handle('chrome-install-host', async () => {
+    try {
+      return { success: true, result: await chromeBridgeService.ensureNativeHost(true) };
+    } catch (err) {
+      console.error('[chrome-install-host] Error:', err.message);
+      return { success: false, error: err.message };
+    }
+  });
+
+  // Remove only the manifests we wrote; one left by Claude Code stays.
+  ipcMain.handle('chrome-remove-host', async () => {
+    try {
+      return { success: true, result: await chromeBridgeService.removeNativeHost() };
+    } catch (err) {
+      console.error('[chrome-remove-host] Error:', err.message);
+      return { success: false, error: err.message };
+    }
+  });
+
+  // Open the Chrome Web Store listing in the user's default browser.
+  ipcMain.handle('chrome-open-store', async () => {
+    try {
+      await shell.openExternal(chromeBridgeService.getExtensionUrl());
+      return { success: true };
+    } catch (err) {
+      console.error('[chrome-open-store] Error:', err.message);
+      return { success: false, error: err.message };
+    }
+  });
+}
+
+module.exports = { registerChromeHandlers };

--- a/src/main/ipc/chrome.ipc.js
+++ b/src/main/ipc/chrome.ipc.js
@@ -23,6 +23,14 @@ function registerChromeHandlers() {
   // the toggle, so the browser side is ready before the first session needs it.
   ipcMain.handle('chrome-install-host', async () => {
     try {
+      // This is the one handler with a system-level side effect — it writes
+      // native messaging manifests and, on Windows, HKCU keys. It re-reads the
+      // opt-in rather than trusting the caller: the CSP means injected markup
+      // cannot reach IPC today, and this is what keeps that from being the only
+      // thing standing between a chat message and the registry.
+      if (!chromeBridgeService.isEnabled()) {
+        return { success: false, error: 'disabled' };
+      }
       return { success: true, result: await chromeBridgeService.ensureNativeHost(true) };
     } catch (err) {
       console.error('[chrome-install-host] Error:', err.message);

--- a/src/main/ipc/index.js
+++ b/src/main/ipc/index.js
@@ -19,6 +19,7 @@ const { registerMarketplaceHandlers } = require('./marketplace.ipc');
 const { registerMcpRegistryHandlers } = require('./mcpRegistry.ipc');
 const { registerPluginHandlers } = require('./plugin.ipc');
 const { registerChatHandlers } = require('./chat.ipc');
+const { registerChromeHandlers } = require('./chrome.ipc');
 const { registerHooksHandlers } = require('./hooks.ipc');
 const { registerMinecraftHandlers } = require('../../project-types/minecraft/main/minecraft.ipc');
 const { registerDiscordHandlers } = require('../../project-types/discord/main/discord.ipc');
@@ -69,6 +70,7 @@ function registerAllHandlers(mainWindow) {
   registerMcpRegistryHandlers();
   registerPluginHandlers();
   registerChatHandlers();
+  registerChromeHandlers();
   registerHooksHandlers();
   registerMinecraftHandlers();
   registerDiscordHandlers();

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -581,6 +581,14 @@ contextBridge.exposeInMainWorld('electron_api', {
   },
 
   // ==================== CHAT (Agent SDK) ====================
+  // Claude in Chrome: drive the user's browser through the official extension.
+  chrome: {
+    status: (params) => ipcRenderer.invoke('chrome-status', params || {}),
+    installHost: () => ipcRenderer.invoke('chrome-install-host'),
+    removeHost: () => ipcRenderer.invoke('chrome-remove-host'),
+    openStore: () => ipcRenderer.invoke('chrome-open-store')
+  },
+
   chat: {
     start: (params) => ipcRenderer.invoke('chat-start', params),
     send: (params) => ipcRenderer.invoke('chat-send', params),

--- a/src/main/services/ChatService.js
+++ b/src/main/services/ChatService.js
@@ -10,6 +10,8 @@ const { app } = require('electron');
 const { execFileSync } = require('child_process');
 const ModelCatalogService = require('./ModelCatalogService');
 const AccountManager = require('./AccountManager');
+const chromeBridgeService = require('./ChromeBridgeService');
+const { getSdkCliPath } = require('../utils/sdkCli');
 const { isCliFailureText } = require('../../shared/cli-failure-text');
 const { isApiErrorMessage } = require('../../shared/api-error');
 const { isPermissionMode } = require('../../shared/permission-modes');
@@ -104,31 +106,6 @@ async function loadSDK() {
     sdkPromise = import('@anthropic-ai/claude-agent-sdk');
   }
   return sdkPromise;
-}
-
-/**
- * Resolve the path to the SDK's native CLI binary.
- *
- * As of @anthropic-ai/claude-agent-sdk 0.3 the SDK no longer ships a `cli.js`;
- * it spawns a platform-specific native binary shipped in the optional dependency
- * `@anthropic-ai/claude-agent-sdk-<platform>-<arch>` (e.g. `claude.exe` on
- * Windows). That package is pulled into the asarUnpack closure automatically
- * (resolve-unpack-deps walks optionalDependencies — see electron-builder.config.js).
- *
- * We resolve it explicitly so the spawn behaves identically in dev and in the
- * packaged app.asar.unpacked layout. If the expected binary is missing (e.g. a
- * musl Linux build), we return null so the SDK self-resolves via
- * require.resolve, which handles the glibc/musl split on its own.
- */
-function getSdkCliPath() {
-  const ext = process.platform === 'win32' ? '.exe' : '';
-  const pkg = `claude-agent-sdk-${process.platform}-${process.arch}`;
-  const binRelative = path.join('node_modules', '@anthropic-ai', pkg, `claude${ext}`);
-  const base = app.isPackaged
-    ? app.getAppPath().replace('app.asar', 'app.asar.unpacked')
-    : app.getAppPath();
-  const binPath = path.join(base, binRelative);
-  return fs.existsSync(binPath) ? binPath : null;
 }
 
 /**
@@ -782,6 +759,20 @@ class ChatService {
       // Arrives via task_progress system messages with a `summary` field.
       options.agentProgressSummaries = true;
 
+      // Claude in Chrome: hand the session the browser-automation MCP server.
+      //
+      // Skipped for a self-restricting session (see RESTRICTED_SESSION_MAX_TURNS):
+      // it runs unattended off a possibly-misheard transcription, and its
+      // allowlist would withhold the browser tools anyway, so spawning the
+      // server would only cost a process.
+      if (!allowedTools?.length) {
+        const chrome = chromeBridgeService.getSessionConfig();
+        if (chrome) {
+          options.mcpServers = { ...(options.mcpServers || {}), ...chrome.mcpServers };
+          options.systemPrompt = this._appendSystemPrompt(options.systemPrompt, chrome.systemPrompt);
+        }
+      }
+
       // Ephemeral session: skip writing transcript to ~/.claude/projects/
       // The session cannot be resumed later but leaves no trace on disk.
       if (persistSession === false) {
@@ -903,6 +894,26 @@ class ChatService {
    * @param {Array} documents - Array of { base64, mediaType } PDF attachments
    * @returns {string|Array}
    */
+  /**
+   * Add a section to a session's system prompt, whatever shape it currently has.
+   *
+   * The SDK accepts three: a preset object (the default), a preset object the
+   * renderer already appended a custom prompt to, and a bare string (a fully
+   * custom prompt). Appending must preserve the preset, so a string is the only
+   * case we concatenate directly.
+   *
+   * @param {object|string|undefined} current
+   * @param {string} extra
+   * @returns {object|string}
+   */
+  _appendSystemPrompt(current, extra) {
+    if (typeof current === 'string') {
+      return current ? `${current}\n\n${extra}` : extra;
+    }
+    const base = current || { type: 'preset', preset: 'claude_code' };
+    return { ...base, append: base.append ? `${base.append}\n\n${extra}` : extra };
+  }
+
   _buildContent(text, images, mentions = [], documents = []) {
     const hasImages = images && images.length > 0;
     const hasMentions = mentions && mentions.length > 0;

--- a/src/main/services/ChromeBridgeService.js
+++ b/src/main/services/ChromeBridgeService.js
@@ -280,6 +280,17 @@ class ChromeBridgeService {
     }
   }
 
+  /** The manifest the extension reads to find our native host. */
+  _manifestBody(wrapper) {
+    return JSON.stringify({
+      name: HOST_NAME,
+      description: 'Claude Terminal Browser Extension Native Host',
+      path: wrapper,
+      type: 'stdio',
+      allowed_origins: [`chrome-extension://${EXTENSION_ID}/`]
+    }, null, 2);
+  }
+
   /** Write the wrapper that Chrome will exec, pointing at our bundled binary. */
   async _writeWrapper(cli) {
     const wrapper = this._wrapperPath();
@@ -292,17 +303,43 @@ class ChromeBridgeService {
     return wrapper;
   }
 
-  /** Point the installed Windows browsers' registry keys at our manifest. */
-  _registerWindows(manifestPath, browsers) {
-    const jobs = browsers
-      .map(browser => ({ browser, key: BROWSERS[browser]?.win32?.registryKey }))
-      .filter(j => j.key);
-    return Promise.all(jobs.map(({ browser, key }) => new Promise(resolve => {
-      execFile('reg', ['add', `${key}\\${HOST_NAME}`, '/ve', '/t', 'REG_SZ', '/d', manifestPath, '/f'], err => {
-        if (err) console.warn(`[ChromeBridge] Registry registration failed for ${browser}: ${err.message}`);
-        resolve();
+  /**
+   * The manifest a Windows browser is currently pointed at, or '' when it is
+   * pointed at nothing.
+   *
+   * Windows keeps no well-known directory: the registry key IS the
+   * registration, so it is the only thing that can answer "does this browser
+   * already reach a working host". Reading it is what makes adoption possible
+   * here at all — the file check the other platforms use looks in a directory
+   * of ours that Claude Code never writes to, so on Windows it could only ever
+   * answer no, and we would overwrite their key every time.
+   */
+  _readWindowsHostPath(key) {
+    return new Promise(resolve => {
+      execFile('reg', ['query', `${key}\\${HOST_NAME}`, '/ve'], (err, stdout) => {
+        if (err) return resolve('');
+        // "    (Default)    REG_SZ    C:\path\to\manifest.json"
+        const line = String(stdout).split(/\r?\n/).find(l => l.includes('REG_SZ'));
+        resolve(line ? line.slice(line.indexOf('REG_SZ') + 6).trim() : '');
       });
-    })));
+    });
+  }
+
+  /** Point one Windows browser's registry key at our manifest. */
+  _registerWindowsBrowser(key, manifestPath) {
+    return new Promise(resolve => {
+      execFile('reg', ['add', `${key}\\${HOST_NAME}`, '/ve', '/t', 'REG_SZ', '/d', manifestPath, '/f'], err => {
+        if (err) console.warn(`[ChromeBridge] Registry registration failed: ${err.message}`);
+        resolve(!err);
+      });
+    });
+  }
+
+  /** Drop one Windows browser's registry key. An absent key is not an error. */
+  _unregisterWindowsBrowser(key) {
+    return new Promise(resolve => {
+      execFile('reg', ['delete', `${key}\\${HOST_NAME}`, '/f'], () => resolve());
+    });
   }
 
   /**
@@ -353,16 +390,45 @@ class ChromeBridgeService {
     const browsers = await this._installedBrowsers();
     if (browsers.length === 0) return { ...empty, error: 'no-browser-found' };
 
-    // Windows resolves native hosts through the registry, so one manifest in a
-    // directory of ours serves every browser. Elsewhere each browser reads its
-    // own directory, so each needs its own copy.
-    const targets = process.platform === 'win32'
-      ? [{ browser: 'windows', dir: this._windowsManifestDir() }]
-      : this._nativeMessagingDirs().filter(t => browsers.includes(t.browser));
-
     let wrapper = null;
     const installed = [];
     const adopted = [];
+
+    // Windows resolves native hosts through the registry rather than a
+    // well-known directory, so the decision is made per browser by reading the
+    // key — the same per-browser adopt-or-install decision the other platforms
+    // make by reading each browser's manifest, just against the store that
+    // actually governs here.
+    if (process.platform === 'win32') {
+      const manifestPath = path.join(this._windowsManifestDir(), `${HOST_NAME}.json`);
+      for (const browser of browsers) {
+        const key = BROWSERS[browser]?.win32?.registryKey;
+        if (!key) continue;
+        const current = await this._readWindowsHostPath(key);
+        // Already reaching a working host — Claude Code's, or ours from a
+        // previous run. Either speaks the same protocol, so leave it be.
+        if (current && await this._manifestIsUsable(current)) {
+          adopted.push(browser);
+          continue;
+        }
+        try {
+          if (!wrapper) {
+            wrapper = await this._writeWrapper(cli);
+            await fsp.mkdir(path.dirname(manifestPath), { recursive: true });
+            await fsp.writeFile(manifestPath, this._manifestBody(wrapper), 'utf8');
+          }
+          if (await this._registerWindowsBrowser(key, manifestPath)) installed.push(browser);
+        } catch (e) {
+          console.warn(`[ChromeBridge] Could not install native host for ${browser}: ${e.message}`);
+        }
+      }
+      const okWin = installed.length + adopted.length > 0;
+      if (!okWin) return { ...empty, error: 'install-failed' };
+      if (installed.length) console.log(`[ChromeBridge] Installed native host for: ${installed.join(', ')}`);
+      return { ok: okWin, installed, adopted };
+    }
+
+    const targets = this._nativeMessagingDirs().filter(t => browsers.includes(t.browser));
 
     for (const t of targets) {
       const manifestPath = path.join(t.dir, `${HOST_NAME}.json`);
@@ -376,21 +442,11 @@ class ChromeBridgeService {
       try {
         if (!wrapper) wrapper = await this._writeWrapper(cli);
         await fsp.mkdir(t.dir, { recursive: true });
-        await fsp.writeFile(path.join(t.dir, `${HOST_NAME}.json`), JSON.stringify({
-          name: HOST_NAME,
-          description: 'Claude Terminal Browser Extension Native Host',
-          path: wrapper,
-          type: 'stdio',
-          allowed_origins: [`chrome-extension://${EXTENSION_ID}/`]
-        }, null, 2), 'utf8');
+        await fsp.writeFile(path.join(t.dir, `${HOST_NAME}.json`), this._manifestBody(wrapper), 'utf8');
         installed.push(t.browser);
       } catch (e) {
         console.warn(`[ChromeBridge] Could not install manifest for ${t.browser}: ${e.message}`);
       }
-    }
-
-    if (process.platform === 'win32' && installed.length > 0) {
-      await this._registerWindows(path.join(this._windowsManifestDir(), `${HOST_NAME}.json`), browsers);
     }
 
     const ok = installed.length + adopted.length > 0;
@@ -407,11 +463,34 @@ class ChromeBridgeService {
    */
   async removeNativeHost() {
     const wrapper = this._wrapperPath();
-    const targets = process.platform === 'win32'
-      ? [{ browser: 'windows', dir: this._windowsManifestDir() }]
-      : this._nativeMessagingDirs();
     const removed = [];
     const kept = [];
+
+    // Windows: the registration is the key, so it is the key that has to be
+    // checked before anything is deleted. Blanket-deleting every browser's key
+    // is how turning our toggle off used to break a Claude Code install that
+    // had never involved us — the key it deleted was theirs.
+    if (process.platform === 'win32') {
+      const ours = path.join(this._windowsManifestDir(), `${HOST_NAME}.json`);
+      for (const [browser, def] of Object.entries(BROWSERS)) {
+        const key = def.win32?.registryKey;
+        if (!key) continue;
+        const current = await this._readWindowsHostPath(key);
+        if (!current) continue;
+        if (path.normalize(current).toLowerCase() !== path.normalize(ours).toLowerCase()) {
+          kept.push(browser);
+          continue;
+        }
+        await this._unregisterWindowsBrowser(key);
+        removed.push(browser);
+      }
+      // The manifest only mattered to the keys that named it.
+      if (removed.length) await fsp.unlink(ours).catch(() => {});
+      this._hostReady = null;
+      return { removed, kept };
+    }
+
+    const targets = this._nativeMessagingDirs();
     for (const t of targets) {
       const manifestPath = path.join(t.dir, `${HOST_NAME}.json`);
       try {
@@ -421,21 +500,8 @@ class ChromeBridgeService {
         removed.push(t.browser);
       } catch { /* absent or unreadable — nothing to undo */ }
     }
-    // A registry key outliving its manifest points Chrome at a file that is no
-    // longer there, so it goes with the manifest it described.
-    if (process.platform === 'win32' && removed.length > 0) {
-      await this._unregisterWindows();
-    }
     this._hostReady = null;
     return { removed, kept };
-  }
-
-  /** Drop the registry keys we added. Absent keys are not an error. */
-  _unregisterWindows() {
-    const keys = Object.values(BROWSERS).map(def => def.win32?.registryKey).filter(Boolean);
-    return Promise.all(keys.map(key => new Promise(resolve => {
-      execFile('reg', ['delete', `${key}\\${HOST_NAME}`, '/f'], () => resolve());
-    })));
   }
 
   // ── Session wiring ────────────────────────────────────────────────────────
@@ -452,6 +518,14 @@ class ChromeBridgeService {
    */
   getSessionConfig() {
     if (!this.isEnabled() || !this.isSupported()) return null;
+    // A detection that has already run and found nothing is a reason not to
+    // wire this up: every session would spawn an MCP server that cannot reach
+    // a browser, while the appended prompt tells the model it can drive one —
+    // so it calls the tools and burns turns on failures. A detection that has
+    // never run does not block the session; it is kicked off instead, and the
+    // next session gets the benefit.
+    if (this._detection && !this._detection.installed) return null;
+    if (!this._detection) this.detectExtension().catch(() => {});
     const config = this.getMcpServerConfig();
     if (!config) return null;
     this.ensureNativeHost().catch(() => {});

--- a/src/main/services/ChromeBridgeService.js
+++ b/src/main/services/ChromeBridgeService.js
@@ -1,0 +1,499 @@
+/**
+ * ChromeBridgeService - "Claude in Chrome" integration.
+ *
+ * Lets a chat session drive a real Chrome tab (click, type, screenshot, read the
+ * DOM, inspect console/network) through the official Claude browser extension —
+ * the same capability Claude Desktop and the `claude --chrome` CLI flag expose.
+ *
+ * HOW THE PIECES FIT
+ * ------------------
+ * There are three processes, and we own none of the protocol between them:
+ *
+ *   chat session ──stdio MCP──> `claude --claude-in-chrome-mcp`  (we spawn)
+ *                                        │
+ *                                        │ bridge (account-paired)
+ *                                        ▼
+ *   Chrome ──native messaging──> `claude --chrome-native-host`   (Chrome spawns)
+ *                                        ▲
+ *                                        └── located via a manifest JSON we drop
+ *                                            into each browser's NativeMessagingHosts dir
+ *
+ * The Agent SDK binary we already ship (`@anthropic-ai/claude-agent-sdk-<plat>-<arch>`)
+ * implements BOTH subcommands, so the whole feature needs no extra download and
+ * no reimplementation of the wire protocol: we register an MCP server and make
+ * sure Chrome can find the native host. The 22 browser tools then appear in the
+ * session as `mcp__claude-in-chrome__*`.
+ *
+ * SHARED IDENTITY WITH CLAUDE CODE — WHY WE DON'T OVERWRITE
+ * --------------------------------------------------------
+ * The extension picks the native-host name, so we cannot invent our own: it must
+ * be `com.anthropic.claude_code_browser_extension`, the exact name the Claude
+ * Code CLI also uses. If the user runs both, we would be fighting over one file.
+ * So `ensureNativeHost()` only writes a manifest that is missing or broken, and
+ * otherwise adopts whatever is already there. Any 2.x Claude Code binary speaks
+ * the same protocol, so adopting is safe and keeps both installs working.
+ */
+
+const fs = require('fs');
+const fsp = fs.promises;
+const os = require('os');
+const path = require('path');
+const { execFile } = require('child_process');
+const { dataDir, settingsFile } = require('../utils/paths');
+const { getSdkCliPath } = require('../utils/sdkCli');
+
+/** Chrome Web Store id of the official "Claude for Chrome" extension. */
+const EXTENSION_ID = 'fcoeoabgfenejglbffodgkkbkcdhcgfn';
+
+/** Where the user installs the extension from. */
+const EXTENSION_URL = 'https://claude.ai/chrome';
+
+/**
+ * Native-messaging host name. Fixed by the extension, not by us — see the
+ * "shared identity" note above.
+ */
+const HOST_NAME = 'com.anthropic.claude_code_browser_extension';
+
+/**
+ * MCP server name. Fixed by the CLI: the tool ids it advertises are
+ * `mcp__claude-in-chrome__*`, and the system prompt refers to them by that name.
+ */
+const MCP_SERVER_NAME = 'claude-in-chrome';
+
+/**
+ * Chromium-family browsers that can host the extension, with the per-platform
+ * locations we need. `nativeMessaging` is where the host manifest goes;
+ * `data` is the profile root we scan to detect the extension; `registryKey` is
+ * how Windows resolves native hosts (it uses the registry, not a well-known dir).
+ */
+const BROWSERS = {
+  chrome: {
+    label: 'Google Chrome',
+    macos: { nativeMessaging: ['Library', 'Application Support', 'Google', 'Chrome', 'NativeMessagingHosts'], data: ['Library', 'Application Support', 'Google', 'Chrome'] },
+    linux: { nativeMessaging: ['.config', 'google-chrome', 'NativeMessagingHosts'], data: ['.config', 'google-chrome'] },
+    win32: { data: ['Google', 'Chrome', 'User Data'], registryKey: 'HKCU\\Software\\Google\\Chrome\\NativeMessagingHosts' }
+  },
+  brave: {
+    label: 'Brave',
+    macos: { nativeMessaging: ['Library', 'Application Support', 'BraveSoftware', 'Brave-Browser', 'NativeMessagingHosts'], data: ['Library', 'Application Support', 'BraveSoftware', 'Brave-Browser'] },
+    linux: { nativeMessaging: ['.config', 'BraveSoftware', 'Brave-Browser', 'NativeMessagingHosts'], data: ['.config', 'BraveSoftware', 'Brave-Browser'] },
+    win32: { data: ['BraveSoftware', 'Brave-Browser', 'User Data'], registryKey: 'HKCU\\Software\\BraveSoftware\\Brave-Browser\\NativeMessagingHosts' }
+  },
+  arc: {
+    label: 'Arc',
+    macos: { nativeMessaging: ['Library', 'Application Support', 'Arc', 'User Data', 'NativeMessagingHosts'], data: ['Library', 'Application Support', 'Arc', 'User Data'] },
+    linux: null,
+    win32: { data: ['Arc', 'User Data'], registryKey: 'HKCU\\Software\\ArcBrowser\\Arc\\NativeMessagingHosts' }
+  },
+  edge: {
+    label: 'Microsoft Edge',
+    macos: { nativeMessaging: ['Library', 'Application Support', 'Microsoft Edge', 'NativeMessagingHosts'], data: ['Library', 'Application Support', 'Microsoft Edge'] },
+    linux: { nativeMessaging: ['.config', 'microsoft-edge', 'NativeMessagingHosts'], data: ['.config', 'microsoft-edge'] },
+    win32: { data: ['Microsoft', 'Edge', 'User Data'], registryKey: 'HKCU\\Software\\Microsoft\\Edge\\NativeMessagingHosts' }
+  },
+  chromium: {
+    label: 'Chromium',
+    macos: { nativeMessaging: ['Library', 'Application Support', 'Chromium', 'NativeMessagingHosts'], data: ['Library', 'Application Support', 'Chromium'] },
+    linux: { nativeMessaging: ['.config', 'chromium', 'NativeMessagingHosts'], data: ['.config', 'chromium'] },
+    win32: { data: ['Chromium', 'User Data'], registryKey: 'HKCU\\Software\\Chromium\\NativeMessagingHosts' }
+  },
+  vivaldi: {
+    label: 'Vivaldi',
+    macos: { nativeMessaging: ['Library', 'Application Support', 'Vivaldi', 'NativeMessagingHosts'], data: ['Library', 'Application Support', 'Vivaldi'] },
+    linux: { nativeMessaging: ['.config', 'vivaldi', 'NativeMessagingHosts'], data: ['.config', 'vivaldi'] },
+    win32: { data: ['Vivaldi', 'User Data'], registryKey: 'HKCU\\Software\\Vivaldi\\NativeMessagingHosts' }
+  },
+  opera: {
+    label: 'Opera',
+    macos: { nativeMessaging: ['Library', 'Application Support', 'com.operasoftware.Opera', 'NativeMessagingHosts'], data: ['Library', 'Application Support', 'com.operasoftware.Opera'] },
+    linux: { nativeMessaging: ['.config', 'opera', 'NativeMessagingHosts'], data: ['.config', 'opera'] },
+    win32: { data: ['Opera Software', 'Opera Stable'], registryKey: 'HKCU\\Software\\Opera Software\\Opera Stable\\NativeMessagingHosts', useRoaming: true }
+  }
+};
+
+/**
+ * Appended to the session's system prompt when the bridge is on.
+ *
+ * Kept short on purpose: the MCP tool descriptions already document each tool.
+ * What the model cannot infer from them is the ordering constraint
+ * (`tabs_context_mcp` first) and that this is the user's real, logged-in
+ * browser — which is why it must not act on consequential pages uninvited.
+ */
+const SYSTEM_PROMPT = `## Claude in Chrome
+
+You can drive the user's Chrome browser through the \`${MCP_SERVER_NAME}\` MCP tools \
+(navigate, click and type via \`computer\`, read the DOM via \`read_page\`/\`get_page_text\`, \
+inspect \`read_console_messages\` and \`read_network_requests\`).
+
+- Call \`tabs_context_mcp\` once before any other browser tool: the other tools need a tab id from it.
+- Work in tabs you created with \`tabs_create_mcp\` where you can, and close what you opened.
+- This is the user's real browser, signed into their real accounts. Read freely, but ask \
+before anything that sends, buys, deletes, or posts.`;
+
+class ChromeBridgeService {
+  constructor() {
+    /** Cache for extension detection, which walks profile dirs on disk. */
+    this._detection = null;
+    this._detectionAt = 0;
+    /** Resolved once per app run: installing the host is idempotent. */
+    this._hostReady = null;
+  }
+
+  // ── Capability & configuration ────────────────────────────────────────────
+
+  /** Chromium native messaging exists on these three; nothing else is supported. */
+  isSupported() {
+    return ['darwin', 'win32', 'linux'].includes(process.platform);
+  }
+
+  /**
+   * Whether the user turned the bridge on. The renderer owns settings.json, so
+   * we read it rather than hold a copy — same pattern as DiscordRpcService.
+   *
+   * Defaults to OFF: driving a signed-in browser is a large capability, so it
+   * is opt-in rather than something a user discovers after the fact.
+   */
+  isEnabled() {
+    try {
+      const s = JSON.parse(fs.readFileSync(settingsFile, 'utf8'));
+      return s.chromeBridgeEnabled === true;
+    } catch {
+      return false;
+    }
+  }
+
+  getExtensionId() { return EXTENSION_ID; }
+  getExtensionUrl() { return EXTENSION_URL; }
+  getMcpServerName() { return MCP_SERVER_NAME; }
+  getSystemPrompt() { return SYSTEM_PROMPT; }
+
+  /** Descriptor for the browser-tool MCP server, or null if we can't serve it. */
+  getMcpServerConfig() {
+    const cli = getSdkCliPath();
+    if (!cli) return null;
+    return { type: 'stdio', command: cli, args: ['--claude-in-chrome-mcp'] };
+  }
+
+  // ── Browser & extension detection ─────────────────────────────────────────
+
+  /** Per-browser native-messaging dirs for this platform (empty on Windows). */
+  _nativeMessagingDirs() {
+    const home = os.homedir();
+    const key = process.platform === 'darwin' ? 'macos' : process.platform === 'win32' ? 'win32' : 'linux';
+    if (key === 'win32') return [];
+    const out = [];
+    for (const [id, def] of Object.entries(BROWSERS)) {
+      const cfg = def[key];
+      if (!cfg?.nativeMessaging?.length) continue;
+      out.push({ browser: id, label: def.label, dir: path.join(home, ...cfg.nativeMessaging) });
+    }
+    return out;
+  }
+
+  /**
+   * Windows resolves native hosts through the registry, so the manifest can live
+   * anywhere stable — we keep it beside our own wrapper.
+   */
+  _windowsManifestDir() {
+    const base = process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local');
+    return path.join(base, 'Claude Terminal', 'ChromeNativeHost');
+  }
+
+  /** Per-browser profile roots, used to look for the installed extension. */
+  _profileRoots() {
+    const home = os.homedir();
+    const key = process.platform === 'darwin' ? 'macos' : process.platform === 'win32' ? 'win32' : 'linux';
+    const out = [];
+    for (const [id, def] of Object.entries(BROWSERS)) {
+      const cfg = def[key];
+      if (!cfg?.data?.length) continue;
+      const base = key === 'win32'
+        ? (cfg.useRoaming
+          ? (process.env.APPDATA || path.join(home, 'AppData', 'Roaming'))
+          : (process.env.LOCALAPPDATA || path.join(home, 'AppData', 'Local')))
+        : home;
+      out.push({ browser: id, label: def.label, dir: path.join(base, ...cfg.data) });
+    }
+    return out;
+  }
+
+  /**
+   * Look for the extension across every Chromium profile we know about.
+   *
+   * Result is cached briefly: this walks a handful of directories and the
+   * renderer polls it to render status.
+   *
+   * @param {boolean} [force] Skip the cache (used right after the user installs).
+   * @returns {Promise<{installed: boolean, browser: string|null, label: string|null}>}
+   */
+  async detectExtension(force = false) {
+    if (!force && this._detection && Date.now() - this._detectionAt < 30_000) {
+      return this._detection;
+    }
+    let result = { installed: false, browser: null, label: null };
+    for (const { browser, label, dir } of this._profileRoots()) {
+      let entries;
+      try {
+        entries = await fsp.readdir(dir, { withFileTypes: true });
+      } catch {
+        continue; // browser not installed
+      }
+      const profiles = entries
+        .filter(e => e.isDirectory())
+        .filter(e => e.name === 'Default' || e.name.startsWith('Profile '))
+        .map(e => e.name);
+      for (const profile of profiles) {
+        try {
+          await fsp.access(path.join(dir, profile, 'Extensions', EXTENSION_ID));
+          result = { installed: true, browser, label };
+          break;
+        } catch { /* not in this profile */ }
+      }
+      if (result.installed) break;
+    }
+    this._detection = result;
+    this._detectionAt = Date.now();
+    return result;
+  }
+
+  // ── Native host installation ──────────────────────────────────────────────
+
+  /** Our wrapper script, which execs the bundled binary as the native host. */
+  _wrapperPath() {
+    return path.join(dataDir, 'chrome', process.platform === 'win32' ? 'chrome-native-host.bat' : 'chrome-native-host');
+  }
+
+  /**
+   * A manifest counts as usable when it points the extension at an executable
+   * that still exists. That is the test for "adopt vs. replace": a Claude Code
+   * install satisfies it, a stale path left by an uninstall does not.
+   */
+  async _manifestIsUsable(manifestPath) {
+    try {
+      const parsed = JSON.parse(await fsp.readFile(manifestPath, 'utf8'));
+      if (parsed?.name !== HOST_NAME || !parsed?.path) return false;
+      if (!parsed.allowed_origins?.some(o => o.includes(EXTENSION_ID))) return false;
+      await fsp.access(parsed.path, fs.constants.X_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Write the wrapper that Chrome will exec, pointing at our bundled binary. */
+  async _writeWrapper(cli) {
+    const wrapper = this._wrapperPath();
+    await fsp.mkdir(path.dirname(wrapper), { recursive: true });
+    const body = process.platform === 'win32'
+      ? `@echo off\r\n"${cli}" --chrome-native-host %*\r\n`
+      : `#!/bin/sh\n# Chrome native host wrapper - generated by Claude Terminal, do not edit.\nexec "${cli}" --chrome-native-host "$@"\n`;
+    await fsp.writeFile(wrapper, body, 'utf8');
+    if (process.platform !== 'win32') await fsp.chmod(wrapper, 0o755);
+    return wrapper;
+  }
+
+  /** Point the installed Windows browsers' registry keys at our manifest. */
+  _registerWindows(manifestPath, browsers) {
+    const jobs = browsers
+      .map(browser => ({ browser, key: BROWSERS[browser]?.win32?.registryKey }))
+      .filter(j => j.key);
+    return Promise.all(jobs.map(({ browser, key }) => new Promise(resolve => {
+      execFile('reg', ['add', `${key}\\${HOST_NAME}`, '/ve', '/t', 'REG_SZ', '/d', manifestPath, '/f'], err => {
+        if (err) console.warn(`[ChromeBridge] Registry registration failed for ${browser}: ${err.message}`);
+        resolve();
+      });
+    })));
+  }
+
+  /**
+   * Browsers actually present on this machine — the ones worth wiring up.
+   *
+   * Gating on the profile root keeps us from creating config directories for
+   * browsers the user does not have: a manifest under a Vivaldi directory we
+   * invented ourselves is litter that nothing will ever read.
+   *
+   * @returns {Promise<string[]>} Browser ids.
+   */
+  async _installedBrowsers() {
+    const found = [];
+    for (const { browser, dir } of this._profileRoots()) {
+      try {
+        await fsp.access(dir);
+        found.push(browser);
+      } catch { /* not installed */ }
+    }
+    return found;
+  }
+
+  /**
+   * Make sure Chrome can reach a native host, installing ours only where none
+   * is usable. Idempotent, and memoised for the app's lifetime.
+   *
+   * @param {boolean} [force] Redo the work even if it already ran.
+   * @returns {Promise<{ok: boolean, installed: string[], adopted: string[], error?: string}>}
+   *   `installed` are browsers we wrote a manifest for, `adopted` are those
+   *   that already had a working one.
+   */
+  async ensureNativeHost(force = false) {
+    if (this._hostReady && !force) return this._hostReady;
+    this._hostReady = this._ensureNativeHost().catch(err => {
+      console.error('[ChromeBridge] Native host install failed:', err.message);
+      return { ok: false, installed: [], adopted: [], error: err.message };
+    });
+    return this._hostReady;
+  }
+
+  async _ensureNativeHost() {
+    const empty = { ok: false, installed: [], adopted: [] };
+    if (!this.isSupported()) return { ...empty, error: 'unsupported-platform' };
+
+    const cli = getSdkCliPath();
+    if (!cli) return { ...empty, error: 'sdk-cli-missing' };
+
+    const browsers = await this._installedBrowsers();
+    if (browsers.length === 0) return { ...empty, error: 'no-browser-found' };
+
+    // Windows resolves native hosts through the registry, so one manifest in a
+    // directory of ours serves every browser. Elsewhere each browser reads its
+    // own directory, so each needs its own copy.
+    const targets = process.platform === 'win32'
+      ? [{ browser: 'windows', dir: this._windowsManifestDir() }]
+      : this._nativeMessagingDirs().filter(t => browsers.includes(t.browser));
+
+    let wrapper = null;
+    const installed = [];
+    const adopted = [];
+
+    for (const t of targets) {
+      const manifestPath = path.join(t.dir, `${HOST_NAME}.json`);
+      // Adopt a working host rather than fight Claude Code over the file. This
+      // is decided per browser: a manifest Claude Code left in Chrome says
+      // nothing about Brave, which may still need ours.
+      if (await this._manifestIsUsable(manifestPath)) {
+        adopted.push(t.browser);
+        continue;
+      }
+      try {
+        if (!wrapper) wrapper = await this._writeWrapper(cli);
+        await fsp.mkdir(t.dir, { recursive: true });
+        await fsp.writeFile(path.join(t.dir, `${HOST_NAME}.json`), JSON.stringify({
+          name: HOST_NAME,
+          description: 'Claude Terminal Browser Extension Native Host',
+          path: wrapper,
+          type: 'stdio',
+          allowed_origins: [`chrome-extension://${EXTENSION_ID}/`]
+        }, null, 2), 'utf8');
+        installed.push(t.browser);
+      } catch (e) {
+        console.warn(`[ChromeBridge] Could not install manifest for ${t.browser}: ${e.message}`);
+      }
+    }
+
+    if (process.platform === 'win32' && installed.length > 0) {
+      await this._registerWindows(path.join(this._windowsManifestDir(), `${HOST_NAME}.json`), browsers);
+    }
+
+    const ok = installed.length + adopted.length > 0;
+    if (!ok) return { ...empty, error: 'install-failed' };
+    if (installed.length) console.log(`[ChromeBridge] Installed native host for: ${installed.join(', ')}`);
+    return { ok, installed, adopted };
+  }
+
+  /**
+   * Remove only the manifests we wrote. One left by Claude Code is left alone —
+   * turning our toggle off must not break their integration.
+   *
+   * @returns {Promise<{removed: string[], kept: string[]}>}
+   */
+  async removeNativeHost() {
+    const wrapper = this._wrapperPath();
+    const targets = process.platform === 'win32'
+      ? [{ browser: 'windows', dir: this._windowsManifestDir() }]
+      : this._nativeMessagingDirs();
+    const removed = [];
+    const kept = [];
+    for (const t of targets) {
+      const manifestPath = path.join(t.dir, `${HOST_NAME}.json`);
+      try {
+        const parsed = JSON.parse(await fsp.readFile(manifestPath, 'utf8'));
+        if (parsed?.path !== wrapper) { kept.push(t.browser); continue; }
+        await fsp.unlink(manifestPath);
+        removed.push(t.browser);
+      } catch { /* absent or unreadable — nothing to undo */ }
+    }
+    // A registry key outliving its manifest points Chrome at a file that is no
+    // longer there, so it goes with the manifest it described.
+    if (process.platform === 'win32' && removed.length > 0) {
+      await this._unregisterWindows();
+    }
+    this._hostReady = null;
+    return { removed, kept };
+  }
+
+  /** Drop the registry keys we added. Absent keys are not an error. */
+  _unregisterWindows() {
+    const keys = Object.values(BROWSERS).map(def => def.win32?.registryKey).filter(Boolean);
+    return Promise.all(keys.map(key => new Promise(resolve => {
+      execFile('reg', ['delete', `${key}\\${HOST_NAME}`, '/f'], () => resolve());
+    })));
+  }
+
+  // ── Session wiring ────────────────────────────────────────────────────────
+
+  /**
+   * What a chat session needs to gain the browser tools, or null when the
+   * bridge is off or unavailable.
+   *
+   * Installing the native host is fire-and-forget: the MCP server starts fine
+   * without it and only needs it once the model actually reaches for the
+   * browser, so a slow filesystem must not delay the session's first token.
+   *
+   * @returns {{mcpServers: Object, systemPrompt: string}|null}
+   */
+  getSessionConfig() {
+    if (!this.isEnabled() || !this.isSupported()) return null;
+    const config = this.getMcpServerConfig();
+    if (!config) return null;
+    this.ensureNativeHost().catch(() => {});
+    return {
+      mcpServers: { [MCP_SERVER_NAME]: config },
+      systemPrompt: SYSTEM_PROMPT
+    };
+  }
+
+  // ── Status for the UI ─────────────────────────────────────────────────────
+
+  /**
+   * Everything the settings panel renders, in one call.
+   *
+   * @param {boolean} [force] Bypass the extension-detection cache.
+   */
+  async getStatus(force = false) {
+    const supported = this.isSupported();
+    const enabled = this.isEnabled();
+    const cli = getSdkCliPath();
+    const detection = supported ? await this.detectExtension(force) : { installed: false, browser: null, label: null };
+    let host = { ok: false, installed: [], adopted: [] };
+    if (supported && enabled) host = await this.ensureNativeHost(force);
+    return {
+      supported,
+      enabled,
+      platform: process.platform,
+      cliAvailable: Boolean(cli),
+      extensionId: EXTENSION_ID,
+      extensionUrl: EXTENSION_URL,
+      extensionInstalled: detection.installed,
+      browser: detection.browser,
+      browserLabel: detection.label,
+      hostInstalled: host.ok,
+      hostAdopted: host.adopted.length > 0 && host.installed.length === 0,
+      hostBrowsers: [...host.installed, ...host.adopted],
+      hostError: host.error || null
+    };
+  }
+}
+
+module.exports = new ChromeBridgeService();
+module.exports.EXTENSION_ID = EXTENSION_ID;
+module.exports.HOST_NAME = HOST_NAME;
+module.exports.MCP_SERVER_NAME = MCP_SERVER_NAME;

--- a/src/main/utils/sdkCli.js
+++ b/src/main/utils/sdkCli.js
@@ -1,0 +1,43 @@
+/**
+ * Resolution of the Claude Code binary shipped with the Agent SDK.
+ *
+ * As of @anthropic-ai/claude-agent-sdk 0.3 the SDK no longer ships a `cli.js`;
+ * it spawns a platform-specific native binary shipped in the optional dependency
+ * `@anthropic-ai/claude-agent-sdk-<platform>-<arch>` (e.g. `claude.exe` on
+ * Windows). That package is pulled into the asarUnpack closure automatically
+ * (resolve-unpack-deps walks optionalDependencies — see electron-builder.config.js).
+ *
+ * We resolve it explicitly so the spawn behaves identically in dev and in the
+ * packaged app.asar.unpacked layout.
+ *
+ * This lives in a util rather than in ChatService because two callers need the
+ * very same binary: ChatService (to run the session) and ChromeBridgeService
+ * (to run `--claude-in-chrome-mcp` and `--chrome-native-host`). Both must agree
+ * on the path, and ChromeBridgeService must not import ChatService — ChatService
+ * imports it.
+ */
+
+const path = require('path');
+const fs = require('fs');
+const { app } = require('electron');
+
+/**
+ * Absolute path to the SDK's Claude Code binary.
+ *
+ * @returns {string|null} The path, or null when the expected binary is missing
+ *   (e.g. a musl Linux build). Callers passing this to the SDK as
+ *   `pathToClaudeCodeExecutable` should forward the null so the SDK
+ *   self-resolves via require.resolve, which handles the glibc/musl split.
+ */
+function getSdkCliPath() {
+  const ext = process.platform === 'win32' ? '.exe' : '';
+  const pkg = `claude-agent-sdk-${process.platform}-${process.arch}`;
+  const binRelative = path.join('node_modules', '@anthropic-ai', pkg, `claude${ext}`);
+  const base = app.isPackaged
+    ? app.getAppPath().replace('app.asar', 'app.asar.unpacked')
+    : app.getAppPath();
+  const binPath = path.join(base, binRelative);
+  return fs.existsSync(binPath) ? binPath : null;
+}
+
+module.exports = { getSdkCliPath };

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -936,6 +936,20 @@
       "description": "Real-time insights from Claude Code (time tracking, notifications, dashboard stats)",
       "toggleError": "Failed to update Smart Hooks."
     },
+    "chrome": {
+      "title": "Claude in Chrome",
+      "enable": "Let Claude use your browser",
+      "enableDesc": "Chat sessions can open tabs, click, type, read pages and inspect the console through the Claude browser extension.",
+      "checking": "Checking browser integration…",
+      "connected": "Connected — Claude can drive {browser}.",
+      "readyDisabled": "Extension found in {browser}. Turn this on to let Claude use it.",
+      "extensionMissing": "The Claude browser extension is not installed.",
+      "installExtension": "Install",
+      "unsupported": "Browser control is not available on this platform.",
+      "cliMissing": "The bundled Claude Code binary is missing, so browser control cannot start.",
+      "hostFailed": "Could not register the browser connector. No supported browser was found.",
+      "toggleError": "Failed to update the browser integration."
+    },
     "advanced": "Advanced",
     "restoreTerminalSessions": "Remember last terminal states",
     "restoreTerminalSessionsDesc": "Restore terminal tabs and Claude sessions from the previous session on startup",

--- a/src/renderer/i18n/locales/es.json
+++ b/src/renderer/i18n/locales/es.json
@@ -933,6 +933,20 @@
       "description": "Información en tiempo real de Claude Code (seguimiento de tiempo, notificaciones, estadísticas)",
       "toggleError": "No se pudieron actualizar los hooks inteligentes."
     },
+    "chrome": {
+      "title": "Claude en Chrome",
+      "enable": "Permitir que Claude use tu navegador",
+      "enableDesc": "Las sesiones de chat pueden abrir pestañas, hacer clic, escribir, leer páginas e inspeccionar la consola mediante la extensión de Claude.",
+      "checking": "Comprobando la integración con el navegador…",
+      "connected": "Conectado: Claude puede controlar {browser}.",
+      "readyDisabled": "Extensión detectada en {browser}. Actívalo para que Claude pueda usarla.",
+      "extensionMissing": "La extensión de Claude para el navegador no está instalada.",
+      "installExtension": "Instalar",
+      "unsupported": "El control del navegador no está disponible en esta plataforma.",
+      "cliMissing": "Falta el binario de Claude Code incluido, por lo que el control del navegador no puede iniciarse.",
+      "hostFailed": "No se pudo registrar el conector del navegador. No se encontró ningún navegador compatible.",
+      "toggleError": "No se pudo actualizar la integración con el navegador."
+    },
     "advanced": "Avanzado",
     "restoreTerminalSessions": "Recordar estados de terminal",
     "restoreTerminalSessionsDesc": "Restaurar las pestañas de terminal y sesiones de Claude de la sesión anterior al iniciar",

--- a/src/renderer/i18n/locales/fr.json
+++ b/src/renderer/i18n/locales/fr.json
@@ -1031,6 +1031,20 @@
       "description": "Infos en temps réel de Claude Code (suivi du temps, notifications, stats du dashboard)",
       "toggleError": "Impossible de mettre à jour les hooks intelligents."
     },
+    "chrome": {
+      "title": "Claude dans Chrome",
+      "enable": "Autoriser Claude à utiliser votre navigateur",
+      "enableDesc": "Les sessions de chat peuvent ouvrir des onglets, cliquer, saisir du texte, lire les pages et inspecter la console via l'extension Claude.",
+      "checking": "Vérification de l'intégration navigateur…",
+      "connected": "Connecté — Claude peut piloter {browser}.",
+      "readyDisabled": "Extension détectée dans {browser}. Activez cette option pour que Claude puisse l'utiliser.",
+      "extensionMissing": "L'extension navigateur Claude n'est pas installée.",
+      "installExtension": "Installer",
+      "unsupported": "Le pilotage du navigateur n'est pas disponible sur cette plateforme.",
+      "cliMissing": "Le binaire Claude Code fourni est introuvable : le pilotage du navigateur ne peut pas démarrer.",
+      "hostFailed": "Impossible d'enregistrer le connecteur navigateur. Aucun navigateur compatible n'a été trouvé.",
+      "toggleError": "Échec de la mise à jour de l'intégration navigateur."
+    },
     "advanced": "Avancé",
     "restoreTerminalSessions": "Mémoriser les derniers états des terminaux",
     "restoreTerminalSessionsDesc": "Restaurer les onglets de terminal et les sessions Claude de la session précédente au démarrage",

--- a/src/renderer/i18n/locales/id.json
+++ b/src/renderer/i18n/locales/id.json
@@ -936,6 +936,20 @@
       "description": "Wawasan real-time dari Claude Code (pelacakan waktu, notifikasi, statistik dasbor)",
       "toggleError": "Gagal memperbarui Smart Hooks."
     },
+    "chrome": {
+      "title": "Claude di Chrome",
+      "enable": "Izinkan Claude menggunakan peramban Anda",
+      "enableDesc": "Sesi obrolan dapat membuka tab, mengeklik, mengetik, membaca halaman, dan memeriksa konsol melalui ekstensi peramban Claude.",
+      "checking": "Memeriksa integrasi peramban…",
+      "connected": "Terhubung — Claude dapat mengendalikan {browser}.",
+      "readyDisabled": "Ekstensi ditemukan di {browser}. Aktifkan agar Claude dapat menggunakannya.",
+      "extensionMissing": "Ekstensi peramban Claude belum terpasang.",
+      "installExtension": "Pasang",
+      "unsupported": "Kendali peramban tidak tersedia di platform ini.",
+      "cliMissing": "Biner Claude Code bawaan tidak ditemukan, sehingga kendali peramban tidak dapat dimulai.",
+      "hostFailed": "Tidak dapat mendaftarkan konektor peramban. Tidak ada peramban yang didukung ditemukan.",
+      "toggleError": "Gagal memperbarui integrasi peramban."
+    },
     "advanced": "Lanjutan",
     "restoreTerminalSessions": "Ingat kondisi terminal terakhir",
     "restoreTerminalSessionsDesc": "Pulihkan tab terminal dan sesi Claude dari sesi sebelumnya saat aplikasi dijalankan",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -936,6 +936,20 @@
       "description": "来自 Claude Code 的实时见解（时间跟踪、通知、仪表板统计数据）",
       "toggleError": "更新智能 Hooks 失败。"
     },
+    "chrome": {
+      "title": "Claude 控制 Chrome",
+      "enable": "允许 Claude 使用你的浏览器",
+      "enableDesc": "聊天会话可通过 Claude 浏览器扩展打开标签页、点击、输入、读取页面并查看控制台。",
+      "checking": "正在检查浏览器集成…",
+      "connected": "已连接 — Claude 可以控制 {browser}。",
+      "readyDisabled": "在 {browser} 中检测到扩展。开启后 Claude 即可使用。",
+      "extensionMissing": "尚未安装 Claude 浏览器扩展。",
+      "installExtension": "安装",
+      "unsupported": "当前平台不支持浏览器控制。",
+      "cliMissing": "缺少随应用附带的 Claude Code 二进制文件，无法启动浏览器控制。",
+      "hostFailed": "无法注册浏览器连接器，未找到受支持的浏览器。",
+      "toggleError": "更新浏览器集成失败。"
+    },
     "advanced": "高级",
     "restoreTerminalSessions": "记住最后的终端状态",
     "restoreTerminalSessionsDesc": "启动时从上一个会话恢复终端选项卡和 Claude 会话",

--- a/src/renderer/state/settings.state.js
+++ b/src/renderer/state/settings.state.js
@@ -68,6 +68,7 @@ const defaultSettings = {
   agentColors: {}, // Custom colors per tool/agent name: { 'Grep': '#ff0000', 'my-agent': '#00ff00' }
   enableFollowupSuggestions: true, // Show AI-generated follow-up suggestion chips after Claude responds (uses Haiku)
   enhancePrompts: false, // Opt-in: reformulate prompts via Haiku for better prompt engineering before sending
+  chromeBridgeEnabled: false, // Opt-in: let chat sessions drive Chrome via the Claude browser extension
   // Every tab is pinned by default: the grouped sidebar fits without overflow,
   // so the More menu is now opt-in rather than the default state.
   pinnedTabs: ['claude', 'dashboard', 'files', 'git', 'session-replay', 'tasks', 'control-tower', 'workspace', 'memory', 'timetracking', 'database', 'skills', 'agents', 'plugins', 'mcp', 'workflows', 'errorlog', 'connectivity'],

--- a/src/renderer/ui/panels/SettingsPanel.js
+++ b/src/renderer/ui/panels/SettingsPanel.js
@@ -552,6 +552,54 @@ class SettingsPanel extends BasePanel {
 
   // ── Agent Colors Panel ──
 
+  /**
+   * Fill in the "Claude in Chrome" status line.
+   *
+   * Three things have to line up for the bridge to work, and each fails
+   * differently, so the line names the one that is missing rather than showing
+   * a generic error: the platform must support native messaging, the browser
+   * extension must be installed, and the native host must be registered.
+   *
+   * @param {boolean} [force] Re-scan for the extension instead of using the
+   *   30s cache — passed after sending the user to the Web Store.
+   */
+  async refreshChromeBridgeStatus(force = false) {
+    const row = document.getElementById('chrome-bridge-status');
+    if (!row) return;
+    const text = row.querySelector('.chrome-bridge-text');
+    const installBtn = document.getElementById('chrome-bridge-install');
+
+    const set = (state, message, showInstall = false) => {
+      // The panel can be re-rendered or closed while the IPC is in flight.
+      if (!document.body.contains(row)) return;
+      row.dataset.state = state;
+      if (text) text.textContent = message;
+      if (installBtn) installBtn.hidden = !showInstall;
+    };
+
+    let res;
+    try {
+      res = await this.api.chrome.status({ force });
+    } catch (e) {
+      set('error', e.message || t('common.errorOccurred'));
+      return;
+    }
+    if (!res?.success) {
+      set('error', res?.error || t('common.errorOccurred'));
+      return;
+    }
+
+    const st = res.status;
+    if (!st.supported) return set('error', t('settings.chrome.unsupported'));
+    if (!st.cliAvailable) return set('error', t('settings.chrome.cliMissing'));
+    if (!st.extensionInstalled) return set('warn', t('settings.chrome.extensionMissing'), true);
+    if (!st.enabled) {
+      return set('idle', t('settings.chrome.readyDisabled', { browser: st.browserLabel || 'Chrome' }));
+    }
+    if (!st.hostInstalled) return set('error', t('settings.chrome.hostFailed'));
+    set('ok', t('settings.chrome.connected', { browser: st.browserLabel || 'Chrome' }));
+  }
+
   async loadAgentsColorPanel() {
     const content = document.getElementById('agent-colors-content');
     if (!content) return;
@@ -1318,6 +1366,26 @@ class SettingsPanel extends BasePanel {
                 <div class="persona-help">${t('settings.personaHelp')}</div>
               </div>
             </div>
+            <div class="settings-group" data-section="chrome">
+              <div class="settings-group-title">${t('settings.chrome.title')}</div>
+              <div class="settings-card">
+                <div class="settings-toggle-row">
+                  <div class="settings-toggle-label">
+                    <div>${t('settings.chrome.enable')}</div>
+                    <div class="settings-toggle-desc">${t('settings.chrome.enableDesc')}</div>
+                  </div>
+                  <label class="settings-toggle">
+                    <input type="checkbox" id="chrome-bridge-toggle" ${settings.chromeBridgeEnabled ? 'checked' : ''}>
+                    <span class="settings-toggle-slider"></span>
+                  </label>
+                </div>
+                <div class="chrome-bridge-status" id="chrome-bridge-status" data-state="loading">
+                  <span class="chrome-bridge-dot"></span>
+                  <span class="chrome-bridge-text">${t('settings.chrome.checking')}</span>
+                  <button class="chrome-bridge-action" id="chrome-bridge-install" hidden>${t('settings.chrome.installExtension')}</button>
+                </div>
+              </div>
+            </div>
             <div class="settings-group">
               <div class="settings-group-title">${t('settings.hooks.title')}</div>
               <div class="settings-card">
@@ -1536,6 +1604,19 @@ class SettingsPanel extends BasePanel {
     });
 
     if (initialTab === 'agents') this.loadAgentsColorPanel();
+
+    // Status needs an IPC round-trip (it stats browser profile dirs), so the
+    // markup renders a "checking" placeholder and this fills it in.
+    this.refreshChromeBridgeStatus();
+    const chromeInstallBtn = document.getElementById('chrome-bridge-install');
+    if (chromeInstallBtn) {
+      chromeInstallBtn.onclick = async () => {
+        await this.api.chrome.openStore();
+        // The user installs in the browser, so we cannot know when it lands.
+        // Re-check on a short delay and skip the cache.
+        setTimeout(() => this.refreshChromeBridgeStatus(true), 3000);
+      };
+    }
 
     this._ctx.ShortcutsManager.setupShortcutsPanelHandlers();
 
@@ -1934,6 +2015,8 @@ class SettingsPanel extends BasePanel {
         : null;
       const autoClaudeMdToggle = document.getElementById('auto-claude-md-toggle');
       const newAutoClaudeMd = autoClaudeMdToggle ? autoClaudeMdToggle.checked : true;
+      const chromeBridgeToggle = document.getElementById('chrome-bridge-toggle');
+      const newChromeBridgeEnabled = chromeBridgeToggle ? chromeBridgeToggle.checked : false;
       const hooksToggle = document.getElementById('hooks-enabled-toggle');
       const newHooksEnabled = hooksToggle ? hooksToggle.checked : settings.hooksEnabled;
       const context1MToggle = document.getElementById('enable-1m-context-toggle');
@@ -2004,6 +2087,7 @@ class SettingsPanel extends BasePanel {
         discordRpcEnabled: newDiscordRpcEnabled,
         discordRpcShowProject: newDiscordRpcShowProject,
         enhancePrompts: newEnhancePrompts,
+        chromeBridgeEnabled: newChromeBridgeEnabled,
         autoClaudeMdUpdate: newAutoClaudeMd,
         maxTurns: newMaxTurns,
         telemetryEnabled: newTelemetryEnabled,
@@ -2078,6 +2162,24 @@ class SettingsPanel extends BasePanel {
             launchAtStartupToggle.checked = !requestedLaunchAtStartup;
             showError(t('settings.launchAtStartupError'), 5000);
           }
+        }
+
+        if (newChromeBridgeEnabled !== settings.chromeBridgeEnabled) {
+          try {
+            // Turning it on installs the native messaging host so Chrome can
+            // reach us; turning it off removes only the manifests we wrote.
+            const result = newChromeBridgeEnabled
+              ? await self.api.chrome.installHost()
+              : await self.api.chrome.removeHost();
+            if (result && result.success === false) {
+              throw new Error(result.error || t('common.errorOccurred'));
+            }
+          } catch (e) {
+            console.error('Error toggling Claude in Chrome:', e);
+            self._sideEffectFailed = true;
+            showError(e.message || t('settings.chrome.toggleError'), 5000);
+          }
+          self.refreshChromeBridgeStatus();
         }
 
         if (newHooksEnabled !== settings.hooksEnabled) {

--- a/styles/settings.css
+++ b/styles/settings.css
@@ -3112,3 +3112,55 @@
   color: var(--text-muted);
   padding: 2px 0;
 }
+
+/* ── Claude in Chrome status ──────────────────────────────────────────────── */
+
+.chrome-bridge-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px 12px;
+  font-size: var(--font-xs);
+  color: var(--text-secondary);
+  border-top: 1px solid var(--border-color);
+}
+
+.chrome-bridge-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--text-muted);
+}
+
+/* The dot carries the state so the text stays plain and translatable. */
+.chrome-bridge-status[data-state="loading"] .chrome-bridge-dot { background: var(--text-muted); }
+.chrome-bridge-status[data-state="idle"] .chrome-bridge-dot { background: var(--text-secondary); }
+.chrome-bridge-status[data-state="ok"] .chrome-bridge-dot { background: var(--success); }
+.chrome-bridge-status[data-state="warn"] .chrome-bridge-dot { background: var(--warning); }
+.chrome-bridge-status[data-state="error"] .chrome-bridge-dot { background: var(--danger); }
+
+.chrome-bridge-status[data-state="ok"] .chrome-bridge-text { color: var(--text-primary); }
+
+.chrome-bridge-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.chrome-bridge-action {
+  flex-shrink: 0;
+  padding: 4px 10px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  font-size: var(--font-xs);
+  cursor: pointer;
+}
+
+.chrome-bridge-action:hover {
+  background: var(--bg-hover);
+  border-color: var(--accent);
+}
+
+.chrome-bridge-action[hidden] { display: none; }

--- a/tests/services/ChatService.test.js
+++ b/tests/services/ChatService.test.js
@@ -141,6 +141,43 @@ describe('ChatService._buildContent', () => {
 
 // ── _safeSerialize ──
 
+describe('ChatService._appendSystemPrompt', () => {
+  // Claude in Chrome appends its instructions to whatever the session already
+  // has. Dropping the preset here would silently strip the Claude Code prompt.
+  test('appends to the default preset without replacing it', () => {
+    const result = chatService._appendSystemPrompt(
+      { type: 'preset', preset: 'claude_code' },
+      'BROWSER'
+    );
+    expect(result).toEqual({ type: 'preset', preset: 'claude_code', append: 'BROWSER' });
+  });
+
+  test('keeps an append the renderer already set', () => {
+    const result = chatService._appendSystemPrompt(
+      { type: 'preset', preset: 'claude_code', append: 'USER' },
+      'BROWSER'
+    );
+    expect(result.append).toBe('USER\n\nBROWSER');
+    expect(result.preset).toBe('claude_code');
+  });
+
+  test('falls back to the preset when nothing is set', () => {
+    expect(chatService._appendSystemPrompt(undefined, 'BROWSER'))
+      .toEqual({ type: 'preset', preset: 'claude_code', append: 'BROWSER' });
+  });
+
+  test('concatenates a fully custom string prompt', () => {
+    expect(chatService._appendSystemPrompt('CUSTOM', 'BROWSER')).toBe('CUSTOM\n\nBROWSER');
+    expect(chatService._appendSystemPrompt('', 'BROWSER')).toBe('BROWSER');
+  });
+
+  test('does not mutate the prompt it was given', () => {
+    const original = { type: 'preset', preset: 'claude_code', append: 'USER' };
+    chatService._appendSystemPrompt(original, 'BROWSER');
+    expect(original.append).toBe('USER');
+  });
+});
+
 describe('ChatService._safeSerialize', () => {
   test('serializes plain object', () => {
     const result = chatService._safeSerialize({ foo: 'bar', count: 42 });

--- a/tests/services/ChromeBridgeService.test.js
+++ b/tests/services/ChromeBridgeService.test.js
@@ -332,6 +332,10 @@ function claudeCodeManifest() {
   fs.mkdirSync(dir, { recursive: true });
   const exe = path.join(dir, 'claude.exe');
   fs.writeFileSync(exe, '');
+  // _manifestIsUsable tests X_OK. Windows ignores the bit, POSIX does not, and
+  // a file written at the default 0644 is not executable there — which made
+  // these tests pass locally and fail on the Linux and macOS runners.
+  fs.chmodSync(exe, 0o755);
   const manifest = path.join(dir, `${HOST_NAME}.json`);
   fs.writeFileSync(manifest, JSON.stringify({
     name: HOST_NAME,

--- a/tests/services/ChromeBridgeService.test.js
+++ b/tests/services/ChromeBridgeService.test.js
@@ -314,6 +314,121 @@ describe('ChromeBridgeService — native host installation', () => {
   });
 });
 
+/**
+ * A stand-in for the Windows registry, keyed the way `reg query` addresses it.
+ * The service reads it through execFile, so the mock has to answer in `reg`'s
+ * own output shape — that parse is the whole reason adoption can work here.
+ */
+const registry = {};
+const CHROME_KEY = ['HKCU', 'Software', 'Google', 'Chrome', 'NativeMessagingHosts', HOST_NAME].join('\\');
+
+function ourWindowsManifest() {
+  return path.join(process.env.LOCALAPPDATA, 'Claude Terminal', 'ChromeNativeHost', `${HOST_NAME}.json`);
+}
+
+/** A manifest as Claude Code leaves it: elsewhere on disk, pointing at its own binary. */
+function claudeCodeManifest() {
+  const dir = path.join(mockTmpHome, 'ClaudeCode');
+  fs.mkdirSync(dir, { recursive: true });
+  const exe = path.join(dir, 'claude.exe');
+  fs.writeFileSync(exe, '');
+  const manifest = path.join(dir, `${HOST_NAME}.json`);
+  fs.writeFileSync(manifest, JSON.stringify({
+    name: HOST_NAME,
+    path: exe,
+    type: 'stdio',
+    allowed_origins: [`chrome-extension://${EXTENSION_ID}/`],
+  }));
+  return manifest;
+}
+
+function installWindowsChrome() {
+  process.env.LOCALAPPDATA = path.join(mockTmpHome, 'AppData', 'Local');
+  fs.mkdirSync(path.join(process.env.LOCALAPPDATA, 'Google', 'Chrome', 'User Data'), { recursive: true });
+}
+
+beforeEach(() => {
+  for (const k of Object.keys(registry)) delete registry[k];
+  const { execFile } = require('child_process');
+  execFile.mockImplementation((cmd, args, cb) => {
+    const [verb, key] = args;
+    if (verb === 'query') {
+      const value = registry[key];
+      if (!value) return cb(new Error('ERROR: The system was unable to find the specified registry key'), '', '');
+      return cb(null, `\r\n${key}\r\n    (Default)    REG_SZ    ${value}\r\n\r\n`, '');
+    }
+    if (verb === 'add') registry[key] = args[args.indexOf('/d') + 1];
+    if (verb === 'delete') delete registry[key];
+    cb(null, '', '');
+  });
+});
+
+describe('ChromeBridgeService — Windows adoption', () => {
+  // The case the file check could not see. Windows keeps no well-known
+  // directory: the registry key is the registration, so a Claude Code install
+  // is invisible to a check that looks in a directory of ours. Every enable
+  // then overwrote their key, and every disable deleted it.
+  test('adopts the host a Claude Code install already registered', async () => {
+    const { execFile } = require('child_process');
+    setPlatform('win32');
+    installWindowsChrome();
+    registry[CHROME_KEY] = claudeCodeManifest();
+    execFile.mockClear();
+
+    const res = await service.ensureNativeHost();
+
+    expect(res.ok).toBe(true);
+    expect(res.adopted).toContain('chrome');
+    expect(res.installed).toEqual([]);
+    expect(execFile.mock.calls.filter(c => c[1][0] === 'add')).toHaveLength(0);
+    expect(fs.existsSync(ourWindowsManifest())).toBe(false);
+  });
+
+  test('installs when the key names a manifest whose binary is gone', async () => {
+    // A stale registration left by an uninstall: adopting it would leave the
+    // extension talking to nothing.
+    setPlatform('win32');
+    installWindowsChrome();
+    const stale = path.join(mockTmpHome, 'gone', `${HOST_NAME}.json`);
+    fs.mkdirSync(path.dirname(stale), { recursive: true });
+    fs.writeFileSync(stale, JSON.stringify({
+      name: HOST_NAME,
+      path: path.join(mockTmpHome, 'gone', 'claude.exe'),
+      allowed_origins: [`chrome-extension://${EXTENSION_ID}/`],
+    }));
+    registry[CHROME_KEY] = stale;
+
+    const res = await service.ensureNativeHost();
+
+    expect(res.installed).toContain('chrome');
+    expect(registry[CHROME_KEY]).toBe(ourWindowsManifest());
+  });
+
+  test('installs when nothing is registered at all', async () => {
+    setPlatform('win32');
+    installWindowsChrome();
+
+    const res = await service.ensureNativeHost();
+
+    expect(res.installed).toContain('chrome');
+    expect(res.adopted).toEqual([]);
+    expect(registry[CHROME_KEY]).toBe(ourWindowsManifest());
+    expect(fs.existsSync(ourWindowsManifest())).toBe(true);
+  });
+
+  test('decides per browser, so one adoption does not cover the others', async () => {
+    setPlatform('win32');
+    installWindowsChrome();
+    fs.mkdirSync(path.join(process.env.LOCALAPPDATA, 'BraveSoftware', 'Brave-Browser', 'User Data'), { recursive: true });
+    registry[CHROME_KEY] = claudeCodeManifest();
+
+    const res = await service.ensureNativeHost();
+
+    expect(res.adopted).toContain('chrome');
+    expect(res.installed).toContain('brave');
+  });
+});
+
 describe('ChromeBridgeService — native host removal', () => {
   test('removes a manifest we installed', async () => {
     installChrome();
@@ -343,20 +458,40 @@ describe('ChromeBridgeService — native host removal', () => {
     expect(fs.existsSync(path.join(chromeHostDir(), `${HOST_NAME}.json`))).toBe(true);
   });
 
-  test('drops the Windows registry keys along with the manifest', async () => {
+  test('drops the Windows registry key it owns, along with the manifest', async () => {
     const { execFile } = require('child_process');
     setPlatform('win32');
-    process.env.LOCALAPPDATA = path.join(mockTmpHome, 'AppData', 'Local');
-    fs.mkdirSync(path.join(process.env.LOCALAPPDATA, 'Google', 'Chrome', 'User Data'), { recursive: true });
+    installWindowsChrome();
     await service.ensureNativeHost();
+    // The key now names our manifest, as `reg add` would have left it.
+    registry[CHROME_KEY] = ourWindowsManifest();
     execFile.mockClear();
 
     const res = await service.removeNativeHost();
 
-    expect(res.removed).toContain('windows');
+    expect(res.removed).toContain('chrome');
     // A key outliving its manifest would point Chrome at a missing file.
     const deletes = execFile.mock.calls.filter(c => c[1][0] === 'delete');
     expect(deletes.length).toBeGreaterThan(0);
+    expect(fs.existsSync(ourWindowsManifest())).toBe(false);
+  });
+
+  test('leaves a Windows key that points somewhere else alone', async () => {
+    // The exact shape that used to break a Claude Code install: our toggle goes
+    // off and every browser's key is deleted, including the one we never wrote.
+    const { execFile } = require('child_process');
+    setPlatform('win32');
+    installWindowsChrome();
+    const theirs = claudeCodeManifest();
+    registry[CHROME_KEY] = theirs;
+    execFile.mockClear();
+
+    const res = await service.removeNativeHost();
+
+    expect(res.removed).toEqual([]);
+    expect(res.kept).toContain('chrome');
+    expect(execFile.mock.calls.filter(c => c[1][0] === 'delete')).toHaveLength(0);
+    expect(fs.existsSync(theirs)).toBe(true);
   });
 
   test('is a no-op when nothing is installed', async () => {

--- a/tests/services/ChromeBridgeService.test.js
+++ b/tests/services/ChromeBridgeService.test.js
@@ -1,0 +1,434 @@
+// ChromeBridgeService unit tests — "Claude in Chrome" browser integration.
+//
+// Strategy: point the service at a real temp directory (via a fake homedir and
+// a mocked paths module) and let it do real file I/O. The behaviour that
+// matters here is all filesystem shaped — which manifest gets written, which
+// one is adopted, which one is left alone — so a virtual fs would mostly be
+// testing the mock.
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+// The service destructures `dataDir`/`settingsFile` from paths at require time,
+// so the temp home has to exist and be fixed before the require below — hence a
+// single root for the file, wiped between tests rather than recreated.
+const mockTmpHome = fs.mkdtempSync(path.join(require('os').tmpdir(), 'ct-chrome-'));
+const mockDataDir = path.join(mockTmpHome, '.claude-terminal');
+const mockSettingsFile = path.join(mockDataDir, 'settings.json');
+
+// The service derives every browser path from os.homedir() at call time.
+jest.mock('os', () => {
+  const realOs = jest.requireActual('os');
+  return { ...realOs, homedir: jest.fn(() => realOs.homedir()) };
+});
+
+jest.mock('../../src/main/utils/paths', () => ({
+  dataDir: mockDataDir,
+  settingsFile: mockSettingsFile
+}));
+
+// The Windows branch shells out to `reg`; nothing here should touch the registry.
+jest.mock('child_process', () => ({
+  execFile: jest.fn((cmd, args, cb) => cb && cb(null, '', ''))
+}));
+
+// sdkCli pulls in electron; the tests only care about the path it returns.
+jest.mock('../../src/main/utils/sdkCli', () => ({
+  getSdkCliPath: jest.fn(() => global.__ctCliPath)
+}));
+
+const { getSdkCliPath } = require('../../src/main/utils/sdkCli');
+const service = require('../../src/main/services/ChromeBridgeService');
+const { HOST_NAME, EXTENSION_ID, MCP_SERVER_NAME } = service;
+
+// macOS layout is used throughout so the assertions are identical on every CI
+// runner; the Windows-specific branches are exercised explicitly.
+const ORIGINAL_PLATFORM = process.platform;
+function setPlatform(value) {
+  Object.defineProperty(process, 'platform', { value, configurable: true });
+}
+
+/** Native messaging dir Chrome would read on macOS. */
+function chromeHostDir() {
+  return path.join(mockTmpHome, 'Library', 'Application Support', 'Google', 'Chrome', 'NativeMessagingHosts');
+}
+
+/** Make a browser look installed: the service only wires up browsers it finds. */
+function installBrowser(...segments) {
+  fs.mkdirSync(path.join(mockTmpHome, ...segments), { recursive: true });
+}
+
+function installChrome() {
+  installBrowser('Library', 'Application Support', 'Google', 'Chrome');
+}
+
+function installBrave() {
+  installBrowser('Library', 'Application Support', 'BraveSoftware', 'Brave-Browser');
+}
+
+/** Profile dir we plant the extension in. */
+function chromeProfileDir(profile = 'Default') {
+  return path.join(mockTmpHome, 'Library', 'Application Support', 'Google', 'Chrome', profile);
+}
+
+function writeJson(file, data) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(data, null, 2), 'utf8');
+}
+
+function readManifest(dir) {
+  return JSON.parse(fs.readFileSync(path.join(dir, `${HOST_NAME}.json`), 'utf8'));
+}
+
+beforeEach(() => {
+  // Wipe everything the previous test planted, keeping the root path stable.
+  for (const entry of fs.readdirSync(mockTmpHome)) {
+    fs.rmSync(path.join(mockTmpHome, entry), { recursive: true, force: true });
+  }
+  fs.mkdirSync(mockDataDir, { recursive: true });
+
+  // An executable stand-in for the bundled Claude Code binary.
+  const cli = path.join(mockTmpHome, 'claude');
+  fs.writeFileSync(cli, '#!/bin/sh\nexit 0\n');
+  fs.chmodSync(cli, 0o755);
+  global.__ctCliPath = cli;
+  getSdkCliPath.mockImplementation(() => global.__ctCliPath);
+
+  os.homedir.mockReturnValue(mockTmpHome);
+  setPlatform('darwin');
+
+  // The singleton memoises detection and host installation across calls.
+  service._detection = null;
+  service._detectionAt = 0;
+  service._hostReady = null;
+});
+
+afterEach(() => {
+  setPlatform(ORIGINAL_PLATFORM);
+});
+
+afterAll(() => {
+  fs.rmSync(mockTmpHome, { recursive: true, force: true });
+});
+
+describe('ChromeBridgeService — enablement', () => {
+  test('is disabled when settings.json is absent', () => {
+    expect(service.isEnabled()).toBe(false);
+  });
+
+  test('is disabled unless the flag is explicitly true', () => {
+    writeJson(mockSettingsFile, { chromeBridgeEnabled: false });
+    expect(service.isEnabled()).toBe(false);
+    writeJson(mockSettingsFile, {});
+    expect(service.isEnabled()).toBe(false);
+    // A truthy non-boolean must not count — the setting is written by a checkbox.
+    writeJson(mockSettingsFile, { chromeBridgeEnabled: 'yes' });
+    expect(service.isEnabled()).toBe(false);
+  });
+
+  test('is enabled when the flag is true', () => {
+    writeJson(mockSettingsFile, { chromeBridgeEnabled: true });
+    expect(service.isEnabled()).toBe(true);
+  });
+
+  test('survives a corrupt settings file', () => {
+    fs.writeFileSync(mockSettingsFile, '{ not json', 'utf8');
+    expect(service.isEnabled()).toBe(false);
+  });
+});
+
+describe('ChromeBridgeService — extension detection', () => {
+  test('reports the browser hosting the extension', async () => {
+    fs.mkdirSync(path.join(chromeProfileDir(), 'Extensions', EXTENSION_ID), { recursive: true });
+    const res = await service.detectExtension(true);
+    expect(res).toEqual({ installed: true, browser: 'chrome', label: 'Google Chrome' });
+  });
+
+  test('finds the extension in a secondary profile', async () => {
+    fs.mkdirSync(path.join(chromeProfileDir('Profile 3'), 'Extensions', EXTENSION_ID), { recursive: true });
+    const res = await service.detectExtension(true);
+    expect(res.installed).toBe(true);
+  });
+
+  test('ignores directories that are not Chrome profiles', async () => {
+    fs.mkdirSync(path.join(chromeProfileDir('ShaderCache'), 'Extensions', EXTENSION_ID), { recursive: true });
+    const res = await service.detectExtension(true);
+    expect(res.installed).toBe(false);
+  });
+
+  test('reports absent when no browser has it', async () => {
+    fs.mkdirSync(path.join(chromeProfileDir(), 'Extensions', 'someotherextension'), { recursive: true });
+    const res = await service.detectExtension(true);
+    expect(res).toEqual({ installed: false, browser: null, label: null });
+  });
+
+  test('caches results until forced', async () => {
+    expect((await service.detectExtension(true)).installed).toBe(false);
+    fs.mkdirSync(path.join(chromeProfileDir(), 'Extensions', EXTENSION_ID), { recursive: true });
+    expect((await service.detectExtension()).installed).toBe(false);
+    expect((await service.detectExtension(true)).installed).toBe(true);
+  });
+});
+
+describe('ChromeBridgeService — native host installation', () => {
+  test('installs a manifest and an executable wrapper when none exists', async () => {
+    installChrome();
+    const res = await service.ensureNativeHost();
+
+    expect(res.ok).toBe(true);
+    expect(res.adopted).toEqual([]);
+    expect(res.installed).toContain('chrome');
+
+    const manifest = readManifest(chromeHostDir());
+    expect(manifest.name).toBe(HOST_NAME);
+    expect(manifest.allowed_origins).toEqual([`chrome-extension://${EXTENSION_ID}/`]);
+
+    // Chrome execs the manifest's `path` directly, so it has to exist and run.
+    expect(fs.existsSync(manifest.path)).toBe(true);
+    expect(fs.readFileSync(manifest.path, 'utf8')).toContain('--chrome-native-host');
+    fs.accessSync(manifest.path, fs.constants.X_OK);
+  });
+
+  test('adopts a working Claude Code manifest instead of overwriting it', async () => {
+    // The host name is fixed by the extension, so both apps compete for one
+    // file. Clobbering it would break the other install.
+    const foreignHost = path.join(mockTmpHome, 'foreign-host');
+    fs.writeFileSync(foreignHost, '#!/bin/sh\nexit 0\n');
+    fs.chmodSync(foreignHost, 0o755);
+    const existing = {
+      name: HOST_NAME,
+      description: 'Claude Code Browser Extension Native Host',
+      path: foreignHost,
+      type: 'stdio',
+      allowed_origins: [`chrome-extension://${EXTENSION_ID}/`]
+    };
+    installChrome();
+    writeJson(path.join(chromeHostDir(), `${HOST_NAME}.json`), existing);
+
+    const res = await service.ensureNativeHost();
+
+    expect(res.ok).toBe(true);
+    expect(res.adopted).toEqual(['chrome']);
+    expect(res.installed).toEqual([]);
+    expect(readManifest(chromeHostDir())).toEqual(existing);
+    // Nothing of ours was written either.
+    expect(fs.existsSync(service._wrapperPath())).toBe(false);
+  });
+
+  test('replaces a manifest whose target no longer exists', async () => {
+    installChrome();
+    writeJson(path.join(chromeHostDir(), `${HOST_NAME}.json`), {
+      name: HOST_NAME,
+      path: path.join(mockTmpHome, 'uninstalled', 'claude'),
+      type: 'stdio',
+      allowed_origins: [`chrome-extension://${EXTENSION_ID}/`]
+    });
+
+    const res = await service.ensureNativeHost();
+
+    expect(res.installed).toEqual(['chrome']);
+    expect(readManifest(chromeHostDir()).path).toBe(service._wrapperPath());
+  });
+
+  test('replaces a manifest that does not allow the extension', async () => {
+    installChrome();
+    writeJson(path.join(chromeHostDir(), `${HOST_NAME}.json`), {
+      name: HOST_NAME,
+      path: global.__ctCliPath,
+      type: 'stdio',
+      allowed_origins: ['chrome-extension://unrelatedextensionid/']
+    });
+
+    const res = await service.ensureNativeHost();
+
+    expect(res.installed).toEqual(['chrome']);
+    expect(readManifest(chromeHostDir()).allowed_origins)
+      .toEqual([`chrome-extension://${EXTENSION_ID}/`]);
+  });
+
+  test('fails cleanly when the bundled binary is missing', async () => {
+    installChrome();
+    global.__ctCliPath = null;
+    const res = await service.ensureNativeHost();
+    expect(res).toMatchObject({ ok: false, error: 'sdk-cli-missing' });
+  });
+
+  test('reports no-browser-found when no Chromium browser is present', async () => {
+    const res = await service.ensureNativeHost();
+    expect(res).toMatchObject({ ok: false, error: 'no-browser-found' });
+  });
+
+  test('leaves alone the config directories of browsers that are not installed', async () => {
+    installChrome();
+    await service.ensureNativeHost();
+    // Creating a Vivaldi config dir on a machine with no Vivaldi is litter
+    // nothing will ever read.
+    const vivaldi = path.join(mockTmpHome, 'Library', 'Application Support', 'Vivaldi');
+    expect(fs.existsSync(vivaldi)).toBe(false);
+  });
+
+  test('installs for a second browser even when the first was adopted', async () => {
+    // Per-browser decision: a manifest Claude Code left in Chrome says nothing
+    // about Brave, which still needs ours.
+    installChrome();
+    installBrave();
+    const foreignHost = path.join(mockTmpHome, 'foreign-host');
+    fs.writeFileSync(foreignHost, '#!/bin/sh\nexit 0\n');
+    fs.chmodSync(foreignHost, 0o755);
+    writeJson(path.join(chromeHostDir(), `${HOST_NAME}.json`), {
+      name: HOST_NAME,
+      path: foreignHost,
+      type: 'stdio',
+      allowed_origins: [`chrome-extension://${EXTENSION_ID}/`]
+    });
+
+    const res = await service.ensureNativeHost();
+
+    expect(res.adopted).toEqual(['chrome']);
+    expect(res.installed).toEqual(['brave']);
+    const braveDir = path.join(mockTmpHome, 'Library', 'Application Support', 'BraveSoftware', 'Brave-Browser', 'NativeMessagingHosts');
+    expect(readManifest(braveDir).path).toBe(service._wrapperPath());
+  });
+
+  test('is memoised across calls', async () => {
+    installChrome();
+    const first = await service.ensureNativeHost();
+    fs.rmSync(path.join(chromeHostDir(), `${HOST_NAME}.json`));
+    const second = await service.ensureNativeHost();
+    expect(second).toBe(first);
+    // Forcing redoes the work.
+    const third = await service.ensureNativeHost(true);
+    expect(third.ok).toBe(true);
+    expect(fs.existsSync(path.join(chromeHostDir(), `${HOST_NAME}.json`))).toBe(true);
+  });
+
+  test('writes a .bat wrapper on Windows', async () => {
+    setPlatform('win32');
+    process.env.LOCALAPPDATA = path.join(mockTmpHome, 'AppData', 'Local');
+    fs.mkdirSync(path.join(process.env.LOCALAPPDATA, 'Google', 'Chrome', 'User Data'), { recursive: true });
+    const res = await service.ensureNativeHost();
+    expect(res.ok).toBe(true);
+    expect(service._wrapperPath().endsWith('.bat')).toBe(true);
+    expect(fs.readFileSync(service._wrapperPath(), 'utf8')).toContain('--chrome-native-host');
+  });
+});
+
+describe('ChromeBridgeService — native host removal', () => {
+  test('removes a manifest we installed', async () => {
+    installChrome();
+    await service.ensureNativeHost();
+    expect(fs.existsSync(path.join(chromeHostDir(), `${HOST_NAME}.json`))).toBe(true);
+
+    const res = await service.removeNativeHost();
+
+    expect(res.removed).toContain('chrome');
+    expect(fs.existsSync(path.join(chromeHostDir(), `${HOST_NAME}.json`))).toBe(false);
+  });
+
+  test('keeps a manifest owned by Claude Code', async () => {
+    // Disabling our toggle must not disable the other install.
+    installChrome();
+    writeJson(path.join(chromeHostDir(), `${HOST_NAME}.json`), {
+      name: HOST_NAME,
+      path: path.join(mockTmpHome, '.claude', 'chrome', 'chrome-native-host'),
+      type: 'stdio',
+      allowed_origins: [`chrome-extension://${EXTENSION_ID}/`]
+    });
+
+    const res = await service.removeNativeHost();
+
+    expect(res.removed).toEqual([]);
+    expect(res.kept).toContain('chrome');
+    expect(fs.existsSync(path.join(chromeHostDir(), `${HOST_NAME}.json`))).toBe(true);
+  });
+
+  test('drops the Windows registry keys along with the manifest', async () => {
+    const { execFile } = require('child_process');
+    setPlatform('win32');
+    process.env.LOCALAPPDATA = path.join(mockTmpHome, 'AppData', 'Local');
+    fs.mkdirSync(path.join(process.env.LOCALAPPDATA, 'Google', 'Chrome', 'User Data'), { recursive: true });
+    await service.ensureNativeHost();
+    execFile.mockClear();
+
+    const res = await service.removeNativeHost();
+
+    expect(res.removed).toContain('windows');
+    // A key outliving its manifest would point Chrome at a missing file.
+    const deletes = execFile.mock.calls.filter(c => c[1][0] === 'delete');
+    expect(deletes.length).toBeGreaterThan(0);
+  });
+
+  test('is a no-op when nothing is installed', async () => {
+    await expect(service.removeNativeHost()).resolves.toEqual({ removed: [], kept: [] });
+  });
+});
+
+describe('ChromeBridgeService — session wiring', () => {
+  test('contributes nothing while disabled', () => {
+    writeJson(mockSettingsFile, { chromeBridgeEnabled: false });
+    expect(service.getSessionConfig()).toBeNull();
+  });
+
+  test('contributes the MCP server and a system prompt when enabled', () => {
+    writeJson(mockSettingsFile, { chromeBridgeEnabled: true });
+    const cfg = service.getSessionConfig();
+
+    expect(cfg.mcpServers[MCP_SERVER_NAME]).toEqual({
+      type: 'stdio',
+      command: global.__ctCliPath,
+      args: ['--claude-in-chrome-mcp']
+    });
+    // The ordering constraint is the one thing the tool descriptions don't state.
+    expect(cfg.systemPrompt).toContain('tabs_context_mcp');
+  });
+
+  test('contributes nothing when the bundled binary is missing', () => {
+    writeJson(mockSettingsFile, { chromeBridgeEnabled: true });
+    global.__ctCliPath = null;
+    expect(service.getSessionConfig()).toBeNull();
+  });
+
+  test('contributes nothing on an unsupported platform', () => {
+    writeJson(mockSettingsFile, { chromeBridgeEnabled: true });
+    setPlatform('aix');
+    expect(service.getSessionConfig()).toBeNull();
+  });
+});
+
+describe('ChromeBridgeService — status', () => {
+  test('surfaces a missing extension without claiming the host works', async () => {
+    writeJson(mockSettingsFile, { chromeBridgeEnabled: false });
+    const st = await service.getStatus(true);
+    expect(st).toMatchObject({
+      supported: true,
+      enabled: false,
+      cliAvailable: true,
+      extensionInstalled: false,
+      hostInstalled: false
+    });
+  });
+
+  test('reports the browser and host once everything is in place', async () => {
+    writeJson(mockSettingsFile, { chromeBridgeEnabled: true });
+    fs.mkdirSync(path.join(chromeProfileDir(), 'Extensions', EXTENSION_ID), { recursive: true });
+
+    const st = await service.getStatus(true);
+
+    expect(st).toMatchObject({
+      supported: true,
+      enabled: true,
+      extensionInstalled: true,
+      browser: 'chrome',
+      browserLabel: 'Google Chrome',
+      hostInstalled: true
+    });
+  });
+
+  test('reports unsupported platforms without touching the disk', async () => {
+    setPlatform('aix');
+    const st = await service.getStatus(true);
+    expect(st.supported).toBe(false);
+    expect(st.extensionInstalled).toBe(false);
+  });
+});


### PR DESCRIPTION
Claude Desktop and `claude --chrome` can drive the official Claude browser extension. This gives Claude Terminal the same capability: when enabled, a chat session gains the 22 browser tools — navigate, click and type, read the DOM, inspect console and network — as `mcp__claude-in-chrome__*`.

## How it works

Nothing about the wire protocol is reimplemented. The Claude Code binary already shipped with the Agent SDK (`@anthropic-ai/claude-agent-sdk-<platform>-<arch>`) implements **both** halves, so the feature is a matter of plugging two ends together:

```
chat session ──stdio MCP──> `claude --claude-in-chrome-mcp`   (we spawn)
                                     │
                                     ▼  bridge
Chrome ──native messaging──> `claude --chrome-native-host`    (Chrome spawns,
                                     ▲                          via a manifest we drop in)
```

No extra download, no new dependency.

## The one subtle part

The native-host name is chosen by the extension, so it is necessarily `com.anthropic.claude_code_browser_extension` — the exact name the Claude Code CLI also uses. Both apps therefore compete for a single manifest file per browser, and clobbering it would break the other install.

So a working manifest is **adopted**, never overwritten, and the decision is made **per browser**: one left by Claude Code in Chrome says nothing about Brave, which may still need ours. Removal is symmetric — only manifests we wrote are deleted, and on Windows the registry key goes with them.

## Safety

- **Off by default.** Driving a signed-in browser is a large capability, so it is opt-in rather than something discovered after the fact.
- Sessions that restrict their own toolset — the hands-free voice profile — never get the browser tools.
- The appended system prompt tells the model this is the user's real browser: read freely, ask before anything that sends, buys, deletes or posts.

## Changes

| Area | File |
|---|---|
| Service | `src/main/services/ChromeBridgeService.js` (new) — detection, manifest lifecycle, session config |
| IPC | `src/main/ipc/chrome.ipc.js` (new) — 4 handlers |
| Util | `src/main/utils/sdkCli.js` (new) — CLI path resolution, extracted from `ChatService` so both callers agree without a circular import |
| Session | `ChatService` — registers the MCP server, appends the prompt |
| UI | Settings group with a live status line (extension found / host registered), install shortcut |
| i18n | EN, FR, ES, ID, zh-CN |

## Testing

**Automated** — 35 new tests, full suite green: **2576 passed**.

- 30 for `ChromeBridgeService`: adoption vs. install, per-browser decisions, removal symmetry, the Windows path, and the "browser not installed" gate.
- 5 for the system-prompt merge — dropping the preset there would silently strip the Claude Code prompt.

**End-to-end, against a real browser.** Taking the MCP config the service itself produces, spawning it, and driving Chrome:

```
MCP server "claude-in-chrome" -> claude --claude-in-chrome-mcp
tools exposed: 22

1. tabs_context_mcp   {"availableTabs":[...],"tabGroupId":552705612}
2. tabs_create_mcp    Created new tab. Tab ID: 2125405732
3. navigate           Navigated to https://example.com
4. get_page_text      Title: Example Domain
                      This domain is for use in documentation examples...
5. tabs_close_mcp     Closed tab 2125405732
```

**Adoption verified against a real Claude Code install** — the path that could damage a user's existing setup. With Claude Code's manifests already present in seven browser directories:

```
ensureNativeHost : {"ok":true,"installed":[],"adopted":["chrome","brave","arc",...]}

manifeste INTACT   Chrome
manifeste INTACT   Brave-Browser
manifeste INTACT   Microsoft Edge
```

`installed: []` — nothing written, all three manifests byte-identical afterwards.

App boots cleanly from a sandbox instance with the IPC handlers registered and no errors.

> [!NOTE]
> One path is not covered by the above: the Settings toggle click itself (save → install/remove side effect). Reading the setting has unit coverage, and the end-to-end run stubbed `isEnabled()` rather than mutate a live config file.