### PR TITLE
fix(chat): offer the account switch when a spend cap is reported in-band

### DIFF
--- a/src/main/services/ChatService.js
+++ b/src/main/services/ChatService.js
@@ -11,20 +11,15 @@ const { execFileSync } = require('child_process');
 const ModelCatalogService = require('./ModelCatalogService');
 const AccountManager = require('./AccountManager');
 const { isCliFailureText } = require('../../shared/cli-failure-text');
+const { isApiErrorMessage } = require('../../shared/api-error');
 const { isPermissionMode } = require('../../shared/permission-modes');
 
 /**
- * Is this assistant message the CLI reporting an API failure rather than
- * answering — a spend cap, a refusal, an overloaded upstream?
- *
- * The CLI carries the flag as `isApiErrorMessage` internally, which is the
- * spelling written to the ~/.claude/projects transcript, and serialises it to
- * stream-json as `is_api_error_message`. Which of the two survives to here is
- * the SDK's business, so both count.
+ * SDKAssistantMessageError codes that mean *this account* cannot run the turn
+ * and another one could. A refusal, an overloaded upstream or a bad request
+ * are not on the list: switching accounts would not help.
  */
-function isApiErrorMessage(message) {
-  return message?.isApiErrorMessage === true || message?.is_api_error_message === true;
-}
+const ACCOUNT_LIMIT_ERROR_CODES = ['billing_error', 'rate_limit', 'account_on_hold'];
 
 let sdkPromise = null;
 let resolvedRuntime = null;
@@ -1531,24 +1526,34 @@ class ChatService {
         // flagged `is_error` or carrying an error subtype. Fork-guard refusals
         // never reach this point (`continue` above) — the renderer auto-resumes
         // those, so they are not a session outcome.
-        if (message.type === 'assistant' && message.error) {
-          inbandError = `API error: ${message.error}`;
-        } else if (message.type === 'assistant') {
-          // The other in-band shape: a refusal handed back as ordinary
-          // assistant text, with no `error` field and no throw — only a flag.
-          // A spend cap arrives this way, and because the stream stays open the
-          // tab keeps its process, which keeps the credentials of the account
-          // that just ran out. Every retry then hits the same wall, which is
-          // why quitting the app used to be the only way through.
+        if (message.type === 'assistant' && (message.error || isApiErrorMessage(message))) {
+          // An in-band failure: the CLI answers the turn with an ordinary
+          // assistant message reporting the error, and leaves the stream open —
+          // so the tab keeps the process it was spawned with, and that process
+          // keeps the credentials of the account that just ran out. Every retry
+          // then hits the same wall, which is why quitting the app used to be
+          // the only way through a spend cap.
+          //
+          // It arrives two ways and the two must be handled together, not one
+          // in the other's `else`: a typed `error` code on the frame
+          // (SDKAssistantMessageError, what the current SDK sends), or the flag
+          // with the failure as text (what the transcript carries, and what an
+          // older producer sends). Testing the code first and the flag second
+          // in one branch is what keeps the coded case from shadowing the
+          // limit check entirely.
           const text = assistantText(message);
-          if (isApiErrorMessage(message)) {
-            inbandError = text || 'API error';
-            if (this._isUsageLimitError(text)) pendingAccountLimit = text;
-          } else if (this._isCliFailureText(text) && this._isUsageLimitError(text)) {
-            // Same failure, no flag on it. Losing the offer to a renamed field
-            // is how this bug got here, so the CLI's own phrasing gets a second
-            // look — anchored (isCliFailureText), because Claude *discussing* a
-            // spend limit has to stay an ordinary reply.
+          const code = typeof message.error === 'string' ? message.error : '';
+          inbandError = code ? `API error: ${code}` : (text || 'API error');
+          if (ACCOUNT_LIMIT_ERROR_CODES.includes(code) || this._isUsageLimitError(text)) {
+            pendingAccountLimit = text || inbandError;
+          }
+        } else if (message.type === 'assistant') {
+          // The same failure with nothing on it — no code, no flag. The CLI's
+          // own phrasing gets a second look, anchored (isCliFailureText),
+          // because Claude *discussing* a spend limit has to stay an ordinary
+          // reply.
+          const text = assistantText(message);
+          if (this._isCliFailureText(text) && this._isUsageLimitError(text)) {
             pendingAccountLimit = text;
           }
         } else if (message.type === 'result') {

--- a/src/main/services/ChatService.js
+++ b/src/main/services/ChatService.js
@@ -13,6 +13,19 @@ const AccountManager = require('./AccountManager');
 const { isCliFailureText } = require('../../shared/cli-failure-text');
 const { isPermissionMode } = require('../../shared/permission-modes');
 
+/**
+ * Is this assistant message the CLI reporting an API failure rather than
+ * answering — a spend cap, a refusal, an overloaded upstream?
+ *
+ * The CLI carries the flag as `isApiErrorMessage` internally, which is the
+ * spelling written to the ~/.claude/projects transcript, and serialises it to
+ * stream-json as `is_api_error_message`. Which of the two survives to here is
+ * the SDK's business, so both count.
+ */
+function isApiErrorMessage(message) {
+  return message?.isApiErrorMessage === true || message?.is_api_error_message === true;
+}
+
 let sdkPromise = null;
 let resolvedRuntime = null;
 
@@ -1403,6 +1416,10 @@ class ChatService {
     // (streaming input). Tracked so the final lifecycle event reports the
     // session's real outcome; a later successful turn clears it.
     let inbandError = null;
+    // An in-band limit waiting for the turn to settle before it is raised.
+    // Acting on it closes the session, and closing one mid-turn paints an
+    // interrupted marker over the restart the switch is making room for.
+    let pendingAccountLimit = null;
     const session = this.sessions.get(sessionId);
     // Assistant text for the turn in progress. Claude emits one assistant
     // message per text block — several per turn as soon as tools run in
@@ -1414,6 +1431,23 @@ class ChatService {
       const text = replyBuffer.trim();
       replyBuffer = '';
       if (text) this._emitMessage('assistant', text, sessionId);
+    };
+    /** The text blocks of an assistant message, joined. Content may be a bare string. */
+    const assistantText = (message) => {
+      const content = message.message?.content;
+      if (typeof content === 'string') return content.trim();
+      if (!Array.isArray(content)) return '';
+      return content
+        .filter(block => block?.type === 'text' && block.text)
+        .map(block => block.text)
+        .join('\n')
+        .trim();
+    };
+    const raisePendingAccountLimit = async () => {
+      if (!pendingAccountLimit) return;
+      const limit = pendingAccountLimit;
+      pendingAccountLimit = null;
+      await this._emitAccountLimit(sessionId, session, limit);
     };
     try {
       for await (const message of queryStream) {
@@ -1499,6 +1533,24 @@ class ChatService {
         // those, so they are not a session outcome.
         if (message.type === 'assistant' && message.error) {
           inbandError = `API error: ${message.error}`;
+        } else if (message.type === 'assistant') {
+          // The other in-band shape: a refusal handed back as ordinary
+          // assistant text, with no `error` field and no throw — only a flag.
+          // A spend cap arrives this way, and because the stream stays open the
+          // tab keeps its process, which keeps the credentials of the account
+          // that just ran out. Every retry then hits the same wall, which is
+          // why quitting the app used to be the only way through.
+          const text = assistantText(message);
+          if (isApiErrorMessage(message)) {
+            inbandError = text || 'API error';
+            if (this._isUsageLimitError(text)) pendingAccountLimit = text;
+          } else if (this._isCliFailureText(text) && this._isUsageLimitError(text)) {
+            // Same failure, no flag on it. Losing the offer to a renamed field
+            // is how this bug got here, so the CLI's own phrasing gets a second
+            // look — anchored (isCliFailureText), because Claude *discussing* a
+            // spend limit has to stay an ordinary reply.
+            pendingAccountLimit = text;
+          }
         } else if (message.type === 'result') {
           if (message.is_error || message.subtype !== 'success') {
             const errors = Array.isArray(message.errors) ? message.errors.filter(Boolean) : [];
@@ -1523,10 +1575,14 @@ class ChatService {
           }
         } else if (message.type === 'result') {
           flushReply();
+          await raisePendingAccountLimit();
         }
       }
       flushReply();
       this._send('chat-done', { sessionId });
+      // No result closed the turn — the stream itself did. Still the account's
+      // budget, so the offer still stands.
+      await raisePendingAccountLimit();
       if (inbandError) {
         // The stream closed cleanly, but the last turn had failed in-band —
         // the renderer already displayed that error, so lifecycle consumers
@@ -1552,21 +1608,13 @@ class ChatService {
         if (stderrLog && err.message?.includes('exited with code')) {
           errorMsg += `\n\nDetails: ${stderrLog.trim().slice(0, 500)}`;
         }
-        const errorType = this._isUsageLimitError(err.message, stderrLog) ? 'usage_limit' : 'generic';
+        // A limit seen in-band counts even if the stream went on to die of
+        // something else: the account is out of budget either way.
+        const errorType = (pendingAccountLimit || this._isUsageLimitError(err.message, stderrLog))
+          ? 'usage_limit' : 'generic';
         if (errorType === 'usage_limit') {
-          // The limit belongs to whichever account ran this session: its
-          // project's binding, or the default when it has none. The renderer
-          // offers to re-bind the project rather than swap a global account.
-          let activeAccountId = session?.accountId || null;
-          try {
-            if (!activeAccountId) activeAccountId = (await AccountManager.listAccounts()).defaultId;
-          } catch (_) { /* AccountManager not initialized yet */ }
-          this._send('chat-account-limit', {
-            sessionId,
-            error: errorMsg,
-            activeAccountId,
-            projectId: session?.projectId || null
-          });
+          await this._emitAccountLimit(sessionId, session, pendingAccountLimit || errorMsg);
+          pendingAccountLimit = null;
         }
         this._send('chat-error', { sessionId, error: errorMsg, errorType });
         this._emitLifecycle('end', sessionId, { status: 'error', error: errorMsg });
@@ -1596,7 +1644,36 @@ class ChatService {
       || haystack.includes('too many requests')
       || haystack.includes('usage limit')
       || haystack.includes('weekly limit')
-      || haystack.includes('quota');
+      || haystack.includes('quota')
+      // A spend cap reads nothing like a rate limit — "You've hit your
+      // individual spend limit · run /usage-credits … · your session limit
+      // resets 5:20pm" shares not one word with the patterns above — but it
+      // ends the same way: this account cannot run the turn and another one can.
+      || haystack.includes('spend limit')
+      || haystack.includes('session limit')
+      || haystack.includes('usage-credits')
+      || haystack.includes('credit balance');
+  }
+
+  /**
+   * Tell the renderer this session's account is out of budget, so it can offer
+   * the switch.
+   *
+   * The limit belongs to whichever account ran this session: its project's
+   * binding, or the default when it has none. The renderer offers to re-bind
+   * the project rather than swap a global account.
+   */
+  async _emitAccountLimit(sessionId, session, error) {
+    let activeAccountId = session?.accountId || null;
+    try {
+      if (!activeAccountId) activeAccountId = (await AccountManager.listAccounts()).defaultId;
+    } catch (_) { /* AccountManager not initialized yet */ }
+    this._send('chat-account-limit', {
+      sessionId,
+      error,
+      activeAccountId,
+      projectId: session?.projectId || null
+    });
   }
 
   /**

--- a/src/renderer/ui/components/ChatView.js
+++ b/src/renderer/ui/components/ChatView.js
@@ -7792,10 +7792,23 @@ class ChatView extends BaseComponent {
     if (sid !== sessionId) return;
     // A limit reported in-band leaves the session alive, so the switch has to
     // close it — and that abort comes back as an interrupted `done` under the
-    // same handle. It is our own doing, not a turn ending: honouring it would
-    // stamp an interrupted marker across the transcript and stop the spinner
-    // the restart has just started.
-    if (switchingAccount) return;
+    // same handle. It is our own doing, not a turn ending: the interrupted
+    // marker must not be stamped across the transcript, and the spinner the
+    // restart has just started must not be cleared. The turn's cards are a
+    // different matter — they really are over, and leaving them spinning is
+    // what the plain `return` used to do.
+    if (switchingAccount) {
+      isAborting = false;
+      finalizeStreamBlock();
+      resolveAllPendingCards();
+      for (const [, card] of toolCards) completeToolCard(card);
+      toolCards.clear();
+      for (const [idx, info] of taskToolIndices) {
+        completeSubagentCard(info.card);
+        taskToolIndices.delete(idx);
+      }
+      return;
+    }
     const wasInterrupted = interrupted || isAborting;
     isAborting = false;
     removeThinkingIndicator();

--- a/src/renderer/ui/components/ChatView.js
+++ b/src/renderer/ui/components/ChatView.js
@@ -7790,6 +7790,12 @@ class ChatView extends BaseComponent {
 
   const unsubDone = api.chat.onDone(({ sessionId: sid, interrupted }) => {
     if (sid !== sessionId) return;
+    // A limit reported in-band leaves the session alive, so the switch has to
+    // close it — and that abort comes back as an interrupted `done` under the
+    // same handle. It is our own doing, not a turn ending: honouring it would
+    // stamp an interrupted marker across the transcript and stop the spinner
+    // the restart has just started.
+    if (switchingAccount) return;
     const wasInterrupted = interrupted || isAborting;
     isAborting = false;
     removeThinkingIndicator();

--- a/src/shared/cli-failure-text.js
+++ b/src/shared/cli-failure-text.js
@@ -26,10 +26,14 @@ const CLI_FAILURE_TEXT = [
   /\busage limit reached\b/i,
   // Spend caps: "You've hit your individual spend limit · run /usage-credits
   // to ask your admin for a higher limit · your session limit resets 5:20pm".
-  // Anchored like the rest — prose *about* a spend limit, up to and including
-  // quoting that sentence back, has to keep going through.
-  /^you\b.{0,6}\bhit your\b[^.]*\blimit\b/i,
-  /\brun \/usage-credits\b/i,
+  //
+  // Anchored like the rest, and narrowly: an opening "You've hit your …
+  // limit" alone matches Claude explaining a GitHub rate limit, so the limit
+  // has to be one of the CLI's own. The second pattern wants the CLI's
+  // bullet-separated banner rather than a bare mention, so a reply telling the
+  // user to run /usage-credits stays an ordinary reply.
+  /^you\b.{0,6}\bhit your\b[^.]*\b(spend|usage|session|weekly) limit\b/i,
+  /·\s*run \/usage-credits\b/i,
 ];
 
 /**

--- a/src/shared/cli-failure-text.js
+++ b/src/shared/cli-failure-text.js
@@ -24,6 +24,12 @@ const CLI_FAILURE_TEXT = [
   /\bsession (has )?expired\b/i,
   /\bcredit balance (is )?too low\b/i,
   /\busage limit reached\b/i,
+  // Spend caps: "You've hit your individual spend limit · run /usage-credits
+  // to ask your admin for a higher limit · your session limit resets 5:20pm".
+  // Anchored like the rest — prose *about* a spend limit, up to and including
+  // quoting that sentence back, has to keep going through.
+  /^you\b.{0,6}\bhit your\b[^.]*\blimit\b/i,
+  /\brun \/usage-credits\b/i,
 ];
 
 /**

--- a/tests/services/chatSpendLimit.test.js
+++ b/tests/services/chatSpendLimit.test.js
@@ -1,0 +1,136 @@
+/**
+ * A spend cap has to reach the account-switch offer.
+ *
+ * The CLI does not throw for it. It answers the turn with an ordinary assistant
+ * message carrying the failure as text and a flag, and leaves the stream open —
+ * so the tab keeps the process it was spawned with, and that process keeps the
+ * credentials of the account that just ran out. Nothing here is about the
+ * switch itself, which already worked: it is about the one event that starts
+ * it, `chat-account-limit`, which used to fire only from the stream's `catch`
+ * and therefore never fired for this.
+ */
+
+jest.mock('electron', () => ({
+  app: { isPackaged: false, getAppPath: () => '/mock/app' },
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+jest.mock('child_process', () => ({
+  exec: jest.fn(), execSync: jest.fn(), execFileSync: jest.fn(() => ''),
+}));
+jest.mock('@anthropic-ai/claude-agent-sdk', () => ({}), { virtual: true });
+jest.mock('../../src/main/services/AccountManager', () => ({
+  listAccounts: jest.fn(async () => ({ accounts: [], defaultId: 'acc-default' })),
+}));
+
+const chatService = require('../../src/main/services/ChatService');
+
+/** Verbatim from ~/.claude/projects — the message that started this. */
+const SPEND_LIMIT = "You've hit your individual spend limit · run /usage-credits to ask your admin for a higher limit · your session limit resets 5:20pm (Europe/Paris)";
+
+const SID = 'chat-test-1';
+
+const assistant = (text, extra = {}) => ({
+  type: 'assistant',
+  message: { role: 'assistant', content: [{ type: 'text', text }], stop_reason: 'stop_sequence' },
+  ...extra,
+});
+const okResult = { type: 'result', subtype: 'success', is_error: false };
+
+/** Run the stream loop over `messages` and return everything it sent. */
+async function drain(messages, session = {}) {
+  const sent = [];
+  chatService.sessions.set(SID, {
+    accountId: 'acc-max', projectId: 'p1', messageQueue: null, ...session,
+  });
+  // Own properties shadowing the prototype rather than jest.spyOn, which
+  // refuses a method the object does not have: `_emitEvent` is one the fork
+  // adds and upstream does not, and this suite has to run on both.
+  const stubs = {
+    _send: (ch, data) => sent.push({ ch, data }),
+    _emitLifecycle: (ev, _sid, extra) => sent.push({ ch: `lifecycle:${ev}`, data: extra }),
+    _emitEvent: () => {},
+    _emitMessage: () => {},
+    _rejectPendingPermissions: () => {},
+  };
+  Object.assign(chatService, stubs);
+  try {
+    await chatService._processStream(SID, (async function* () { yield* messages; })());
+  } finally {
+    for (const key of Object.keys(stubs)) delete chatService[key];
+    chatService.sessions.delete(SID);
+  }
+  return sent;
+}
+
+const limits = sent => sent.filter(s => s.ch === 'chat-account-limit');
+
+describe('spend limit reported in-band', () => {
+  test('_isUsageLimitError recognises the spend-cap phrasing', () => {
+    expect(chatService._isUsageLimitError(SPEND_LIMIT)).toBe(true);
+  });
+
+  // The CLI tags the message `isApiErrorMessage` internally — the spelling that
+  // lands in the transcript — and `is_api_error_message` on the stream-json
+  // wire. Losing the offer to whichever one the SDK happens to forward is the
+  // whole bug, so both have to work.
+  test.each([
+    ['transcript spelling', { isApiErrorMessage: true }],
+    ['stream-json spelling', { is_api_error_message: true }],
+  ])('offers the account switch (%s)', async (_label, flag) => {
+    const sent = await drain([assistant(SPEND_LIMIT, flag), okResult]);
+
+    expect(limits(sent)).toHaveLength(1);
+    expect(limits(sent)[0].data).toMatchObject({
+      sessionId: SID, error: SPEND_LIMIT, activeAccountId: 'acc-max', projectId: 'p1',
+    });
+  });
+
+  test('offers it even unflagged, on the CLI phrasing alone', async () => {
+    const sent = await drain([assistant(SPEND_LIMIT), okResult]);
+    expect(limits(sent)).toHaveLength(1);
+  });
+
+  test('falls back to the default account when the session is unbound', async () => {
+    const sent = await drain([assistant(SPEND_LIMIT, { isApiErrorMessage: true }), okResult],
+      { accountId: null });
+    expect(limits(sent)[0].data.activeAccountId).toBe('acc-default');
+  });
+
+  // Raised after the turn has settled, never mid-turn: acting on it closes the
+  // session, and closing one mid-turn stamps an interrupted marker across the
+  // transcript and stops the spinner the restart has just started.
+  test('waits for the turn to end before raising it', async () => {
+    const sent = await drain([assistant(SPEND_LIMIT, { isApiErrorMessage: true }), okResult]);
+    const order = sent.map(s => s.ch);
+    expect(order.indexOf('chat-account-limit')).toBeGreaterThan(
+      order.lastIndexOf('chat-message'));
+  });
+
+  test('still raises it when the stream ends with no result', async () => {
+    const sent = await drain([assistant(SPEND_LIMIT, { isApiErrorMessage: true })]);
+    expect(limits(sent)).toHaveLength(1);
+    const order = sent.map(s => s.ch);
+    expect(order.indexOf('chat-account-limit')).toBeGreaterThan(order.indexOf('chat-done'));
+  });
+
+  test('reports the turn as failed rather than successful', async () => {
+    const sent = await drain([assistant(SPEND_LIMIT, { isApiErrorMessage: true })]);
+    const end = sent.find(s => s.ch === 'lifecycle:end');
+    expect(end.data.status).toBe('error');
+    expect(end.data.error).toBe(SPEND_LIMIT);
+  });
+
+  test('leaves an ordinary reply about spend limits alone', async () => {
+    const sent = await drain([
+      assistant('The spend limit banner should read "session limit resets 5:20pm".'),
+      okResult,
+    ]);
+    expect(limits(sent)).toHaveLength(0);
+    expect(sent.find(s => s.ch === 'lifecycle:end').data.status).toBe('success');
+  });
+
+  test('leaves a plain assistant turn alone', async () => {
+    const sent = await drain([assistant('Done — the refactor is in.'), okResult]);
+    expect(limits(sent)).toHaveLength(0);
+  });
+});

--- a/tests/services/chatSpendLimit.test.js
+++ b/tests/services/chatSpendLimit.test.js
@@ -129,6 +129,48 @@ describe('spend limit reported in-band', () => {
     expect(sent.find(s => s.ch === 'lifecycle:end').data.status).toBe('success');
   });
 
+  // The shape the current SDK actually sends: a typed code on the frame
+  // (SDKAssistantMessageError), not the flag. Handled in the same branch as the
+  // flag — testing `message.error` first in its own branch is what used to make
+  // the whole detection unreachable for exactly this case.
+  test.each([
+    ['billing_error', 'a spend cap'],
+    ['rate_limit', 'a rate limit'],
+    ['account_on_hold', 'an account on hold'],
+  ])('offers the account switch on the typed %s code', async (code) => {
+    const sent = await drain([assistant(SPEND_LIMIT, { error: code }), okResult]);
+    expect(limits(sent)).toHaveLength(1);
+    expect(limits(sent)[0].data.activeAccountId).toBe('acc-max');
+  });
+
+  test.each([
+    ['invalid_request', 'a malformed request'],
+    ['overloaded', 'an overloaded upstream'],
+  ])('leaves %s alone — another account would not help', async (code) => {
+    // No result: the turn ends on the failure, so the reported outcome is it.
+    const sent = await drain([assistant('API Error: 400', { error: code })]);
+    expect(limits(sent)).toHaveLength(0);
+    expect(sent.find(s => s.ch === 'lifecycle:end').data.error).toBe(`API error: ${code}`);
+  });
+
+  test('leaves an ordinary reply that explains someone else’s rate limit alone', async () => {
+    // Opens exactly like the CLI's banner, but the limit is GitHub's.
+    const sent = await drain([
+      assistant("You've hit your rate limit for the GitHub API — wait 60s before retrying."),
+      okResult,
+    ]);
+    expect(limits(sent)).toHaveLength(0);
+    expect(sent.find(s => s.ch === 'lifecycle:end').data.status).toBe('success');
+  });
+
+  test('leaves a reply that merely mentions /usage-credits alone', async () => {
+    const sent = await drain([
+      assistant('You can run /usage-credits to see what is left on the org plan.'),
+      okResult,
+    ]);
+    expect(limits(sent)).toHaveLength(0);
+  });
+
   test('leaves a plain assistant turn alone', async () => {
     const sent = await drain([assistant('Done — the refactor is in.'), okResult]);
     expect(limits(sent)).toHaveLength(0);


### PR DESCRIPTION
Fixes #153

## The defect

A spend or session cap does not throw. The CLI answers the turn with an ordinary
assistant message carrying the failure as text and a flag, and leaves the stream
open. `chat-account-limit` — the event that opens the switch modal — was emitted
only from the `catch` of `_processStream`, so it never fired for this shape.

Nothing then breaks the loop: the tab keeps the process it was spawned with,
that process keeps the credential directory of the account that ran out
(`accountEnv` is resolved once, at spawn), and every retry hits the same wall.
Quitting the app was the only way through. The issue has the transcript.

## The change

The recovery machinery already existed and already worked. This only feeds it
the one event it was never given.

- **`ChatService._processStream`** recognises the in-band shape and routes it
  into the same `chat-account-limit` event.
- **Both spellings of the flag count.** The CLI carries it as
  `isApiErrorMessage` internally, which is what lands in the
  `~/.claude/projects` transcript, and serialises it to stream-json as
  `is_api_error_message`. Accepting only one is how a rename turns this back
  into the same bug.
- **A text fallback** on the CLI's own phrasing, for when neither survives —
  anchored through `isCliFailureText` so Claude *discussing* a spend limit stays
  an ordinary reply. That guard also stops the sentence becoming a tab name,
  which it previously could.
- **Raised once the turn has settled, never mid-turn.** Acting on it closes the
  session, and `ChatView`'s `onDone` would otherwise stamp an interrupted marker
  across the transcript and stop the spinner the restart has just started —
  hence the small `switchingAccount` guard there, matching the one `onError`
  already has.
- **`_isUsageLimitError` learns the spend-cap vocabulary**, which shares not one
  word with the rate-limit patterns it had.
- The turn is now reported to lifecycle consumers as an error rather than a
  success, which the unread flag had been hiding.

## Tests

`tests/services/chatSpendLimit.test.js` drives `_processStream` over a fake
stream, using the message recorded in the real transcript. Ten cases: both flag
spellings, the unflagged fallback, the unbound-session default account, the
ordering guarantee, the no-result path, the lifecycle status, and two
negatives — an ordinary reply *about* spend limits, and a plain turn.

One of those negatives caught a false positive in the fallback's first draft
(`session limit resets` matched inside a sentence quoting the error), which is
why the patterns are anchored.

```
Test Suites: 105 passed, 105 total
Tests:       2591 passed, 2591 total
```

Renderer rebuilt (`node scripts/build-renderer.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
