### PR TITLE
fix(usage): make the topbar refresh gesture re-read credentials, not just the API

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -6834,10 +6834,11 @@ function updateResetEl(el, target) {
  * Fetch and update usage.
  *
  * `force` re-reads the account's credential store instead of trusting the
- * cached OAuth token, so a deliberate refresh (a click, or the bars following
- * a rebind) can notice an account swapped outside the app — a `claude /login`
- * run straight in a terminal — instead of showing the outgoing account's
- * numbers until the token cache expires on its own, up to 6h later.
+ * cached OAuth token, so an explicit refresh can notice an account swapped
+ * outside the app — a `claude /login` run straight in a terminal — instead of
+ * showing the outgoing account's numbers until the token cache expires on its
+ * own, up to 6h later. It costs a Keychain prompt on macOS, so only the chip
+ * click sets it; everything automatic stays on the cached token.
  *
  * @param {boolean} [force]
  */
@@ -6882,6 +6883,12 @@ if (usageElements.container) {
 
   // Click to refresh — forced, so it also recovers from an account swapped
   // outside the app instead of replaying the cached token.
+  //
+  // This is the one place that pays for a store re-read: on macOS that is a
+  // Keychain prompt. It is confined to this gesture because a click is the
+  // user explicitly asking for current numbers, the window is focused so the
+  // prompt appears in front of them rather than behind, and without it there
+  // is no way back from a swapped account short of restarting the app.
   usageElements.container.addEventListener('click', () => {
     refreshUsageDisplay(true);
   });
@@ -6926,10 +6933,14 @@ if (usageElements.container) {
     // the new ones are in flight.
     renderUsageBuckets(PLACEHOLDER_USAGE_BUCKETS);
     api.usage.setFocus(next).catch(() => {});
-    // Forced: the target account may have last been fetched (for another
-    // project bound to it) before its store was swapped outside the app, and
-    // the fetch key changing is itself a deliberate action, not a poll tick.
-    refreshUsageDisplay(true);
+    // Deliberately NOT forced. This runs on every project tab switch, and on
+    // macOS every credential store — the machine-wide one and each account's
+    // namespaced entry alike — is a Keychain read, so forcing here would raise
+    // a password prompt each time the front tab moved between two accounts.
+    // An account fetched for the first time reads its store anyway, so the
+    // only case this misses is one whose numbers were already cached before
+    // its store was swapped outside the app — which the chip click recovers.
+    refreshUsageDisplay();
   };
 
   try {

--- a/renderer.js
+++ b/renderer.js
@@ -6831,16 +6831,24 @@ function updateResetEl(el, target) {
 }
 
 /**
- * Fetch and update usage
+ * Fetch and update usage.
+ *
+ * `force` re-reads the account's credential store instead of trusting the
+ * cached OAuth token, so a deliberate refresh (a click, or the bars following
+ * a rebind) can notice an account swapped outside the app — a `claude /login`
+ * run straight in a terminal — instead of showing the outgoing account's
+ * numbers until the token cache expires on its own, up to 6h later.
+ *
+ * @param {boolean} [force]
  */
-async function refreshUsageDisplay() {
+async function refreshUsageDisplay(force = false) {
   if (!usageElements.container) return;
 
   usageElements.container.classList.add('loading');
 
   try {
     const requested = usageAccountId;
-    const result = await api.usage.refresh(requested);
+    const result = await api.usage.refresh(requested, force);
     // Tabs can be switched mid-flight; a late answer for the account we left
     // must not repaint the bars.
     if (requested !== usageAccountId) return;
@@ -6872,9 +6880,10 @@ if (usageElements.container) {
   // Bars the API has not described yet, so the titlebar is not empty on boot.
   renderUsageBuckets(PLACEHOLDER_USAGE_BUCKETS);
 
-  // Click to refresh
+  // Click to refresh — forced, so it also recovers from an account swapped
+  // outside the app instead of replaying the cached token.
   usageElements.container.addEventListener('click', () => {
-    refreshUsageDisplay();
+    refreshUsageDisplay(true);
   });
 
   // Start periodic monitoring (every 60 seconds)
@@ -6917,7 +6926,10 @@ if (usageElements.container) {
     // the new ones are in flight.
     renderUsageBuckets(PLACEHOLDER_USAGE_BUCKETS);
     api.usage.setFocus(next).catch(() => {});
-    refreshUsageDisplay();
+    // Forced: the target account may have last been fetched (for another
+    // project bound to it) before its store was swapped outside the app, and
+    // the fetch key changing is itself a deliberate action, not a poll tick.
+    refreshUsageDisplay(true);
   };
 
   try {

--- a/src/main/ipc/usage.ipc.js
+++ b/src/main/ipc/usage.ipc.js
@@ -37,9 +37,15 @@ function registerUsageHandlers() {
   // resolved promise is NOT proof the numbers are current — ask the service
   // whether the fetch actually succeeded before reporting success. Otherwise an
   // expired OAuth token or a moved endpoint shows the same percentages forever.
-  ipcMain.handle('refresh-usage', async (_event, accountId = null) => {
+  //
+  // `force` re-reads the credential store instead of trusting the cached
+  // token, so the explicit refresh gesture picks up an account swapped
+  // outside the app (a manual `claude /login`) instead of serving the
+  // outgoing account's numbers for up to 6h. Passive polling never sets it,
+  // so it stays exempt from the Keychain-read cost that cache exists to avoid.
+  ipcMain.handle('refresh-usage', async (_event, accountId = null, force = false) => {
     try {
-      const data = await usageService.refreshUsage(accountId);
+      const data = await usageService.refreshUsage(accountId, force);
       const fetchState = typeof usageService.getFetchState === 'function'
         ? usageService.getFetchState(accountId)
         : null;

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -718,7 +718,7 @@ contextBridge.exposeInMainWorld('electron_api', {
   // ==================== USAGE ====================
   usage: {
     getData: (accountId = null) => ipcRenderer.invoke('get-usage-data', accountId),
-    refresh: (accountId = null) => ipcRenderer.invoke('refresh-usage', accountId),
+    refresh: (accountId = null, force = false) => ipcRenderer.invoke('refresh-usage', accountId, force),
     setFocus: (accountId = null) => ipcRenderer.invoke('set-usage-focus', accountId),
     startMonitor: (intervalMs) => ipcRenderer.invoke('start-usage-monitor', intervalMs),
     stopMonitor: () => ipcRenderer.invoke('stop-usage-monitor'),

--- a/src/main/services/UsageService.js
+++ b/src/main/services/UsageService.js
@@ -100,12 +100,16 @@ function readCredentialsFor(accountId) {
  * macOS Keychain on darwin, ~/.claude/.credentials.json elsewhere.
  *
  * @param {string|null} accountId
+ * @param {boolean} [force] - skip the cache and re-read the store, for the
+ *   explicit "refresh" gesture: a credential change made outside the app
+ *   (`claude /login` in a terminal) leaves the cached token valid but wrong,
+ *   and only a disk/Keychain re-read can tell the two apart.
  * @returns {Promise<string|null>}
  */
-async function readOAuthToken(accountId) {
+async function readOAuthToken(accountId, force = false) {
   const entry = entryFor(accountId);
   const now = Date.now();
-  if (now < entry.tokenCacheUntil) return entry.tokenCache;
+  if (!force && now < entry.tokenCacheUntil) return entry.tokenCache;
 
   let token = null;
   let expiresAt = null;
@@ -296,16 +300,19 @@ function fetchUsageFromAPI(token) {
  * Fetch usage data from the OAuth API.
  * There is no second source (the PTY fallback was removed), so a failed fetch
  * marks the cached data stale rather than silently passing it off as fresh.
+ * @param {string|null} accountId
+ * @param {boolean} [force] - re-read the credential store instead of trusting
+ *   the cached token; see readOAuthToken().
  * @returns {Promise<Object|null>}
  */
-async function fetchUsage(accountId) {
+async function fetchUsage(accountId, force = false) {
   const entry = entryFor(accountId);
   if (entry.isFetching) return entry.usageData;
   entry.isFetching = true;
 
   try {
     // Try OAuth API first
-    const token = await readOAuthToken(entry.accountId);
+    const token = await readOAuthToken(entry.accountId, force);
     if (token) {
       try {
         const data = await fetchUsageFromAPI(token);
@@ -430,12 +437,19 @@ function getFetchState(accountId) {
 }
 
 /**
- * Force refresh
+ * Force refresh.
+ *
+ * `force` re-reads the credential store rather than trusting the cached
+ * token — without it, this only re-ran the API call, so the explicit refresh
+ * gesture could not notice an account swapped outside the app (`claude
+ * /login` in a terminal for a bound project's own store, or for the
+ * machine-wide one) until the token cache expired on its own, up to 6h later.
  * @param {string|null} [accountId]
+ * @param {boolean} [force]
  * @returns {Promise<Object>}
  */
-function refreshUsage(accountId) {
-  return fetchUsage(accountId);
+function refreshUsage(accountId, force = false) {
+  return fetchUsage(accountId, force);
 }
 
 /**

--- a/src/main/services/UsageService.js
+++ b/src/main/services/UsageService.js
@@ -103,7 +103,9 @@ function readCredentialsFor(accountId) {
  * @param {boolean} [force] - skip the cache and re-read the store, for the
  *   explicit "refresh" gesture: a credential change made outside the app
  *   (`claude /login` in a terminal) leaves the cached token valid but wrong,
- *   and only a disk/Keychain re-read can tell the two apart.
+ *   and only a re-read can tell the two apart. Reserved for that gesture —
+ *   on darwin both stores are Keychain entries, so every forced read is a
+ *   password prompt, which is the whole reason the cache above is that long.
  * @returns {Promise<string|null>}
  */
 async function readOAuthToken(accountId, force = false) {

--- a/tests/ipc/usage.ipc.test.js
+++ b/tests/ipc/usage.ipc.test.js
@@ -98,8 +98,17 @@ describe('refresh-usage', () => {
 
     const result = await handlers['refresh-usage']({}, 'acct-team');
 
-    expect(mockUsageService.refreshUsage).toHaveBeenCalledWith('acct-team');
+    expect(mockUsageService.refreshUsage).toHaveBeenCalledWith('acct-team', false);
     expect(result).toEqual({ success: true, data: mockData, accountId: 'acct-team' });
+  });
+
+  test('forwards a forced refresh, so a credential swap made outside the app is not hidden by the cached token', async () => {
+    const mockData = { dailyUsage: 12, maxDaily: 100 };
+    mockUsageService.refreshUsage.mockResolvedValue(mockData);
+
+    await handlers['refresh-usage']({}, 'acct-team', true);
+
+    expect(mockUsageService.refreshUsage).toHaveBeenCalledWith('acct-team', true);
   });
 
   test('returns error on service failure', async () => {


### PR DESCRIPTION
## Summary

- Fixes https://github.com/Sterll/claude-terminal/issues/159 — the usage topbar can keep showing a previous account's numbers after switching accounts outside the in-app switcher (e.g. running `claude /login` in a project's terminal), and clicking the usage chip to refresh does not recover from it.
- `UsageService.readOAuthToken()` caches the OAuth token per account for up to 6h to avoid raising a macOS Keychain prompt on every poll tick. That cache is only cleared by `invalidateCredentials()`, called solely from the in-app `accounts-switch` flow — so an out-of-app credential swap is invisible to it, and `refreshUsage()` never bypassed the cache either, so even an explicit refresh replayed the stale token.
- Adds a `force` flag threaded from the renderer down to `readOAuthToken()`, where it skips the cache and re-reads the store.

## Where `force` is set — and where it deliberately is not

**Only the usage chip click sets it.** On darwin every credential store is a Keychain entry — the machine-wide one via `KEYCHAIN_SERVICE`, each bound account via `keychainServiceForDir()`, with the plaintext seed only a bootstrap that `pruneSeedForDir()` removes once the Keychain entry exists. So a forced read is a password prompt, and anything automatic must not set it:

| path | forced | why |
|---|---|---|
| usage chip click | yes | explicit "give me current numbers"; window is focused, so the prompt appears in front, and it is the only way back from a swapped account short of restarting |
| `syncUsageAccount()` (project tab switch / rebind) | no | fires on every tab switch; forcing here would prompt each time the front tab moved between two accounts. A first-time account reads its store anyway, so this only misses an account cached *before* its store was swapped — which the click recovers |
| 60s monitor, 30s fallback poll, boot fetch | no | the exact ticks `TOKEN_CACHE_MAX` exists to keep quiet |

## Test plan

- [x] `npx jest` — full suite (2582 tests) passes.
- [x] `npx jest tests/ipc/usage.ipc.test.js tests/ipc/accountsUsage.ipc.test.js` — updated the existing assertion for the new `force` argument and added one asserting it forwards correctly.
- [x] `node scripts/build-renderer.js` — renderer bundle builds clean.
- [x] Verified by inspection that exactly one `refreshUsageDisplay()` call site passes `true`.