### PR TITLE
fix(chat): resend the opening turn when an account switch has nothing to resume

### DIFF
--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -3785,6 +3785,7 @@
     "limitReached": "Usage limit reached on the active account.",
     "switched": "Account switched. Resuming…",
     "switchedNoResume": "Account switched. The previous conversation could not be resumed — continuing without its context.",
+    "switchedResent": "Account switched. The previous conversation was never saved, so your message is being sent again on the new account.",
     "removeConfirm": "Remove this saved account? The credentials will be deleted from local storage.",
     "switchError": "Failed to switch account",
     "renameError": "Failed to rename account",

--- a/src/renderer/i18n/locales/es.json
+++ b/src/renderer/i18n/locales/es.json
@@ -3785,6 +3785,7 @@
     "limitReached": "Límite de uso alcanzado en la cuenta activa.",
     "switched": "Cuenta cambiada. Reanudando…",
     "switchedNoResume": "Cuenta cambiada. No se pudo reanudar la conversación anterior — se continúa sin su contexto.",
+    "switchedResent": "Cuenta cambiada. La conversación anterior nunca se guardó, así que tu mensaje se envía de nuevo en la cuenta nueva.",
     "removeConfirm": "¿Eliminar esta cuenta guardada? Las credenciales se borrarán del almacenamiento local.",
     "switchError": "No se pudo cambiar de cuenta",
     "renameError": "No se pudo renombrar la cuenta",

--- a/src/renderer/i18n/locales/fr.json
+++ b/src/renderer/i18n/locales/fr.json
@@ -3785,6 +3785,7 @@
     "limitReached": "Limite d'usage atteinte sur le compte actif.",
     "switched": "Compte changé. Reprise…",
     "switchedNoResume": "Compte changé. La conversation précédente n'a pas pu être reprise — la suite se fera sans son contexte.",
+    "switchedResent": "Compte changé. La conversation précédente n'a jamais été enregistrée : votre message est renvoyé sur le nouveau compte.",
     "removeConfirm": "Supprimer ce compte enregistré ? Les identifiants seront effacés du stockage local.",
     "switchError": "Impossible de changer de compte",
     "renameError": "Impossible de renommer le compte",

--- a/src/renderer/i18n/locales/id.json
+++ b/src/renderer/i18n/locales/id.json
@@ -3785,6 +3785,7 @@
     "limitReached": "Batas penggunaan tercapai pada akun yang aktif.",
     "switched": "Akun diganti. Melanjutkan…",
     "switchedNoResume": "Akun diganti. Percakapan sebelumnya tidak bisa dilanjutkan — dilanjutkan tanpa konteksnya.",
+    "switchedResent": "Akun diganti. Percakapan sebelumnya tidak pernah tersimpan, jadi pesan Anda dikirim ulang di akun baru.",
     "removeConfirm": "Hapus akun tersimpan ini? Kredensialnya akan dihapus dari penyimpanan lokal.",
     "switchError": "Gagal mengganti akun",
     "renameError": "Gagal mengganti nama akun",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -3785,6 +3785,7 @@
     "limitReached": "活动账户已达到使用限制。",
     "switched": "账号已切换。正在恢复…",
     "switchedNoResume": "账号已切换。无法恢复之前的对话 — 将在缺少其上下文的情况下继续。",
+    "switchedResent": "账号已切换。之前的对话从未保存，因此你的消息将在新账号上重新发送。",
     "removeConfirm": "删除这个已保存的账户吗？凭据将从本地存储中删除。",
     "switchError": "切换账号失败",
     "renameError": "账户重命名失败",

--- a/src/renderer/ui/components/ChatView.js
+++ b/src/renderer/ui/components/ChatView.js
@@ -7188,29 +7188,47 @@ class ChatView extends BaseComponent {
       // tab was opened on.
       const realSid = sdkSessionId || resumeSessionId;
       // The binding is read at spawn time, so the restart has to carry the new
-      // account explicitly — lastStartOpts still holds the one that ran out.
-      // Everything that belonged to the turn that opened the tab is dropped: the
-      // restart sends no prompt, so replaying its images, mentions or message
-      // uuid would post the opening message a second time. A fork's truncation
-      // point goes too — it names a message of the session being resumed, not of
-      // the fork that came out of it.
+      // account explicitly — lastStartOpts still holds the one that ran out. A
+      // fork's truncation point goes too: it names a message of the session
+      // being resumed, not of the fork that came out of it.
+      //
+      // Whether the opening turn rides along depends on whether it survived
+      // anywhere. With a session to resume it is already on disk, and sending it
+      // again would post it twice. Without one it exists nowhere but the bubble
+      // on screen — a limit refused before the SDK's init message means no
+      // session file was ever written — so the restart has to carry it or the
+      // prompt dies with the account that refused it. Its uuid goes along to keep
+      // that bubble matching the message that finally gets recorded.
+      const replayOpeningTurn = !realSid;
       const restartOpts = {
         ...lastStartOpts,
         accountId: newId,
-        prompt: '',
-        images: [],
-        mentions: [],
-        userMessageUuid: null,
+        prompt: replayOpeningTurn ? (lastStartOpts.prompt || '') : '',
+        images: replayOpeningTurn ? (lastStartOpts.images || []) : [],
+        mentions: replayOpeningTurn ? (lastStartOpts.mentions || []) : [],
+        userMessageUuid: replayOpeningTurn ? (lastStartOpts.userMessageUuid || null) : null,
         forkSession: false,
         resumeSessionAt: null,
         resumeDropsTurn: null,
         resumeSessionId: realSid || null,
       };
-      appendSystemNotice(realSid
+      // An opening turn that carried nothing leaves the restart with nothing to
+      // send: the session comes up idle, waiting for the user to type.
+      const replayed = replayOpeningTurn && Boolean(
+        (restartOpts.prompt || '').trim() || restartOpts.images.length || restartOpts.mentions.length
+      );
+      const notice = realSid
         ? (t('accounts.switched') || 'Account switched. Resuming…')
-        : (t('accounts.switchedNoResume') || 'Account switched. The previous conversation could not be resumed — continuing without its context.'), 'info');
-      setStreaming(true);
-      appendThinkingIndicator();
+        : replayed
+          ? (t('accounts.switchedResent') || 'Account switched. The previous conversation was never saved, so your message is being sent again on the new account.')
+          : (t('accounts.switchedNoResume') || 'Account switched. The previous conversation could not be resumed — continuing without its context.');
+      appendSystemNotice(notice, 'info');
+      // Only wait on a turn the SDK will actually run: with nothing queued the
+      // spinner would sit there for the life of the tab.
+      if (realSid || replayed) {
+        setStreaming(true);
+        appendThinkingIndicator();
+      }
       const res = await api.chat.start(restartOpts);
       if (!res.success) {
         appendError(res.error || t('chat.errorOccurred'));

--- a/tests/ui/chatAccountSwitch.test.js
+++ b/tests/ui/chatAccountSwitch.test.js
@@ -1,0 +1,100 @@
+/**
+ * Account switch after a usage limit — what the restart carries.
+ *
+ * A limit refused before the SDK's init message leaves no session file behind,
+ * so the opening turn exists nowhere but the bubble on screen: the restart has
+ * to send it again or the prompt dies with the account that refused it. Once a
+ * real session id exists the opposite holds — the turn is already on disk, and
+ * re-sending it would post the same message twice.
+ */
+
+jest.mock('../../src/renderer/ui/components/AccountSwitchModal', () => ({
+  showAccountSwitchModal: jest.fn(async () => 'acc-team'),
+}));
+
+/** api mock: `on*` captures its callback, everything else records the call. */
+function makeApiMock(listeners, calls) {
+  const ns = (namespace) => new Proxy({}, {
+    get: (_t, method) => (...args) => {
+      if (typeof method === 'string' && method.startsWith('on')) {
+        listeners[method] = args[0];
+        return () => {};
+      }
+      calls.push({ namespace, method, args });
+      return Promise.resolve({ success: true, messages: [] });
+    }
+  });
+  return new Proxy({}, { get: (_t, namespace) => ns(namespace) });
+}
+
+// jsdom ships no crypto.randomUUID; the send path tags each user message with one.
+let uuidSeq = 0;
+Object.defineProperty(global, 'crypto', {
+  value: { ...(global.crypto || {}), randomUUID: () => `uuid-${++uuidSeq}` },
+  configurable: true,
+});
+
+describe('chat account switch', () => {
+  let listeners, calls, wrapper, view, sessionId;
+
+  const flush = async () => { for (let i = 0; i < 5; i++) await new Promise(r => setTimeout(r, 0)); };
+
+  /** The options of the last chat.start — the restart the switch fired. */
+  const lastStart = () => [...calls].reverse().find(c => c.namespace === 'chat' && c.method === 'start')?.args[0];
+
+  const hitLimit = async () => {
+    listeners.onAccountLimit({
+      sessionId, error: 'Usage limit reached', activeAccountId: 'acc-max', projectId: null,
+    });
+    await flush();
+  };
+
+  beforeEach(async () => {
+    jest.resetModules();
+    listeners = {};
+    calls = [];
+    window.electron_api = makeApiMock(listeners, calls);
+    document.body.innerHTML = '';
+    wrapper = document.createElement('div');
+    document.body.appendChild(wrapper);
+    const { createChatView } = require('../../src/renderer/ui/components/ChatView');
+    view = createChatView(wrapper, { id: 'p1', name: 'Test', path: '/tmp/test' });
+    view.sendMessage('contexte Salim');
+    await flush();
+    sessionId = view.getSessionId();
+    expect(sessionId).toBeTruthy();
+    expect(lastStart().prompt).toBe('contexte Salim');
+  });
+
+  afterEach(() => {
+    try { view?.destroy?.(); } catch (_) { /* teardown is best effort */ }
+  });
+
+  it('resends the opening turn when no session was ever written', async () => {
+    await hitLimit();
+
+    const restart = lastStart();
+    expect(restart.accountId).toBe('acc-team');
+    expect(restart.resumeSessionId).toBeNull();
+    // Without this the prompt is lost: nothing on disk to resume, nothing sent.
+    expect(restart.prompt).toBe('contexte Salim');
+  });
+
+  it('resumes without resending once the SDK has given a session id', async () => {
+    listeners.onMessage({
+      sessionId,
+      message: {
+        type: 'assistant', session_id: 'real-uuid-1',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'hi' }] },
+      },
+    });
+
+    await hitLimit();
+
+    const restart = lastStart();
+    expect(restart.accountId).toBe('acc-team');
+    expect(restart.resumeSessionId).toBe('real-uuid-1');
+    // The resumed transcript already holds it; sending it again would double it.
+    expect(restart.prompt).toBe('');
+  });
+});


### PR DESCRIPTION
Fixes #149

## The gap

#142 made the account-switch restart resume on the CLI's session id, and blank the opening turn so the resumed transcript does not receive it twice. Both are right — as long as there *is* a session to resume.

When the usage limit is refused before the SDK's init message there is none: no CLI session was ever created, so no `~/.claude/projects/<dir>/<uuid>.jsonl` holds that turn. The blanking then drops the only copy of it, and `startSession()` queues nothing at all, so the tab comes back on the new account with an idle session and a thinking indicator that never resolves.

## The change

Replay the opening turn only in that case, since nothing consumed it:

```js
const replayOpeningTurn = !realSid;
prompt: replayOpeningTurn ? (lastStartOpts.prompt || '') : '',
```

Its `userMessageUuid` goes along, so the bubble already on screen stays matched to the message that finally gets recorded — that uuid is what `handleRewindFiles()` addresses. The resume path is untouched: with a `realSid` the turn is on disk and re-sending it would post it twice.

The thinking indicator now waits only on a turn the SDK will actually run.

A third notice, `accounts.switchedResent`, tells the user the message is being sent again rather than resumed (5 locales). `accounts.switchedNoResume` stays for the case where the opening turn carried nothing to replay.

## Tests

`tests/ui/chatAccountSwitch.test.js` covers both directions: replay when no session id exists, and no replay once the SDK has given one. The first fails on `main`.

```
Test Suites: 105 passed, 105 total
Tests:       2583 passed, 2583 total
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)