### PR TITLE
fix(chat): resume with the CLI session id when switching account

### DIFF
--- a/src/main/ipc/claude.ipc.js
+++ b/src/main/ipc/claude.ipc.js
@@ -924,15 +924,24 @@ async function resolveSessionFile(sessionsDir, sessionId) {
     return direct;
   } catch { /* not found by name */ }
 
+  // The index spans every directory scanned so far, so a hit has to be checked
+  // against the one being asked about. Returning another project's transcript
+  // would put its history on screen while the CLI — which only ever looks under
+  // the cwd it is launched with — resumes nothing at all.
+  const inThisDir = () => {
+    const cached = _sessionIndex.get(sessionId);
+    return cached && path.dirname(cached) === sessionsDir ? cached : null;
+  };
+
   // Try index
   await buildSessionIndex(sessionsDir);
-  const cached = _sessionIndex.get(sessionId);
+  const cached = inThisDir();
   if (cached) return cached;
 
   // Not found — invalidate and rebuild once (session may be new)
   _indexedDirs.delete(sessionsDir);
   await buildSessionIndex(sessionsDir);
-  return _sessionIndex.get(sessionId) || null;
+  return inThisDir();
 }
 
 /**

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -3778,6 +3778,7 @@
     "emptyHint": "No saved accounts yet. Open a terminal, run \"claude /login\", then click \"Save current account\".",
     "limitReached": "Usage limit reached on the active account.",
     "switched": "Account switched. Resuming…",
+    "switchedNoResume": "Account switched. The previous conversation could not be resumed — continuing without its context.",
     "removeConfirm": "Remove this saved account? The credentials will be deleted from local storage.",
     "switchError": "Failed to switch account",
     "renameError": "Failed to rename account",

--- a/src/renderer/i18n/locales/es.json
+++ b/src/renderer/i18n/locales/es.json
@@ -3778,6 +3778,7 @@
     "emptyHint": "Aún no hay cuentas guardadas. Abre un terminal, ejecuta \"claude /login\", luego haz clic en \"Guardar la cuenta actual\".",
     "limitReached": "Límite de uso alcanzado en la cuenta activa.",
     "switched": "Cuenta cambiada. Reanudando…",
+    "switchedNoResume": "Cuenta cambiada. No se pudo reanudar la conversación anterior — se continúa sin su contexto.",
     "removeConfirm": "¿Eliminar esta cuenta guardada? Las credenciales se borrarán del almacenamiento local.",
     "switchError": "No se pudo cambiar de cuenta",
     "renameError": "No se pudo renombrar la cuenta",

--- a/src/renderer/i18n/locales/fr.json
+++ b/src/renderer/i18n/locales/fr.json
@@ -3778,6 +3778,7 @@
     "emptyHint": "Aucun compte enregistré. Ouvrez un terminal, lancez \"claude /login\", puis cliquez sur \"Sauvegarder le compte actuel\".",
     "limitReached": "Limite d'usage atteinte sur le compte actif.",
     "switched": "Compte changé. Reprise…",
+    "switchedNoResume": "Compte changé. La conversation précédente n'a pas pu être reprise — la suite se fera sans son contexte.",
     "removeConfirm": "Supprimer ce compte enregistré ? Les identifiants seront effacés du stockage local.",
     "switchError": "Impossible de changer de compte",
     "renameError": "Impossible de renommer le compte",

--- a/src/renderer/i18n/locales/id.json
+++ b/src/renderer/i18n/locales/id.json
@@ -3778,6 +3778,7 @@
     "emptyHint": "Belum ada akun tersimpan. Buka terminal, jalankan \"claude /login\", lalu klik \"Simpan akun saat ini\".",
     "limitReached": "Batas penggunaan tercapai pada akun yang aktif.",
     "switched": "Akun diganti. Melanjutkan…",
+    "switchedNoResume": "Akun diganti. Percakapan sebelumnya tidak bisa dilanjutkan — dilanjutkan tanpa konteksnya.",
     "removeConfirm": "Hapus akun tersimpan ini? Kredensialnya akan dihapus dari penyimpanan lokal.",
     "switchError": "Gagal mengganti akun",
     "renameError": "Gagal mengganti nama akun",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -3778,6 +3778,7 @@
     "emptyHint": "尚未保存账户。打开终端，运行“claude /login”，然后单击“保存当前账户”。",
     "limitReached": "活动账户已达到使用限制。",
     "switched": "账号已切换。正在恢复…",
+    "switchedNoResume": "账号已切换。无法恢复之前的对话 — 将在缺少其上下文的情况下继续。",
     "removeConfirm": "删除这个已保存的账户吗？凭据将从本地存储中删除。",
     "switchError": "切换账号失败",
     "renameError": "账户重命名失败",

--- a/src/renderer/ui/components/ChatView.js
+++ b/src/renderer/ui/components/ChatView.js
@@ -7119,10 +7119,35 @@ class ChatView extends BaseComponent {
         sessionId = null;
         return;
       }
+      // `resume` only accepts the CLI's own session UUID. Our `sessionId` is an
+      // app-local `chat-…` handle the CLI has never heard of: handing it over
+      // makes the CLI refuse the resume outright, and the tab carries on with an
+      // empty context while the whole transcript is still on screen.
+      // Before the SDK's init message there is nothing to resume but the id this
+      // tab was opened on.
+      const realSid = sdkSessionId || resumeSessionId;
       // The binding is read at spawn time, so the restart has to carry the new
       // account explicitly — lastStartOpts still holds the one that ran out.
-      const restartOpts = { ...lastStartOpts, accountId: newId, prompt: '', resumeSessionId: sessionId };
-      appendSystemNotice(t('accounts.switched') || 'Account switched. Resuming…', 'info');
+      // Everything that belonged to the turn that opened the tab is dropped: the
+      // restart sends no prompt, so replaying its images, mentions or message
+      // uuid would post the opening message a second time. A fork's truncation
+      // point goes too — it names a message of the session being resumed, not of
+      // the fork that came out of it.
+      const restartOpts = {
+        ...lastStartOpts,
+        accountId: newId,
+        prompt: '',
+        images: [],
+        mentions: [],
+        userMessageUuid: null,
+        forkSession: false,
+        resumeSessionAt: null,
+        resumeDropsTurn: null,
+        resumeSessionId: realSid || null,
+      };
+      appendSystemNotice(realSid
+        ? (t('accounts.switched') || 'Account switched. Resuming…')
+        : (t('accounts.switchedNoResume') || 'Account switched. The previous conversation could not be resumed — continuing without its context.'), 'info');
       setStreaming(true);
       appendThinkingIndicator();
       const res = await api.chat.start(restartOpts);

--- a/tests/ipc/claudeMoveSession.test.js
+++ b/tests/ipc/claudeMoveSession.test.js
@@ -21,7 +21,7 @@ jest.mock('os', () => ({
 
 global.__CT_TMP_HOME__ = TMP_HOME;
 
-const { moveSession, findStraySidecars, getClaudeSessions } = require('../../src/main/ipc/claude.ipc');
+const { moveSession, findStraySidecars, getClaudeSessions, loadSessionHistory } = require('../../src/main/ipc/claude.ipc');
 
 const ALPHA = '/tmp/proj-alpha';
 const BETA = '/tmp/proj-beta';
@@ -228,5 +228,39 @@ describe('findStraySidecars', () => {
 
     expect(await findStraySidecars(SID, [dirFor(ALPHA)])).toEqual([sidecar(GAMMA)]);
     expect(await findStraySidecars(SID, [dirFor(ALPHA), dirFor(GAMMA)])).toEqual([]);
+  });
+});
+
+// Sessions are looked up through an index that spans every directory scanned so
+// far. A transcript whose file name is not its session id can only be found
+// through it — and it must never answer for a project that does not hold it,
+// or the chat replays another project's conversation while the CLI, which only
+// looks under the cwd it is launched with, resumes nothing.
+describe('session lookup is scoped to the project asked about', () => {
+  const ODD = 'bbbbbbbb-1111-2222-3333-444444444444';
+
+  /** A transcript filed under a name that is not its session id. */
+  function writeRenamedSession(projectPath, sid, fileName) {
+    writeSession(projectPath, sid);
+    fs.renameSync(transcript(projectPath, sid), path.join(dirFor(projectPath), fileName));
+  }
+
+  test('a transcript found by index in one project is not served for another', async () => {
+    writeRenamedSession(ALPHA, ODD, 'renamed.jsonl');
+    fs.mkdirSync(dirFor(BETA), { recursive: true });
+
+    // Indexes ALPHA, which is what puts ODD in the shared index
+    expect((await loadSessionHistory(ALPHA, ODD)).messages.length).toBeGreaterThan(0);
+
+    expect(await loadSessionHistory(BETA, ODD)).toMatchObject({ messages: [], total: 0 });
+  });
+
+  test('the project that holds it still finds it after another was indexed', async () => {
+    writeRenamedSession(ALPHA, ODD, 'renamed.jsonl');
+    writeRenamedSession(BETA, ODD, 'renamed-too.jsonl');
+
+    expect((await loadSessionHistory(ALPHA, ODD)).messages.length).toBeGreaterThan(0);
+    expect((await loadSessionHistory(BETA, ODD)).messages.length).toBeGreaterThan(0);
+    expect((await loadSessionHistory(ALPHA, ODD)).messages.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
Fixes #141

## The defect

Taking the account switch offered on a usage limit relaunched the tab with `resumeSessionId: sessionId` — the renderer's own `chat-<timestamp>-<rand>` handle, not the CLI's session UUID. The CLI refuses it (*"is not a UUID and does not match any session title"*), so the tab carried on with an empty context while the full transcript stayed on screen. The refusal arrives as `error_during_execution`, and its banner is suppressed while `switchingAccount` is set, so the user often sees nothing at all — just a model that has forgotten the conversation it is still displaying.

`forkFromMessage()` a few hundred lines above already draws this distinction (`sdkSessionId || pendingResumeId`, with a comment saying to use the real UUID). This was the one call site that missed it.

## The fix

```diff
-const restartOpts = { ...lastStartOpts, accountId: newId, prompt: '', resumeSessionId: sessionId };
+const realSid = sdkSessionId || resumeSessionId;
+const restartOpts = { ...lastStartOpts, accountId: newId, prompt: '', resumeSessionId: realSid || null, … };
```

Before the SDK's init message there is no CLI id yet, so the id the tab was opened on stands in. When there is neither, the restart no longer sends a bogus `resume` — it starts clean and says so (`accounts.switchedNoResume`, added to the five locales), rather than letting the user believe the thread survived.

Two smaller problems on the same path, both fixed here:

- `lastStartOpts` still held the images, mentions and `userMessageUuid` of the turn that opened the tab, so the restart posted that first message a second time under the new account.
- A tab that was itself a fork replayed `forkSession` / `resumeSessionAt` / `resumeDropsTurn`, which name a message of the session that was resumed, not of the fork that came out of it.

## Also: `resolveSessionFile()`

Its `sessionId -> path` index spans every directory scanned so far, and a hit was returned without checking it belonged to the directory being asked about — so one project could be served another's transcript, producing the same "history on screen, CLI resumes nothing" shape. The lookup is now scoped to the directory asked about.

## Verification

The move-between-projects path was checked end to end while tracking this down and is **not** affected: a transcript re-filed under the target project's directory encoding resumes with its full context (a codeword planted in project A came back verbatim after the move and a resume from project B). What is left there — historical messages naming project A's paths, and Claude Code's per-project `memory/` directory staying behind — is inherent to moving a conversation, not a bug in `moveSession`.

Two regression tests cover the index scoping; both fail on `main` (project B is served project A's six messages) and pass here.

`npx jest --testPathIgnorePatterns "/node_modules/" "/.claude/worktrees/"` — 100 suites, 2543 tests, green. `node scripts/build-renderer.js` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)