### PR TITLE
feat(accounts): show each account's usage in Settings

### DIFF
--- a/src/main/ipc/accounts.ipc.js
+++ b/src/main/ipc/accounts.ipc.js
@@ -21,6 +21,30 @@ async function wrap(fn) {
   }
 }
 
+/** Accounts whose credential store this run has already bootstrapped. */
+const seededStores = new Set();
+
+/**
+ * Make sure an account has a credential store to read a token from, once per
+ * run. Accounts captured before per-account stores existed have only a
+ * snapshot, and without the seed they report themselves signed out forever.
+ *
+ * Bounded to one attempt per account because probing a store costs a Keychain
+ * read on macOS, and the settings list asks for these figures on every account
+ * change — a rename would otherwise re-probe every account.
+ *
+ * @param {string} id
+ */
+async function seedStoreOnce(id) {
+  if (seededStores.has(id)) return;
+  seededStores.add(id);
+  try {
+    await AccountManager.ensureAccountStore(id);
+  } catch (err) {
+    console.warn('[accounts.ipc] credential store seed failed:', err.message);
+  }
+}
+
 // Reading the live store can hit the macOS Keychain, so the broadcast payload
 // has to be awaited too.
 async function broadcastAccounts() {
@@ -33,6 +57,22 @@ async function broadcastAccounts() {
 
 function registerAccountsHandlers() {
   ipcMain.handle('accounts-list', () => wrap(() => AccountManager.listAccounts()));
+
+  // Usage figures for every stored account, keyed by account id, so the
+  // settings list can say which account still has room before the user moves
+  // a project onto it.
+  //
+  // Fetched in parallel: the calls are independent, and a serial sweep would
+  // make the whole list wait out one account's five-second API timeout.
+  ipcMain.handle('accounts-usage', (_event, { maxAgeMs } = {}) => wrap(async () => {
+    const { accounts } = await AccountManager.listAccounts();
+    const usage = {};
+    await Promise.all(accounts.map(async (account) => {
+      await seedStoreOnce(account.id);
+      usage[account.id] = await UsageService.usageForAccount(account.id, maxAgeMs);
+    }));
+    return usage;
+  }));
 
   ipcMain.handle('accounts-capture', async (_event, { name } = {}) => {
     const result = await wrap(() => AccountManager.captureCurrent(name));

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -569,6 +569,7 @@ contextBridge.exposeInMainWorld('electron_api', {
   // ==================== ACCOUNTS (multi Claude OAuth) ====================
   accounts: {
     list: () => ipcRenderer.invoke('accounts-list'),
+    usage: (maxAgeMs) => ipcRenderer.invoke('accounts-usage', { maxAgeMs }),
     capture: (name) => ipcRenderer.invoke('accounts-capture', { name }),
     switch: (id) => ipcRenderer.invoke('accounts-switch', { id }),
     setDefault: (id) => ipcRenderer.invoke('accounts-set-default', { id }),

--- a/src/main/services/UsageService.js
+++ b/src/main/services/UsageService.js
@@ -391,6 +391,30 @@ function refreshUsage(accountId) {
 }
 
 /**
+ * Figures for an account, refetched only when the ones already on hand are
+ * older than `maxAgeMs`.
+ *
+ * The settings list asks about every account at once, and it re-renders on any
+ * account change — a rename, a colour, a new capture. Refetching on each of
+ * those would turn a rename into one API call per account, and on macOS one
+ * Keychain read per account with it, so anything recent enough is served from
+ * the cache instead.
+ *
+ * @param {string|null} accountId
+ * @param {number} [maxAgeMs] - 0 forces a fetch
+ * @returns {Promise<Object>} same shape as getUsageData()
+ */
+async function usageForAccount(accountId, maxAgeMs = 5 * 60 * 1000) {
+  const entry = entryFor(accountId);
+  const age = entry.lastFetch ? Date.now() - entry.lastFetch.getTime() : Infinity;
+  // `>=` so that a maxAge of 0 always refetches: figures fetched in the same
+  // millisecond are not "younger than 0ms", and the explicit refresh button
+  // would otherwise be a no-op on a fast machine.
+  if (age >= maxAgeMs) await fetchUsage(accountId);
+  return getUsageData(accountId);
+}
+
+/**
  * Called when window becomes visible - refresh if data is stale
  */
 function onWindowShow() {
@@ -455,6 +479,7 @@ module.exports = {
   getUsageData,
   getFetchState,
   refreshUsage,
+  usageForAccount,
   fetchUsage,
   invalidateCredentials,
   setFocusedAccount,

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -3802,7 +3802,11 @@
     "switchWhileRunning": "{count} session(s) are already running for this project and keep their current account. The change applies to sessions started from now on. Continue?",
     "colorNone": "No colour",
     "chooseForProjectTitle": "Claude account",
-    "chooseForProject": "Which account should {project} run as? You can change this later from its tab."
+    "chooseForProject": "Which account should {project} run as? You can change this later from its tab.",
+    "usageLoading": "Reading usage…",
+    "usageUnavailable": "Usage unavailable — run \"claude /login\" on this account",
+    "usageStale": "The API could not confirm these figures",
+    "usageRefresh": "Refresh usage"
   },
   "usage": {
     "stale": "Usage data may be out of date - the last refresh failed. {error}"

--- a/src/renderer/i18n/locales/es.json
+++ b/src/renderer/i18n/locales/es.json
@@ -3802,7 +3802,11 @@
     "switchWhileRunning": "{count} sesión(es) ya están en curso para este proyecto y conservan su cuenta actual. El cambio se aplicará a las sesiones que inicies después. ¿Continuar?",
     "colorNone": "Sin color",
     "chooseForProjectTitle": "Cuenta de Claude",
-    "chooseForProject": "¿Con qué cuenta debe ejecutarse {project}? Puedes cambiarlo luego desde su pestaña."
+    "chooseForProject": "¿Con qué cuenta debe ejecutarse {project}? Puedes cambiarlo luego desde su pestaña.",
+    "usageLoading": "Leyendo el uso…",
+    "usageUnavailable": "Uso no disponible: ejecuta «claude /login» en esta cuenta",
+    "usageStale": "La API no pudo confirmar estas cifras",
+    "usageRefresh": "Actualizar el uso"
   },
   "usage": {
     "stale": "Datos de uso posiblemente desactualizados - la última actualización falló. {error}"

--- a/src/renderer/i18n/locales/fr.json
+++ b/src/renderer/i18n/locales/fr.json
@@ -3802,7 +3802,11 @@
     "switchWhileRunning": "{count} session(s) tournent déjà pour ce projet et gardent leur compte actuel. Le changement s’appliquera aux sessions démarrées ensuite. Continuer ?",
     "colorNone": "Aucune couleur",
     "chooseForProjectTitle": "Compte Claude",
-    "chooseForProject": "Sur quel compte {project} doit-il tourner ? Modifiable ensuite depuis son onglet."
+    "chooseForProject": "Sur quel compte {project} doit-il tourner ? Modifiable ensuite depuis son onglet.",
+    "usageLoading": "Lecture de la consommation…",
+    "usageUnavailable": "Consommation indisponible — lancez « claude /login » sur ce compte",
+    "usageStale": "L'API n'a pas pu confirmer ces chiffres",
+    "usageRefresh": "Actualiser la consommation"
   },
   "usage": {
     "stale": "Données d'usage peut-être obsolètes - la dernière actualisation a échoué. {error}"

--- a/src/renderer/i18n/locales/id.json
+++ b/src/renderer/i18n/locales/id.json
@@ -3802,7 +3802,11 @@
     "switchWhileRunning": "{count} sesi sudah berjalan untuk proyek ini dan tetap memakai akunnya. Perubahan berlaku untuk sesi berikutnya. Lanjutkan?",
     "colorNone": "Tanpa warna",
     "chooseForProjectTitle": "Akun Claude",
-    "chooseForProject": "Akun mana yang dipakai {project}? Bisa diubah nanti dari tabnya."
+    "chooseForProject": "Akun mana yang dipakai {project}? Bisa diubah nanti dari tabnya.",
+    "usageLoading": "Membaca penggunaan…",
+    "usageUnavailable": "Penggunaan tidak tersedia — jalankan \"claude /login\" pada akun ini",
+    "usageStale": "API tidak dapat memastikan angka ini",
+    "usageRefresh": "Segarkan penggunaan"
   },
   "usage": {
     "stale": "Data penggunaan mungkin sudah tidak terbaru - pemuatan terakhir gagal. {error}"

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -3802,7 +3802,11 @@
     "switchWhileRunning": "该项目已有 {count} 个会话在运行，它们将保留当前账户。更改仅对之后启动的会话生效。是否继续？",
     "colorNone": "无颜色",
     "chooseForProjectTitle": "Claude 账户",
-    "chooseForProject": "{project} 使用哪个账户运行？之后可从其标签页更改。"
+    "chooseForProject": "{project} 使用哪个账户运行？之后可从其标签页更改。",
+    "usageLoading": "正在读取用量…",
+    "usageUnavailable": "无法获取用量 — 请对该账号运行 \"claude /login\"",
+    "usageStale": "API 无法确认这些数据",
+    "usageRefresh": "刷新用量"
   },
   "usage": {
     "stale": "使用情况数据可能已过时 - 上次刷新失败。 {error}"

--- a/src/renderer/ui/panels/SettingsPanel.js
+++ b/src/renderer/ui/panels/SettingsPanel.js
@@ -35,6 +35,82 @@ function renderAgentColorRow(key, label, badge, color) {
     </div>`;
 }
 
+/**
+ * How long until a limit window resets, in the same compact form the titlebar
+ * uses. Empty once the window has passed — a countdown at zero says nothing.
+ * @param {string|null} iso
+ * @returns {string}
+ */
+function formatUsageReset(iso) {
+  if (!iso) return '';
+  const target = new Date(iso).getTime();
+  if (Number.isNaN(target)) return '';
+  const remaining = target - Date.now();
+  if (remaining <= 0) return '';
+  const dayUnit = getCurrentLanguage() === 'fr' ? 'j' : 'd';
+  const d = Math.floor(remaining / 86400000);
+  const h = Math.floor((remaining % 86400000) / 3600000);
+  const m = Math.floor((remaining % 3600000) / 60000);
+  if (d > 0) return `${d}${dayUnit} ${h}h`;
+  if (h > 0) return `${h}h ${String(m).padStart(2, '0')}min`;
+  return `${m}min`;
+}
+
+/**
+ * One usage bucket, in the markup the titlebar bars already use so both read
+ * the same: blue for the session window, purple for the weekly one, and the
+ * warning / danger tints above 70% and 90%.
+ *
+ * A scoped bucket is named by the API, so its label is escaped rather than
+ * translated — it is data, not a string we ship.
+ *
+ * @param {Object} bucket
+ * @returns {string}
+ */
+function buildUsageBucketHtml(bucket) {
+  const percent = typeof bucket.utilization === 'number' ? Math.round(bucket.utilization) : null;
+  const level = percent === null ? '' : percent >= 90 ? ' danger' : percent >= 70 ? ' warning' : '';
+  const label = bucket.labelKey ? t(bucket.labelKey) : (bucket.label || '');
+  const reset = formatUsageReset(bucket.resetsAt);
+  return `
+    <div class="usage-item" data-type="${escapeHtml(bucket.type || '')}">
+      <div class="usage-header">
+        <span class="usage-label">${escapeHtml(label)}</span>
+        <span class="usage-value">
+          <span class="usage-percent">${percent === null ? '--' : `${percent}%`}</span>
+          <span class="usage-reset">${escapeHtml(reset)}</span>
+        </span>
+      </div>
+      <div class="usage-bar-container">
+        <div class="usage-bar${level}" style="width: ${Math.min(percent ?? 0, 100)}%"></div>
+      </div>
+    </div>`;
+}
+
+/**
+ * The usage strip under an account row.
+ *
+ * An account nobody has run lately has no usable token of its own, and no
+ * amount of retrying will produce one — so that case says what to do about it
+ * rather than showing bars stuck at zero, which would read as "plenty left".
+ *
+ * @param {Object|null|undefined} usage - one entry of the accounts-usage map
+ * @returns {string}
+ */
+function buildAccountUsageHtml(usage) {
+  if (!usage) {
+    return `<div class="account-usage-note">${escapeHtml(t('accounts.usageLoading') || 'Reading usage…')}</div>`;
+  }
+  const buckets = usage.data?.buckets;
+  if (!Array.isArray(buckets) || !buckets.length) {
+    return `<div class="account-usage-note" title="${escapeHtml(usage.error || '')}">${escapeHtml(t('accounts.usageUnavailable') || 'Usage unavailable — run "claude /login" on this account')}</div>`;
+  }
+  return `
+    <div class="account-usage-bars${usage.stale ? ' stale' : ''}"${usage.stale ? ` title="${escapeHtml(t('accounts.usageStale') || 'The API could not confirm these figures')}"` : ''}>
+      ${buckets.map(buildUsageBucketHtml).join('')}
+    </div>`;
+}
+
 function buildContextItemRow(item, index) {
   const typeOptions = ['file', 'folder', 'text'].map(type =>
     `<option value="${type}" ${item.type === type ? 'selected' : ''}>${type === 'file' ? t('settings.contextPackItemFile') : type === 'folder' ? t('settings.contextPackItemFolder') : t('settings.contextPackItemText')}</option>`
@@ -1023,6 +1099,7 @@ class SettingsPanel extends BasePanel {
                 </div>
                 <div style="display: flex; gap: 8px; padding: 8px 16px 16px;">
                   <button class="btn btn-secondary" id="btn-account-capture">${t('accounts.captureCurrent') || 'Save current account'}</button>
+                  <button class="btn btn-secondary" id="btn-accounts-usage-refresh">${t('accounts.usageRefresh') || 'Refresh usage'}</button>
                 </div>
               </div>
             </div>
@@ -1428,6 +1505,9 @@ class SettingsPanel extends BasePanel {
         tab.classList.add('active');
         container.querySelector(`.settings-panel[data-panel="${tab.dataset.tab}"]`)?.classList.add('active');
         if (tab.dataset.tab === 'agents') self.loadAgentsColorPanel();
+        // Account usage is only read once its panel is on screen: each account
+        // costs a credential-store read, which prompts for the Keychain on macOS.
+        if (tab.dataset.tab === 'claude') self._loadAccountsUsage();
       };
     });
 
@@ -2166,26 +2246,35 @@ class SettingsPanel extends BasePanel {
         const bound = getProjectsForAccount(a.id);
         return `
         <div class="account-row${a.id === defaultId ? ' active' : ''}" data-id="${a.id}">
-          <button type="button" class="account-row-color${color ? '' : ' account-row-color--none'}"
-                  data-action="color" data-id="${a.id}" data-color="${color || ''}"
-                  ${color ? `style="background:${color}"` : ''}
-                  title="${escapeHtml(t('accounts.colorTitle') || 'Account colour')}"
-                  aria-label="${escapeHtml(t('accounts.colorTitle') || 'Account colour')}"></button>
-          <div class="account-row-main">
-            <div class="account-row-name">${escapeHtml(a.name)}</div>
-            <div class="account-row-meta">${escapeHtml((a.fingerprint || '').slice(0, 8))}${bound.length ? ` &middot; ${escapeHtml(t('accounts.boundProjects', { count: bound.length }))}` : ''}</div>
+          <div class="account-row-head">
+            <button type="button" class="account-row-color${color ? '' : ' account-row-color--none'}"
+                    data-action="color" data-id="${a.id}" data-color="${color || ''}"
+                    ${color ? `style="background:${color}"` : ''}
+                    title="${escapeHtml(t('accounts.colorTitle') || 'Account colour')}"
+                    aria-label="${escapeHtml(t('accounts.colorTitle') || 'Account colour')}"></button>
+            <div class="account-row-main">
+              <div class="account-row-name">${escapeHtml(a.name)}</div>
+              <div class="account-row-meta">${escapeHtml((a.fingerprint || '').slice(0, 8))}${bound.length ? ` &middot; ${escapeHtml(t('accounts.boundProjects', { count: bound.length }))}` : ''}</div>
+            </div>
+            <div class="account-row-buttons">
+              ${a.id === defaultId
+                ? `<span class="account-row-status">${escapeHtml(t('accounts.isDefault') || 'Default')}</span>`
+                : `<button class="btn btn-secondary btn-sm" data-action="set-default" data-id="${a.id}">${escapeHtml(t('accounts.makeDefault') || 'Make default')}</button>`}
+              <button class="btn btn-secondary btn-sm" data-action="rename" data-id="${a.id}">${escapeHtml(t('common.rename') || 'Rename')}</button>
+              <button class="btn btn-secondary btn-sm" data-action="remove" data-id="${a.id}">${escapeHtml(t('common.delete') || 'Delete')}</button>
+            </div>
           </div>
-          <div class="account-row-buttons">
-            ${a.id === defaultId
-              ? `<span class="account-row-status">${escapeHtml(t('accounts.isDefault') || 'Default')}</span>`
-              : `<button class="btn btn-secondary btn-sm" data-action="set-default" data-id="${a.id}">${escapeHtml(t('accounts.makeDefault') || 'Make default')}</button>`}
-            <button class="btn btn-secondary btn-sm" data-action="rename" data-id="${a.id}">${escapeHtml(t('common.rename') || 'Rename')}</button>
-            <button class="btn btn-secondary btn-sm" data-action="remove" data-id="${a.id}">${escapeHtml(t('common.delete') || 'Delete')}</button>
-          </div>
+          <div class="account-row-usage" data-usage-for="${a.id}"></div>
         </div>`;
       }).join('');
+      // Repaint from whatever was last fetched: a rename or a colour change
+      // rebuilds the list, and blanking the bars each time would make the
+      // section flicker between two states that are both current.
+      this._paintAccountsUsage(listEl);
+      this._loadAccountsUsage();
       if (captureBtn) captureBtn.disabled = !hasCredentials;
     };
+    this._renderAccountsList = renderList;
 
     listEl.onclick = async (e) => {
       const btn = e.target.closest('button[data-action]');
@@ -2308,11 +2397,66 @@ class SettingsPanel extends BasePanel {
       };
     }
 
+    const refreshBtn = container.querySelector('#btn-accounts-usage-refresh');
+    if (refreshBtn) {
+      refreshBtn.onclick = async () => {
+        refreshBtn.disabled = true;
+        try {
+          await this._loadAccountsUsage({ force: true });
+        } finally {
+          refreshBtn.disabled = false;
+        }
+      };
+    }
+
     // Live refresh when accounts change elsewhere (e.g. via switch modal)
     const unsub = this.api.accounts.onChanged(() => renderList());
     this._cleanups.push(unsub);
 
     await renderList();
+  }
+
+  /**
+   * Fetch the usage figures of every stored account.
+   *
+   * Reading an account's credential store costs a Keychain read on macOS, so
+   * the sweep is skipped while the Claude tab is off screen — the figures are
+   * fetched when the tab that shows them is opened, not when Settings is.
+   *
+   * @param {{force?: boolean}} [opts] - force also bypasses the main-process
+   *   cache, for the explicit refresh button
+   */
+  async _loadAccountsUsage({ force = false } = {}) {
+    const listEl = document.getElementById('claude-accounts-list');
+    if (!listEl?.isConnected) return;
+    if (!force && !listEl.closest('.settings-panel')?.classList.contains('active')) return;
+    if (this._accountsUsageInFlight) return;
+
+    this._accountsUsageInFlight = true;
+    try {
+      const res = await this.api.accounts.usage(force ? 0 : undefined);
+      if (res?.success) this._accountsUsage = res.data || {};
+    } catch (err) {
+      console.warn('[SettingsPanel] account usage failed:', err?.message);
+    } finally {
+      this._accountsUsageInFlight = false;
+    }
+    this._paintAccountsUsage();
+  }
+
+  /**
+   * Paint the cached figures into the account rows.
+   *
+   * Kept apart from the fetch so a list rebuild — a rename, a colour change —
+   * can repaint what is already known without waiting on the API.
+   *
+   * @param {Element} [listEl]
+   */
+  _paintAccountsUsage(listEl = document.getElementById('claude-accounts-list')) {
+    if (!listEl) return;
+    for (const slot of listEl.querySelectorAll('.account-row-usage[data-usage-for]')) {
+      slot.innerHTML = buildAccountUsageHtml(this._accountsUsage?.[slot.dataset.usageFor]);
+    }
   }
 
   // ── BasePanel lifecycle ──

--- a/styles/settings.css
+++ b/styles/settings.css
@@ -3056,3 +3056,59 @@
   letter-spacing: 0.5px;
   padding: 4px 8px;
 }
+
+/* ── Per-account usage ──
+   The settings card carries a second line, the usage strip, so it stacks —
+   scoped to the list because the same .account-row class is a single-row
+   button in the switch modal. */
+.accounts-list .account-row {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 10px;
+}
+
+.account-row-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+/* Indented to the account name rather than to the card, so the strip reads as
+   part of the row above it and not as a separate band. */
+.account-row-usage {
+  padding-left: 34px;
+}
+
+/* Same bars as the titlebar. Their colours, warning tints and reset countdown
+   all come from layout.css, so an account reads here exactly as the active one
+   does up there.
+
+   Capped rather than stretched: a bar spread over a third of a wide card puts
+   its label and its percentage at opposite ends of the row, and the two stop
+   looking like one reading. */
+.account-usage-bars {
+  display: flex;
+  align-items: stretch;
+}
+
+.account-usage-bars .usage-item {
+  flex: 1 1 0;
+  min-width: 0;
+  max-width: 200px;
+}
+
+.account-usage-bars .usage-item:first-child {
+  padding-left: 0;
+}
+
+/* Figures the API could not confirm: shown, but visibly not current. */
+.account-usage-bars.stale {
+  opacity: 0.5;
+}
+
+.account-usage-note {
+  font-size: var(--font-xs);
+  color: var(--text-muted);
+  padding: 2px 0;
+}

--- a/tests/ipc/accountsUsage.ipc.test.js
+++ b/tests/ipc/accountsUsage.ipc.test.js
@@ -1,0 +1,125 @@
+/**
+ * accounts-usage IPC handler.
+ *
+ * The settings list shows every account's remaining headroom, so the handler
+ * has to answer for all of them at once — without turning a rename into one
+ * credential-store probe per account, which prompts for the Keychain on macOS.
+ */
+
+const mockAccountManager = {
+  listAccounts: jest.fn(),
+  ensureAccountStore: jest.fn(),
+  switchTo: jest.fn(),
+  setDefault: jest.fn(),
+  captureCurrent: jest.fn(),
+  updateAccount: jest.fn(),
+  renameAccount: jest.fn(),
+  removeAccount: jest.fn(),
+  syncActiveFromDisk: jest.fn()
+};
+
+const mockUsageService = {
+  usageForAccount: jest.fn(),
+  invalidateCredentials: jest.fn(),
+  refreshUsage: jest.fn(() => Promise.resolve(null))
+};
+
+jest.mock('electron', () => ({
+  ipcMain: { handle: jest.fn() },
+  BrowserWindow: { getAllWindows: () => [] }
+}));
+
+jest.mock('../../src/main/services/AccountManager', () => mockAccountManager);
+jest.mock('../../src/main/services/UsageService', () => mockUsageService);
+
+const { ipcMain } = require('electron');
+
+/**
+ * Register the handlers against a freshly evaluated module.
+ *
+ * The handler remembers which credential stores it has bootstrapped, for the
+ * life of the process. Sharing one instance between tests would make each test
+ * inherit the previous one's bookkeeping.
+ */
+function loadHandlers() {
+  const handlers = {};
+  jest.isolateModules(() => {
+    ipcMain.handle.mockImplementation((channel, handler) => { handlers[channel] = handler; });
+    require('../../src/main/ipc/accounts.ipc').registerAccountsHandlers();
+  });
+  return handlers;
+}
+
+let handlers;
+
+beforeEach(() => {
+  handlers = loadHandlers();
+  mockAccountManager.listAccounts.mockReset();
+  mockAccountManager.ensureAccountStore.mockReset();
+  mockUsageService.usageForAccount.mockReset();
+
+  mockAccountManager.listAccounts.mockResolvedValue({
+    accounts: [{ id: 'acct-max', name: 'Max' }, { id: 'acct-team', name: 'Team' }],
+    defaultId: 'acct-max',
+    liveId: 'acct-max',
+    hasCredentials: true
+  });
+  mockAccountManager.ensureAccountStore.mockResolvedValue('/tmp/store');
+  mockUsageService.usageForAccount.mockImplementation(async (id) => ({
+    accountId: id,
+    data: { buckets: [{ id: 'session', utilization: 12 }] },
+    stale: false,
+    error: null
+  }));
+});
+
+describe('accounts-usage', () => {
+  test('answers with one entry per account, keyed by id', async () => {
+    const res = await handlers['accounts-usage']({}, {});
+
+    expect(res.success).toBe(true);
+    expect(Object.keys(res.data).sort()).toEqual(['acct-max', 'acct-team']);
+    expect(res.data['acct-team'].accountId).toBe('acct-team');
+  });
+
+  test('passes the requested max age through, so refresh can force a fetch', async () => {
+    await handlers['accounts-usage']({}, { maxAgeMs: 0 });
+
+    expect(mockUsageService.usageForAccount).toHaveBeenCalledWith('acct-max', 0);
+  });
+
+  test('bootstraps each credential store once, not on every call', async () => {
+    await handlers['accounts-usage']({}, {});
+    await handlers['accounts-usage']({}, {});
+
+    // Probing a store costs a Keychain read; the list asks again on every
+    // account change, so a second sweep must not re-probe what is already set.
+    expect(mockAccountManager.ensureAccountStore).toHaveBeenCalledTimes(2);
+  });
+
+  test('a store that cannot be seeded still reports that account', async () => {
+    mockAccountManager.ensureAccountStore.mockRejectedValue(new Error('keychain denied'));
+
+    const res = await handlers['accounts-usage']({}, {});
+
+    // Falling over here would blank every account's figures over one that has
+    // no store — the others are readable and must still come back.
+    expect(res.success).toBe(true);
+    expect(Object.keys(res.data)).toHaveLength(2);
+  });
+
+  test('an account whose figures are unreadable comes back unreadable, not missing', async () => {
+    mockUsageService.usageForAccount.mockImplementation(async (id) => (
+      id === 'acct-team'
+        ? { accountId: id, data: null, stale: true, error: 'No valid Claude OAuth token' }
+        : { accountId: id, data: { buckets: [] }, stale: false, error: null }
+    ));
+
+    const res = await handlers['accounts-usage']({}, {});
+
+    // The renderer needs the entry to say "sign in again" — an absent key is
+    // indistinguishable from figures that have not arrived yet.
+    expect(res.data['acct-team'].error).toBeTruthy();
+    expect(res.data['acct-team'].data).toBeNull();
+  });
+});

--- a/tests/services/UsageServicePerAccount.test.js
+++ b/tests/services/UsageServicePerAccount.test.js
@@ -170,6 +170,51 @@ describe('invalidation', () => {
   });
 });
 
+describe('usageForAccount', () => {
+  test('fetches an account it has never seen', async () => {
+    mockBodyByToken.set('tok-acct-max', usageBody(0.25));
+
+    const usage = await UsageService.usageForAccount('acct-max');
+
+    expect(usage.data.buckets[0].utilization).toBe(0.25);
+    expect(mockRequestedTokens).toEqual(['tok-acct-max']);
+  });
+
+  test('serves recent figures from the cache', async () => {
+    mockBodyByToken.set('tok-acct-max', usageBody(0.25));
+    await UsageService.usageForAccount('acct-max');
+
+    await UsageService.usageForAccount('acct-max');
+
+    // The settings list asks about every account and re-renders on any account
+    // change, so asking again a moment later must not cost a second API call.
+    expect(mockRequestedTokens).toHaveLength(1);
+  });
+
+  test('refetches figures older than the age asked for', async () => {
+    mockBodyByToken.set('tok-acct-max', usageBody(0.25));
+    await UsageService.usageForAccount('acct-max');
+
+    mockBodyByToken.set('tok-acct-max', usageBody(0.60));
+    const usage = await UsageService.usageForAccount('acct-max', 0);
+
+    // A maxAge of 0 is what the explicit refresh button sends: it has to reach
+    // the API even when the cached figures are milliseconds old.
+    expect(mockRequestedTokens).toHaveLength(2);
+    expect(usage.data.buckets[0].utilization).toBe(0.60);
+  });
+
+  test('reports an account it cannot read rather than borrowing figures', async () => {
+    mockBodyByToken.set('tok-acct-max', usageBody(0.25));
+    await UsageService.usageForAccount('acct-max');
+
+    const usage = await UsageService.usageForAccount('acct-team'); // 401
+
+    expect(usage.data).toBeNull();
+    expect(usage.stale).toBe(true);
+  });
+});
+
 describe('focus', () => {
   test('the focused account is what the poller refreshes', async () => {
     mockBodyByToken.set('tok-acct-team', usageBody(0.44));


### PR DESCRIPTION
## Why

Accounts are picked per project, so the titlebar only ever shows the figures of the account the current tab runs as. Deciding which account to move a project onto — the whole point of keeping several — meant switching to one to find out whether it had any headroom left.

## What

The Claude settings tab now carries the same usage bars under every saved account: the session window, the weekly one, and whichever scoped model limit the API reports, each with its reset countdown. The markup and colours are the titlebar's, so an account reads here exactly as the active one does up there.

An account whose own credential store holds no usable token says so, and what to do about it, rather than showing bars stuck at zero — which would read as "plenty left" on precisely the account you should not move work onto.

A **Refresh usage** button next to *Save current account* forces a fetch.

## How

`UsageService` already fetches per account, so the figures come from there. What is new is `usageForAccount(id, maxAge)` and an `accounts-usage` IPC handler that answers for every account at once.

The sweep is bounded, because the list re-renders on every account change — a rename, a colour, a capture — and each account read costs a Keychain prompt on macOS:

- figures under five minutes old are served from the cache;
- the fetch only runs while the Claude tab is actually on screen;
- a credential store is bootstrapped at most once per run (which is also what lets an account captured before per-account stores existed report anything at all).

## Tests

`tests/ipc/accountsUsage.ipc.test.js` (new) and four cases added to `tests/services/UsageServicePerAccount.test.js`. Full suite green: 102 suites, 2555 tests.

## Verified in the app

Two saved accounts: one showed `Session 45% · 8min`, `Weekly 19% · 2d 2h`, `Fable 3% · 2d 2h`; the other, whose token had expired, showed the sign-in-again note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)