### PR TITLE
fix(chat): read the frames that measure the window without an API call

### DIFF
--- a/src/main/ipc/claude.ipc.js
+++ b/src/main/ipc/claude.ipc.js
@@ -335,11 +335,11 @@ async function loadSessionHistory(projectPath, sessionId, options = {}) {
     const maxKept = limit ? limit * 2 : Infinity;
     let total = 0;
     let dropped = 0;
-    // Context occupancy at the last turn read, for the chat's context gauge. A
-    // resumed conversation has no live session to ask until the user sends
-    // something, but the figure is already on disk. Tracked across every line
-    // rather than the returned window, so a trimmed replay still reports the
-    // real tail.
+    // Context occupancy at the last frame that measured it — a reply, or what a
+    // compaction left — for the chat's context gauge. A resumed conversation
+    // has no live session to ask until the user sends something, but the figure
+    // is already on disk. Tracked across every line rather than the returned
+    // window, so a trimmed replay still reports the real tail.
     let contextTokens = 0;
     let done = false;
     const stream = fs.createReadStream(filePath, { encoding: 'utf8' });

--- a/src/renderer/ui/components/ChatView.js
+++ b/src/renderer/ui/components/ChatView.js
@@ -6193,6 +6193,25 @@ class ChatView extends BaseComponent {
       .finally(() => { contextUsageBusy = false; });
   }
 
+  /**
+   * Ask the session for its own count of the window where the stream carries
+   * no figure of its own: a compact boundary without `post_tokens`. A frame
+   * that lands while the request is in flight describes a later state and
+   * wins — the ring only moves if nothing else has moved it meanwhile.
+   */
+  function refreshContextGaugeFromSession() {
+    if (!sessionId) return;
+    const before = inputTokens;
+    window.electron_api.chat.getContextUsage({ sessionId })
+      .then(result => {
+        const total = Number(result?.usage?.totalTokens);
+        if (!result?.success || !(total > 0) || inputTokens !== before) return;
+        inputTokens = total;
+        updateStatusInfo();
+      })
+      .catch(() => {});
+  }
+
   function hideContextBreakdown() {
     contextPopover.hidden = true;
   }
@@ -6321,11 +6340,16 @@ class ChatView extends BaseComponent {
           : t('chat.compactedSimple') || 'Conversation compacted';
         appendSystemNotice(notice, 'compact');
         // The window just emptied; without this the ring stays full until the
-        // next turn's first frame reports the new prefix.
-        const postTokens = message.compact_metadata?.post_tokens;
+        // next turn's first frame reports the new prefix. The boundary says
+        // what survived on CLIs new enough to report it. An older one says
+        // nothing, and a manual /compact ends the turn, so no frame would come
+        // along to bring the ring down — ask the session for its count instead.
+        const postTokens = contextTokensFromMessage(message);
         if (postTokens > 0) {
           inputTokens = postTokens;
           updateStatusInfo();
+        } else {
+          refreshContextGaugeFromSession();
         }
         setStreaming(false);
       } else if (message.subtype === 'task_started') {

--- a/src/shared/context-usage.js
+++ b/src/shared/context-usage.js
@@ -17,6 +17,8 @@
 
 'use strict';
 
+const positive = (v) => (typeof v === 'number' && isFinite(v) && v > 0 ? v : 0);
+
 /**
  * @param {object|null|undefined} usage An Anthropic usage object, from either an
  *   SDK result message or a session JSONL line.
@@ -24,10 +26,9 @@
  */
 function contextTokensFromUsage(usage) {
   if (!usage || typeof usage !== 'object') return 0;
-  const n = (v) => (typeof v === 'number' && isFinite(v) && v > 0 ? v : 0);
-  return n(usage.input_tokens)
-    + n(usage.cache_read_input_tokens)
-    + n(usage.cache_creation_input_tokens);
+  return positive(usage.input_tokens)
+    + positive(usage.cache_read_input_tokens)
+    + positive(usage.cache_creation_input_tokens);
 }
 
 /**
@@ -38,6 +39,16 @@ function contextTokensFromUsage(usage) {
  * A turn's total is not: the SDK result message sums every call the turn made,
  * so five tool round-trips over a 300K conversation add up to 1.5M and the
  * gauge reported "1.1M / 1M (109%)" on a window that was never over.
+ *
+ * Two frames measure the window without an API call behind them:
+ *
+ * - A compact boundary says what survived (`post_tokens`, camel-cased in the
+ *   session file) on CLIs new enough to report it. Nothing with a usage follows
+ *   it until the next reply — only the summary and the prompts — so without
+ *   this a resume right after /compact opens on the figure from *before* the
+ *   compaction.
+ * - `/context` answers with a synthetic assistant frame whose usage is all
+ *   zeros; its structured twin carries the CLI's own count of the window.
  *
  * Frames from a subagent or a sidechain carry their own separate window, so
  * they measure someone else's context and are skipped rather than mistaken for
@@ -51,7 +62,12 @@ function contextTokensFromUsage(usage) {
 function contextTokensFromMessage(msg) {
   if (!msg || typeof msg !== 'object') return 0;
   if (msg.parent_tool_use_id || msg.subagent_type || msg.isSidechain) return 0;
-  return contextTokensFromUsage(msg.message?.usage);
+  if (msg.type === 'system' && msg.subtype === 'compact_boundary') {
+    const meta = msg.compact_metadata || msg.compactMetadata || {};
+    return positive(meta.post_tokens) || positive(meta.postTokens);
+  }
+  return positive(msg.context_usage?.total_tokens)
+    || contextTokensFromUsage(msg.message?.usage);
 }
 
 module.exports = { contextTokensFromUsage, contextTokensFromMessage };

--- a/tests/ipc/claude.ipc.test.js
+++ b/tests/ipc/claude.ipc.test.js
@@ -153,6 +153,32 @@ describe('loadSessionHistory', () => {
     });
   });
 
+  test('opens on what a compaction left when nothing has been said since', async () => {
+    // A session closed right after /compact. The last frame with a usage is
+    // the big one from before; the boundary says what survived, and only the
+    // summary and prompts follow it until the next reply.
+    const dir = sessionsDir();
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, `${SESSION_ID}.jsonl`), [
+      JSON.stringify({
+        type: 'assistant', uuid: 'a-0', sessionId: SESSION_ID,
+        message: { role: 'assistant', content: [{ type: 'text', text: 'answer 0' }], usage: { input_tokens: 2, cache_read_input_tokens: 36216 } }
+      }),
+      JSON.stringify({
+        type: 'system', subtype: 'compact_boundary', uuid: 's-1', sessionId: SESSION_ID, isSidechain: false,
+        content: 'Conversation compacted',
+        compactMetadata: { trigger: 'manual', preTokens: 36218, postTokens: 3356 }
+      }),
+      JSON.stringify({
+        type: 'user', uuid: 'u-2', sessionId: SESSION_ID, isCompactSummary: true,
+        message: { role: 'user', content: 'This session is being continued from a previous conversation.' }
+      }),
+    ].join('\n') + '\n');
+
+    const result = await loadSessionHistory(PROJECT_PATH, SESSION_ID);
+    expect(result.contextTokens).toBe(3356);
+  });
+
   test('keeps the real tail figure when the replay window is trimmed', async () => {
     // A trimmed replay drops early messages; the gauge must still describe the
     // end of the conversation, not the last message that survived the window.

--- a/tests/shared/contextUsage.test.js
+++ b/tests/shared/contextUsage.test.js
@@ -56,6 +56,36 @@ describe('contextTokensFromMessage', () => {
     expect(contextTokensFromMessage(frame(usage, { isSidechain: true }))).toBe(0);
   });
 
+  test('reads what a compaction left, in either casing', () => {
+    // As the SDK delivers the boundary…
+    expect(contextTokensFromMessage({
+      type: 'system', subtype: 'compact_boundary',
+      compact_metadata: { trigger: 'manual', pre_tokens: 36218, post_tokens: 3356 },
+    })).toBe(3356);
+    // …and as the CLI writes it to the session file.
+    expect(contextTokensFromMessage({
+      type: 'system', subtype: 'compact_boundary', isSidechain: false,
+      compactMetadata: { trigger: 'manual', preTokens: 36218, postTokens: 3356 },
+    })).toBe(3356);
+  });
+
+  test('a boundary that does not say what survived measures nothing', () => {
+    // pre_tokens is the size *before* — the one figure a post-compaction gauge
+    // must not show.
+    expect(contextTokensFromMessage({
+      type: 'system', subtype: 'compact_boundary',
+      compact_metadata: { trigger: 'auto', pre_tokens: 940584 },
+    })).toBe(0);
+  });
+
+  test('takes the CLI’s own count off the /context frame', () => {
+    // Verbatim shape: an all-zero usage, and the structured twin of the table.
+    expect(contextTokensFromMessage(frame(
+      { input_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+      { context_usage: { model: 'claude-haiku-4-5-20251001', total_tokens: 11626, raw_max_tokens: 200000, percentage: 6, categories: [] } }
+    ))).toBe(11626);
+  });
+
   test('tolerates junk', () => {
     expect(contextTokensFromMessage(null)).toBe(0);
     expect(contextTokensFromMessage({})).toBe(0);


### PR DESCRIPTION
Fixes #145

Follow-up to d29e700a, which moved the gauge onto assistant frames. Three frames still measure the window and were read past; all three now go through `contextTokensFromMessage`, so the live stream and the session replay keep one rule.

## What changes

- **Compact boundary on the session file.** The reader took the last frame with a usage, which after `/compact` is the big one from before; the boundary's `postTokens` sat one line below it, and only the summary and the prompts follow until the next reply. A session closed right after a compaction resumed on the pre-compaction figure. The helper now reads `post_tokens` / `postTokens` off the boundary.
- **Boundary without `post_tokens` on the live stream.** The field is optional in the SDK types: the bundled CLI reports it, an older one says nothing, and a manual `/compact` ends the turn, so no frame came along to bring the ring down. `ChatView` now asks the session for its own count (`getContextUsage().totalTokens`) in that case; a frame that lands while the request is in flight wins.
- **`/context`.** Its reply is a synthetic assistant frame with an all-zero usage and the structured twin of the table in `context_usage`. The gauge adopts `total_tokens`, the same way the hover breakdown already adopts the CLI's count.

## Verified

- Shapes captured from the bundled CLI through the SDK: a real compaction (`pre_tokens: 36218, post_tokens: 3356`), the `/context` frame (`context_usage.total_tokens: 11626`), and the on-disk boundary casing (`compactMetadata.postTokens`).
- `npx jest`: 104 suites, 2585 tests. `node scripts/build-renderer.js`.
- Tests added: boundary in both casings, boundary without `post_tokens`, the `/context` frame, and a replay closed right after a compaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
