### PR TITLE
feat(tabs): confirm before a tab's × closes a session or project

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -2860,31 +2860,59 @@ function selectProjectFromBar(projectIndex) {
   applyProjectContext(projectIndex);
 }
 
+// A project close-confirmation dialog is up; further × clicks are ignored.
+let _closeProjectConfirmOpen = false;
+
 /**
- * Close a project tab. Sessions belong to the project, so a tab with live
- * terminals asks first rather than silently killing running Claude sessions.
+ * Terminals belonging to a project, worktree tabs included.
  * @param {Object} project
+ * @returns {string[]} Terminal ids
  */
-async function closeProjectFromBar(project) {
-  const projectIndex = getProjectIndex(project.id);
-  const openTerminalIds = [];
+function openTerminalIdsForProject(project) {
+  const ids = [];
   terminalsState.get().terminals.forEach((termData, id) => {
     if (termData.project && (termData.project.path === project.path ||
       (termData.parentProjectId && termData.parentProjectId === project.id))) {
-      openTerminalIds.push(id);
+      ids.push(id);
     }
   });
+  return ids;
+}
 
-  if (openTerminalIds.length > 0) {
-    const confirmed = await ModalComponent.showConfirm({
-      title: t('projects.closeProjectTitle', { name: project.name }),
-      message: t('projects.closeProjectMessage', { count: openTerminalIds.length }),
-      confirmLabel: t('projects.closeProjectConfirm'),
-      danger: true,
-    });
+/**
+ * Close a project tab. Closing is never silent: sessions belong to the
+ * project, so the tab always asks first rather than dropping live Claude
+ * sessions on a stray click.
+ * @param {Object} project
+ * @param {Object} [options]
+ * @param {boolean} [options.skipConfirm] - Caller already asked (bulk close)
+ */
+async function closeProjectFromBar(project, { skipConfirm = false } = {}) {
+  const openTerminalIds = openTerminalIdsForProject(project);
+
+  if (!skipConfirm) {
+    // The dialog is modal: a × click on another project tab while it is up
+    // would stack a second overlay that Escape/Enter answers at the same time.
+    if (_closeProjectConfirmOpen) return;
+    const hasSessions = openTerminalIds.length > 0;
+    _closeProjectConfirmOpen = true;
+    let confirmed = false;
+    try {
+      confirmed = await ModalComponent.showConfirm({
+        title: t('projects.closeProjectTitle', { name: project.name }),
+        message: hasSessions
+          ? t('projects.closeProjectMessage', { count: openTerminalIds.length })
+          : t('projects.closeProjectMessageEmpty'),
+        confirmLabel: hasSessions ? t('projects.closeProjectConfirm') : t('projects.closeProject'),
+        danger: true,
+      });
+    } finally {
+      _closeProjectConfirmOpen = false;
+    }
     if (!confirmed) return;
-    openTerminalIds.forEach(id => TerminalManager.closeTerminal(id));
   }
+
+  openTerminalIds.forEach(id => TerminalManager.closeTerminal(id));
 
   const nextIndex = closeProjectTab(project.id);
   TerminalManager.filterByProject(nextIndex);
@@ -3129,8 +3157,22 @@ function showProjectTabContextMenu(project, x, y) {
       if (action === "close") {
         await closeProjectFromBar(project);
       } else if (action === "close-others") {
-        for (const other of getOpenProjects()) {
-          if (other.id !== project.id) await closeProjectFromBar(other);
+        // One prompt for the batch: asking per project would put N dialogs in
+        // front of a single decision.
+        const others = getOpenProjects().filter(other => other.id !== project.id);
+        if (others.length === 0) return;
+        const sessionCount = others.reduce((n, other) => n + openTerminalIdsForProject(other).length, 0);
+        const confirmed = await ModalComponent.showConfirm({
+          title: t("projects.closeOthersTitle", { count: others.length }),
+          message: sessionCount > 0
+            ? t("projects.closeOthersMessage", { count: sessionCount })
+            : t("projects.closeOthersMessageEmpty"),
+          confirmLabel: t("projects.closeOtherProjects"),
+          danger: true,
+        });
+        if (!confirmed) return;
+        for (const other of others) {
+          await closeProjectFromBar(other, { skipConfirm: true });
         }
       }
     },

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -109,6 +109,10 @@
     "closeProjectTitle": "Close {name}?",
     "closeProjectMessage": "This project has {count} open session(s). Closing its tab ends them.",
     "closeProjectConfirm": "Close and end sessions",
+    "closeProjectMessageEmpty": "Its tab will be closed. The project itself is not deleted.",
+    "closeOthersTitle": "Close {count} other project(s)?",
+    "closeOthersMessage": "Their tabs will be closed and {count} running session(s) ended.",
+    "closeOthersMessageEmpty": "Their tabs will be closed. The projects themselves are not deleted.",
     "moreActions": "More actions"
   },
   "terminals": {
@@ -2447,6 +2451,8 @@
     "closeOthers": "Close Others",
     "closeToLeft": "Close Tabs to Left",
     "closeToRight": "Close Tabs to Right",
+    "closeTabTitle": "Close {name}?",
+    "closeTabMessage": "This tab will be closed. Any session running in it ends.",
     "closeAll": "Close All"
   },
   "telemetry": {

--- a/src/renderer/i18n/locales/es.json
+++ b/src/renderer/i18n/locales/es.json
@@ -109,6 +109,10 @@
     "closeProjectTitle": "¿Cerrar {name}?",
     "closeProjectMessage": "Este proyecto tiene {count} sesión(es) abierta(s). Cerrar su pestaña las finaliza.",
     "closeProjectConfirm": "Cerrar y finalizar sesiones",
+    "closeProjectMessageEmpty": "Se cerrará su pestaña. El proyecto en sí no se elimina.",
+    "closeOthersTitle": "¿Cerrar {count} proyecto(s) más?",
+    "closeOthersMessage": "Se cerrarán sus pestañas y finalizarán {count} sesión(es) en curso.",
+    "closeOthersMessageEmpty": "Se cerrarán sus pestañas. Los proyectos en sí no se eliminan.",
     "moreActions": "Más acciones"
   },
   "terminals": {
@@ -2444,6 +2448,8 @@
     "closeOthers": "Cerrar las demás",
     "closeToLeft": "Cerrar pestañas a la izquierda",
     "closeToRight": "Cerrar pestañas a la derecha",
+    "closeTabTitle": "¿Cerrar {name}?",
+    "closeTabMessage": "Se cerrará esta pestaña. Cualquier sesión en curso finalizará.",
     "closeAll": "Cerrar todo"
   },
   "telemetry": {

--- a/src/renderer/i18n/locales/fr.json
+++ b/src/renderer/i18n/locales/fr.json
@@ -109,6 +109,10 @@
     "closeProjectTitle": "Fermer {name} ?",
     "closeProjectMessage": "Ce projet a {count} session(s) ouverte(s). Fermer son onglet y met fin.",
     "closeProjectConfirm": "Fermer et terminer les sessions",
+    "closeProjectMessageEmpty": "Son onglet va être fermé. Le projet lui-même n'est pas supprimé.",
+    "closeOthersTitle": "Fermer {count} autre(s) projet(s) ?",
+    "closeOthersMessage": "Leurs onglets vont être fermés et {count} session(s) en cours terminée(s).",
+    "closeOthersMessageEmpty": "Leurs onglets vont être fermés. Les projets eux-mêmes ne sont pas supprimés.",
     "moreActions": "Plus d'actions"
   },
   "terminals": {
@@ -2447,6 +2451,8 @@
     "closeOthers": "Fermer les autres",
     "closeToLeft": "Fermer les onglets à gauche",
     "closeToRight": "Fermer les onglets à droite",
+    "closeTabTitle": "Fermer {name} ?",
+    "closeTabMessage": "Cet onglet va être fermé. Toute session en cours y sera terminée.",
     "closeAll": "Tout fermer"
   },
   "telemetry": {

--- a/src/renderer/i18n/locales/id.json
+++ b/src/renderer/i18n/locales/id.json
@@ -109,6 +109,10 @@
     "closeProjectTitle": "Tutup {name}?",
     "closeProjectMessage": "Proyek ini memiliki {count} sesi terbuka. Menutup tabnya akan mengakhirinya.",
     "closeProjectConfirm": "Tutup dan akhiri sesi",
+    "closeProjectMessageEmpty": "Tabnya akan ditutup. Proyeknya sendiri tidak dihapus.",
+    "closeOthersTitle": "Tutup {count} proyek lainnya?",
+    "closeOthersMessage": "Tab mereka akan ditutup dan {count} sesi yang berjalan akan diakhiri.",
+    "closeOthersMessageEmpty": "Tab mereka akan ditutup. Proyeknya sendiri tidak dihapus.",
     "moreActions": "Aksi lainnya"
   },
   "terminals": {
@@ -2447,6 +2451,8 @@
     "closeOthers": "Tutup Tab Lain",
     "closeToLeft": "Tutup Tab di Sebelah Kiri",
     "closeToRight": "Tutup Tab di Sebelah Kanan",
+    "closeTabTitle": "Tutup {name}?",
+    "closeTabMessage": "Tab ini akan ditutup. Sesi apa pun yang berjalan di dalamnya akan berakhir.",
     "closeAll": "Tutup Semua"
   },
   "telemetry": {

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -109,6 +109,10 @@
     "closeProjectTitle": "关闭 {name}？",
     "closeProjectMessage": "该项目有 {count} 个打开的会话。关闭其标签页将结束这些会话。",
     "closeProjectConfirm": "关闭并结束会话",
+    "closeProjectMessageEmpty": "其标签页将被关闭。项目本身不会被删除。",
+    "closeOthersTitle": "关闭其他 {count} 个项目？",
+    "closeOthersMessage": "它们的标签页将被关闭，并结束 {count} 个正在运行的会话。",
+    "closeOthersMessageEmpty": "它们的标签页将被关闭。项目本身不会被删除。",
     "moreActions": "更多操作"
   },
   "terminals": {
@@ -2447,6 +2451,8 @@
     "closeOthers": "关闭其他",
     "closeToLeft": "关闭左侧选项卡",
     "closeToRight": "关闭右侧选项卡",
+    "closeTabTitle": "关闭 {name}？",
+    "closeTabMessage": "此标签页将被关闭，其中正在运行的会话也会结束。",
     "closeAll": "关闭全部"
   },
   "telemetry": {

--- a/src/renderer/ui/components/TerminalManager.js
+++ b/src/renderer/ui/components/TerminalManager.js
@@ -52,6 +52,7 @@ const {
 const registry = require('../../../project-types/registry');
 const { createChatView } = require('./ChatView');
 const { showContextMenu } = require('./ContextMenu');
+const { showConfirm } = require('./Modal');
 const ContextPromptService = require('../../services/ContextPromptService');
 const { getBuiltinSystemPrompt } = require('../../services/BuiltinSystemPrompts');
 
@@ -528,6 +529,8 @@ class TerminalManager extends BaseComponent {
     this._loadingTimeouts = new Map();
     // Tabs mid mode-switch — the chat->terminal leg awaits a PTY spawn.
     this._modeSwitching = new Set();
+    // A close-confirmation dialog is up; further × clicks are ignored.
+    this._closeConfirmOpen = false;
     this._callbacks = {
       onNotification: null,
       onRenderProjects: null,
@@ -1632,6 +1635,48 @@ class TerminalManager extends BaseComponent {
 
   // ── Close terminal ──
 
+  /**
+   * Ask before a tab's × throws away a running session.
+   *
+   * Only the per-tab close button routes through here. Tabs are also closed by
+   * a PTY exiting, by closing their project, and by the bulk context-menu
+   * actions — those either are not a user gesture at all or have already asked
+   * once for the whole batch, so putting the prompt in closeTerminal() would
+   * fire it twice (or N times) for a single decision.
+   *
+   * @param {string} id - Terminal id
+   * @param {Function} close - Performs the real close once confirmed
+   */
+  async _confirmCloseTab(id, close) {
+    // The dialog is modal, so a × click on another tab while it is up would
+    // stack a second overlay that Escape/Enter then answers at the same time.
+    if (this._closeConfirmOpen) return;
+
+    // Read the label off the tab rather than termData.name: a renamed tab (or
+    // one titled from Claude's output) only has its current name in the DOM.
+    const tabName = document.querySelector(`.terminal-tab[data-id="${id}"] .tab-name`)?.textContent?.trim()
+      || getTerminal(id)?.name
+      || '';
+
+    this._closeConfirmOpen = true;
+    let confirmed = false;
+    try {
+      confirmed = await showConfirm({
+        title: t('tabs.closeTabTitle', { name: tabName }),
+        message: t('tabs.closeTabMessage'),
+        confirmLabel: t('tabs.close'),
+        danger: true
+      });
+    } finally {
+      this._closeConfirmOpen = false;
+    }
+
+    if (!confirmed) return;
+    // The tab can be gone by the time the user answers (PTY exit, project close).
+    if (!getTerminal(id)) return;
+    close();
+  }
+
   closeTerminal(id) {
     const termData = getTerminal(id);
     const closedProjectIndex = termData?.projectIndex;
@@ -1989,7 +2034,7 @@ class TerminalManager extends BaseComponent {
 
     tab.onclick = (e) => { if (!e.target.closest('.tab-close') && !e.target.closest('.tab-name-input') && !e.target.closest('.tab-mode-toggle')) self.setActiveTerminal(id); };
     tab.querySelector('.tab-name').ondblclick = (e) => { e.stopPropagation(); self._startRenameTab(id); };
-    tab.querySelector('.tab-close').onclick = (e) => { e.stopPropagation(); self.closeTerminal(id); };
+    tab.querySelector('.tab-close').onclick = (e) => { e.stopPropagation(); self._confirmCloseTab(id, () => self.closeTerminal(id)); };
     tab.oncontextmenu = (e) => self._showTabContextMenu(e, id);
 
     const modeToggleBtn = tab.querySelector('.tab-mode-toggle');
@@ -2220,7 +2265,7 @@ class TerminalManager extends BaseComponent {
 
     tab.onclick = (e) => { if (!e.target.closest('.tab-close') && !e.target.closest('.tab-name-input')) self.setActiveTerminal(id); };
     tab.querySelector('.tab-name').ondblclick = (e) => { e.stopPropagation(); self._startRenameTab(id); };
-    tab.querySelector('.tab-close').onclick = (e) => { e.stopPropagation(); self._closeTypeConsole(id, projectIndex, typeId); };
+    tab.querySelector('.tab-close').onclick = (e) => { e.stopPropagation(); self._confirmCloseTab(id, () => self._closeTypeConsole(id, projectIndex, typeId)); };
     tab.oncontextmenu = (e) => self._showTabContextMenu(e, id);
 
     this._setupTabDragDrop(tab);
@@ -3227,7 +3272,7 @@ class TerminalManager extends BaseComponent {
 
     tab.onclick = (e) => { if (!e.target.closest('.tab-close') && !e.target.closest('.tab-name-input')) self.setActiveTerminal(id); };
     tab.querySelector('.tab-name').ondblclick = (e) => { e.stopPropagation(); self._startRenameTab(id); };
-    tab.querySelector('.tab-close').onclick = (e) => { e.stopPropagation(); self.closeTerminal(id); };
+    tab.querySelector('.tab-close').onclick = (e) => { e.stopPropagation(); self._confirmCloseTab(id, () => self.closeTerminal(id)); };
     tab.oncontextmenu = (e) => self._showTabContextMenu(e, id);
 
     this._setupTabDragDrop(tab);
@@ -3396,7 +3441,7 @@ class TerminalManager extends BaseComponent {
 
     tab.onclick = (e) => { if (!e.target.closest('.tab-close') && !e.target.closest('.tab-name-input')) self.setActiveTerminal(id); };
     tab.querySelector('.tab-name').ondblclick = (e) => { e.stopPropagation(); self._startRenameTab(id); };
-    tab.querySelector('.tab-close').onclick = (e) => { e.stopPropagation(); self.closeTerminal(id); };
+    tab.querySelector('.tab-close').onclick = (e) => { e.stopPropagation(); self._confirmCloseTab(id, () => self.closeTerminal(id)); };
     tab.oncontextmenu = (e) => self._showTabContextMenu(e, id);
 
     this._setupTabDragDrop(tab);
@@ -3835,7 +3880,7 @@ class TerminalManager extends BaseComponent {
     const self = this;
     tab.onclick = (e) => { if (!e.target.closest('.tab-close') && !e.target.closest('.tab-name-input')) self.setActiveTerminal(id); };
     tab.querySelector('.tab-name').ondblclick = (e) => { e.stopPropagation(); self._startRenameTab(id); };
-    tab.querySelector('.tab-close').onclick = (e) => { e.stopPropagation(); self.closeTerminal(id); };
+    tab.querySelector('.tab-close').onclick = (e) => { e.stopPropagation(); self._confirmCloseTab(id, () => self.closeTerminal(id)); };
     tab.oncontextmenu = (e) => self._showTabContextMenu(e, id);
 
     this._setupTabDragDrop(tab);
@@ -4036,7 +4081,7 @@ class TerminalManager extends BaseComponent {
 
     tab.onclick = (e) => { if (!e.target.closest('.tab-close') && !e.target.closest('.tab-name-input') && !e.target.closest('.tab-mode-toggle')) self.setActiveTerminal(id); };
     tab.querySelector('.tab-name').ondblclick = (e) => { e.stopPropagation(); self._startRenameTab(id); };
-    tab.querySelector('.tab-close').onclick = (e) => { e.stopPropagation(); self.closeTerminal(id); };
+    tab.querySelector('.tab-close').onclick = (e) => { e.stopPropagation(); self._confirmCloseTab(id, () => self.closeTerminal(id)); };
     tab.oncontextmenu = (e) => self._showTabContextMenu(e, id);
     const modeToggleBtn = tab.querySelector('.tab-mode-toggle');
     if (modeToggleBtn) {


### PR DESCRIPTION
## Problem

Clicking the × on a session tab ended a running Claude session immediately, with no undo. A project tab only asked for confirmation when it still had terminals attached — closing an idle project was silent too.

## Change

Both close buttons now open the app's existing `showConfirm` dialog before anything is closed.

- **Session tabs** — every kind (terminal, chat, resumed session, file viewer, type console) routes its × through a new `TerminalManager._confirmCloseTab(id, close)`. The dialog title uses the tab's current label, read from the DOM so a renamed or Claude-titled tab shows the name the user actually sees.
- **Project tabs** — `closeProjectFromBar()` always asks, with the existing "N open session(s)" wording when sessions are attached and a new message when there are none.

## Where the prompt is *not*

The confirmation deliberately lives on the close button, not inside `closeTerminal()` / `closeProjectFromBar()`. Tabs are also closed by a PTY exiting, by remote control / MCP `tab_close`, and by the bulk context-menu actions — those either aren't a user gesture at all, or have already asked once for the whole batch. Putting the prompt deeper would have fired it twice (project close → its terminals) or N times (close-others).

For that reason **"Close other projects"** now shows one aggregate prompt (project count + total sessions) and then closes each with `skipConfirm: true`, instead of N stacked dialogs.

A small `_closeConfirmOpen` guard stops a second × click from stacking a second modal overlay while one is up — `showConfirm` binds Escape/Enter on `document`, so two overlays would answer the same keypress.

## i18n

New keys in all five locales (`en`, `fr`, `es`, `id`, `zh-CN`): `tabs.closeTabTitle`, `tabs.closeTabMessage`, `projects.closeProjectMessageEmpty`, `projects.closeOthersTitle`, `projects.closeOthersMessage`, `projects.closeOthersMessageEmpty`.

## Testing

`npm run build:renderer` + `npm test` — 100 suites / 2541 tests pass, i18n coherence included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)