### PR TITLE
fix(chat): stop the model label reading Default while a turn starts

### DIFF
--- a/src/shared/model-options.js
+++ b/src/shared/model-options.js
@@ -201,8 +201,21 @@ function baseModelId(id) {
  *
  * A persisted setting can hold any of three things: the exact `value` the CLI
  * advertises ('opus[1m]'), a canonical wire id the alias resolves to
- * ('claude-opus-5'), or a legacy id chosen from the More models submenu. Match
- * in that order of specificity so an exact hit always wins over a base-id one.
+ * ('claude-opus-5'), or a legacy id chosen from the More models submenu. The
+ * stream adds a fourth spelling: the CLI's init message names the model it is
+ * running the way `resolvedModel` spells it ('claude-opus-5[1m]'), while the
+ * API answers with the bare wire id ('claude-opus-5'). Match in that order of
+ * specificity so an exact hit always wins over a base-id one.
+ *
+ * Past the first tier, prefer a concrete row over the `default` alias.
+ * `default` points at whatever the CLI currently recommends, so resolving an
+ * id onto it would let a later CLI release silently move a deliberate choice —
+ * while the concrete row ('opus[1m]') is the same model the user actually
+ * picked. The alias also shares its `resolvedModel` with that row and leads
+ * the menu, so an exact pass without the preference handed it every id the
+ * init message reported: the footer read "Default (recommended)" from session
+ * start until the first stream event named the bare wire id and flipped it
+ * back to the model that had been picked all along.
  *
  * @param {Array<object>} models Catalog rows (SDK ModelInfo shape).
  * @param {string} id Persisted or requested model id.
@@ -210,20 +223,21 @@ function baseModelId(id) {
  */
 function matchModel(models, id) {
   if (!Array.isArray(models) || !id) return null;
-  const exact = models.find(m => m.value === id || m.resolvedModel === id);
+
+  // Naming a row's own `value` is the one way to land on the alias: only an
+  // explicit pick of "Default (recommended)" stores 'default'.
+  const byValue = models.find(m => m.value === id);
+  if (byValue) return byValue;
+
+  const concreteFirst = covers =>
+    models.find(m => m.value !== DEFAULT_ALIAS && covers(m)) || models.find(covers) || null;
+
+  const exact = concreteFirst(m => m.resolvedModel === id);
   if (exact) return exact;
 
   const base = baseModelId(id);
   if (!base) return null;
-  const covers = m => baseModelId(m.value) === base || baseModelId(m.resolvedModel) === base;
-
-  // Prefer a concrete row over the `default` alias. `default` points at
-  // whatever the CLI currently recommends, so resolving a stored id onto it
-  // would let a later CLI release silently move a deliberate choice — while
-  // the concrete row ('opus[1m]') is the same model the user actually picked.
-  return models.find(m => m.value !== DEFAULT_ALIAS && covers(m))
-    || models.find(covers)
-    || null;
+  return concreteFirst(m => baseModelId(m.value) === base || baseModelId(m.resolvedModel) === base);
 }
 
 /**

--- a/tests/shared/modelOptions.test.js
+++ b/tests/shared/modelOptions.test.js
@@ -78,6 +78,26 @@ describe('matchModel', () => {
     expect(matchModel(onlyDefault, 'claude-opus-5').value).toBe('default');
   });
 
+  test('prefers a concrete row when the alias shares its exact resolvedModel', () => {
+    // What the CLI's init message reports for a session started on 'opus[1m]':
+    // the id as resolvedModel spells it, suffix included. Both rows carry it
+    // and the alias sits first, so an exact pass that took the first hit made
+    // the footer read "Default (recommended)" from session start until the
+    // first stream event named the bare 'claude-opus-5' and flipped it back.
+    expect(matchModel(CLI_MODELS, 'claude-opus-5[1m]').value).toBe('opus[1m]');
+  });
+
+  test('the init id and the API id land on the same row', () => {
+    // One turn, two spellings of one model. The label must not move between
+    // them, whichever order the events arrive in.
+    expect(matchModel(CLI_MODELS, 'claude-opus-5[1m]')).toBe(matchModel(CLI_MODELS, 'claude-opus-5'));
+  });
+
+  test('still resolves default when it alone carries that resolvedModel', () => {
+    const rows = [CLI_MODELS[0], CLI_MODELS[3]];
+    expect(matchModel(rows, 'claude-opus-5[1m]').value).toBe('default');
+  });
+
   test('an explicit default pick resolves to itself', () => {
     expect(matchModel(CLI_MODELS, 'default').value).toBe('default');
   });


### PR DESCRIPTION
Fixes #143

## The defect

Send the first message of a session on **Opus 5** and the footer's model label reads **Default (recommended)** until the first token arrives, then **Opus 5** again. The model in use never changed; the label did.

`updateStatusInfo()` repaints the label from the model id the stream reports, through `matchModel()`. Within one turn the stream spells that id two ways (probed over the SDK with `model: 'opus[1m]'`, Claude Code 2.1.260):

| event | `model` |
|---|---|
| `system` / `init` | `claude-opus-5[1m]` |
| `stream_event` / `message_start`, `assistant` | `claude-opus-5` |

The CLI catalog lists `default` and `opus[1m]` with the same `resolvedModel`, `claude-opus-5[1m]`, and `orderPrimary()` puts `default` first. The exact pass of `matchModel()` took the first row whose `value` or `resolvedModel` equalled the id, so the init id landed on the alias. The base-id pass that handles the bare `claude-opus-5` already preferred a concrete row over the alias; the exact pass did not.

## The fix

`matchModel()` now applies that preference at every tier past the first. A row's own `value` is still matched first, so an explicit pick of *Default (recommended)* keeps resolving to itself.

```diff
-  const exact = models.find(m => m.value === id || m.resolvedModel === id);
+  const byValue = models.find(m => m.value === id);
+  if (byValue) return byValue;
+
+  const concreteFirst = covers =>
+    models.find(m => m.value !== DEFAULT_ALIAS && covers(m)) || models.find(covers) || null;
+
+  const exact = concreteFirst(m => m.resolvedModel === id);
   if (exact) return exact;
```

Behaviour otherwise unchanged: as before, once the stream names the model actually served, the footer shows that model, including when *Default (recommended)* was picked.

## Verification

- Three tests added to `tests/shared/modelOptions.test.js`. `prefers a concrete row when the alias shares its exact resolvedModel` fails on `main` (returns `default`) and passes here; `the init id and the API id land on the same row` pins the two spellings to one row; `still resolves default when it alone carries that resolvedModel` keeps the single-cover case.
- Checked against the catalog this machine's CLI advertises: `claude-opus-5[1m]`, `claude-opus-5`, `opus[1m]` and `opus` all land on the `opus[1m]` row; `default` resolves to itself; Fable, Sonnet, Haiku and the legacy ids are unchanged.
- `npx jest --testPathIgnorePatterns "/node_modules/" "/.claude/worktrees/"` — 100 suites, 2544 tests, green. `node scripts/build-renderer.js` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
