### PR TITLE
fix(chat): restore artifact action buttons (Copy / Save as / Open in editor)

### DIFF
--- a/src/renderer/ui/components/ChatView.js
+++ b/src/renderer/ui/components/ChatView.js
@@ -4750,7 +4750,7 @@ class ChatView extends BaseComponent {
   artifactHeadEl.addEventListener('click', async (e) => {
     const btn = e.target.closest('.chat-artifact-action');
     if (!btn) return;
-    const artifact = artifactRegistry.get(artifactPaneEl.dataset.artifactId);
+    const artifact = artifactRegistry.get(artifactViewEl.dataset.artifactId);
     if (!artifact) return;
 
     switch (btn.dataset.action) {


### PR DESCRIPTION
## Summary
- The artifact pane's click handler for Copy / Save as... / Open in editor still read a stale `artifactPaneEl` reference left over from its rename to `artifactViewEl`, throwing a `ReferenceError` before the switch statement ran
- All three buttons silently no-op on click as a result
- Fixes #157

## Test plan
- [x] `node scripts/build-renderer.js` succeeds
- [ ] Open an artifact in the Documents tab, click Copy / Save as... / Open in editor, confirm each works