### PR TITLE
fix(chat): keep the message typed during an account switch

### DIFF
--- a/src/main/services/ChatService.js
+++ b/src/main/services/ChatService.js
@@ -865,6 +865,18 @@ class ChatService {
     }
 
     try {
+      // Held until the CLI says it has written this message down. The
+      // account-switch offer leaves the composer usable, so a message can
+      // still be waiting in the queue — or be mid-flight — when the switch
+      // aborts the process, and nothing of it has reached the transcript at
+      // that point; prepareSwitchAccount hands those back to be sent again.
+      //
+      // A list, not a slot: two messages can be typed while the offer is on
+      // screen, and the second overwriting the first is how the first
+      // disappeared.
+      (session.pendingUserMessages ||= []).push({
+        text, images, mentions, userMessageUuid: userMessageUuid || null,
+      });
       session.messageQueue.push({
         type: 'user',
         message: { role: 'user', content: this._buildContent(text, images, mentions, documents) },
@@ -1549,6 +1561,8 @@ class ChatService {
         // flagged `is_error` or carrying an error subtype. Fork-guard refusals
         // never reach this point (`continue` above) — the renderer auto-resumes
         // those, so they are not a session outcome.
+        if (message.type === 'assistant') this._ackUserMessages(session, message);
+
         if (message.type === 'assistant' && (message.error || isApiErrorMessage(message))) {
           // An in-band failure: the CLI answers the turn with an ordinary
           // assistant message reporting the error, and leaves the stream open —
@@ -1580,6 +1594,12 @@ class ChatService {
             pendingAccountLimit = text;
           }
         } else if (message.type === 'result') {
+          // Older producers do not stamp the prompt uuid on their replies, so a
+          // closed turn is the only acknowledgement they give. Sessions that do
+          // stamp are left alone here: a message queued *behind* the turn that
+          // just closed has not been written down yet, and clearing it would
+          // lose it.
+          if (session && !session.stampsUserMessageUuids) session.pendingUserMessages = [];
           if (message.is_error || message.subtype !== 'success') {
             const errors = Array.isArray(message.errors) ? message.errors.filter(Boolean) : [];
             inbandError = errors.join('\n')
@@ -1709,12 +1729,43 @@ class ChatService {
    * it (with `resumeSessionId`) under freshly swapped credentials. Returns the
    * cwd / projectId / model context the caller should reuse.
    */
+  /**
+   * Drop the pending messages the CLI has just acknowledged.
+   *
+   * `user_message_uuid` is stamped on the first reply frame of the turn that
+   * consumed a prompt (and `user_message_uuids` on a batch the host merged into
+   * one turn). That stamp is the one reliable "this is written down": once it
+   * lands the message is in the transcript, a resume brings it back, and
+   * sending it again would post it twice.
+   *
+   * Which is what used to happen. The clear was on the result message, and a
+   * usage limit refused mid-turn throws instead of producing one — so the very
+   * message that caused the limit survived as pending and was replayed on top
+   * of a resume that already held it.
+   */
+  _ackUserMessages(session, message) {
+    if (!session) return;
+    const ids = Array.isArray(message.user_message_uuids) && message.user_message_uuids.length
+      ? message.user_message_uuids
+      : (message.user_message_uuid ? [message.user_message_uuid] : []);
+    if (!ids.length) return;
+    session.stampsUserMessageUuids = true;
+    if (!session.pendingUserMessages?.length) return;
+    session.pendingUserMessages = session.pendingUserMessages
+      .filter(m => !ids.includes(m.userMessageUuid));
+  }
+
   prepareSwitchAccount(sessionId) {
     const session = this.sessions.get(sessionId);
     const ctx = session ? {
       cwd: session.cwd || null,
       projectId: session.projectId || null,
       accountId: session.accountId || null,
+      // Messages still waiting on a turn: closeSession is about to abort the
+      // process out from under them, and the resume that follows only brings
+      // back what the CLI wrote down. Handed to the caller so the restart can
+      // send them rather than let them disappear with the account.
+      pendingUserMessages: session.pendingUserMessages || [],
     } : null;
     this.closeSession(sessionId);
     return ctx;

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -3829,6 +3829,7 @@
     "switched": "Account switched. Resuming…",
     "switchedNoResume": "Account switched. The previous conversation could not be resumed — continuing without its context.",
     "switchedResent": "Account switched. The previous conversation was never saved, so your message is being sent again on the new account.",
+    "switchedQueuedResent": "Account switched. Your last message never reached the previous account, so it is being sent again.",
     "removeConfirm": "Remove this saved account? The credentials will be deleted from local storage.",
     "switchError": "Failed to switch account",
     "renameError": "Failed to rename account",

--- a/src/renderer/i18n/locales/es.json
+++ b/src/renderer/i18n/locales/es.json
@@ -3829,6 +3829,7 @@
     "switched": "Cuenta cambiada. Reanudando…",
     "switchedNoResume": "Cuenta cambiada. No se pudo reanudar la conversación anterior — se continúa sin su contexto.",
     "switchedResent": "Cuenta cambiada. La conversación anterior nunca se guardó, así que tu mensaje se envía de nuevo en la cuenta nueva.",
+    "switchedQueuedResent": "Cuenta cambiada. Tu último mensaje nunca llegó a la cuenta anterior, así que se envía de nuevo.",
     "removeConfirm": "¿Eliminar esta cuenta guardada? Las credenciales se borrarán del almacenamiento local.",
     "switchError": "No se pudo cambiar de cuenta",
     "renameError": "No se pudo renombrar la cuenta",

--- a/src/renderer/i18n/locales/fr.json
+++ b/src/renderer/i18n/locales/fr.json
@@ -3829,6 +3829,7 @@
     "switched": "Compte changé. Reprise…",
     "switchedNoResume": "Compte changé. La conversation précédente n'a pas pu être reprise — la suite se fera sans son contexte.",
     "switchedResent": "Compte changé. La conversation précédente n'a jamais été enregistrée : votre message est renvoyé sur le nouveau compte.",
+    "switchedQueuedResent": "Compte changé. Votre dernier message n'est jamais parti sur le compte précédent : il est renvoyé.",
     "removeConfirm": "Supprimer ce compte enregistré ? Les identifiants seront effacés du stockage local.",
     "switchError": "Impossible de changer de compte",
     "renameError": "Impossible de renommer le compte",

--- a/src/renderer/i18n/locales/id.json
+++ b/src/renderer/i18n/locales/id.json
@@ -3829,6 +3829,7 @@
     "switched": "Akun diganti. Melanjutkan…",
     "switchedNoResume": "Akun diganti. Percakapan sebelumnya tidak bisa dilanjutkan — dilanjutkan tanpa konteksnya.",
     "switchedResent": "Akun diganti. Percakapan sebelumnya tidak pernah tersimpan, jadi pesan Anda dikirim ulang di akun baru.",
+    "switchedQueuedResent": "Akun diganti. Pesan terakhir Anda tidak pernah sampai ke akun sebelumnya, jadi dikirim ulang.",
     "removeConfirm": "Hapus akun tersimpan ini? Kredensialnya akan dihapus dari penyimpanan lokal.",
     "switchError": "Gagal mengganti akun",
     "renameError": "Gagal mengganti nama akun",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -3829,6 +3829,7 @@
     "switched": "账号已切换。正在恢复…",
     "switchedNoResume": "账号已切换。无法恢复之前的对话 — 将在缺少其上下文的情况下继续。",
     "switchedResent": "账号已切换。之前的对话从未保存，因此你的消息将在新账号上重新发送。",
+    "switchedQueuedResent": "账号已切换。你的最后一条消息从未发送到之前的账号，因此将重新发送。",
     "removeConfirm": "删除这个已保存的账户吗？凭据将从本地存储中删除。",
     "switchError": "切换账号失败",
     "renameError": "账户重命名失败",

--- a/src/renderer/ui/components/ChatView.js
+++ b/src/renderer/ui/components/ChatView.js
@@ -7950,36 +7950,48 @@ class ChatView extends BaseComponent {
       // fork's truncation point goes too: it names a message of the session
       // being resumed, not of the fork that came out of it.
       //
-      // Whether the opening turn rides along depends on whether it survived
-      // anywhere. With a session to resume it is already on disk, and sending it
-      // again would post it twice. Without one it exists nowhere but the bubble
-      // on screen — a limit refused before the SDK's init message means no
-      // session file was ever written — so the restart has to carry it or the
-      // prompt dies with the account that refused it. Its uuid goes along to keep
-      // that bubble matching the message that finally gets recorded.
-      const replayOpeningTurn = !realSid;
+      // Two different things can need re-sending, and only one of them applies
+      // at a time.
+      //
+      // Messages the CLI never wrote down. The offer leaves the composer
+      // usable, so a follow-up can be sent while it is on screen and still be
+      // waiting when the switch aborts the process. Main hands those back — and
+      // only those: anything the CLI acknowledged is in the transcript the
+      // resume brings back, so replaying it would post it twice.
+      //
+      // The opening turn, when there is no session to resume at all. A limit
+      // refused before the SDK's init message means no session file was ever
+      // written, so that turn exists nowhere but the bubble on screen.
+      //
+      // Their uuids ride along so the bubbles already on screen stay matched to
+      // the messages that finally get recorded.
+      const queued = prep.context?.pendingUserMessages || [];
+      const replayOpeningTurn = !realSid && queued.length === 0;
+      const first = queued[0] || (replayOpeningTurn ? lastStartOpts : null);
       const restartOpts = {
         ...lastStartOpts,
         accountId: newId,
-        prompt: replayOpeningTurn ? (lastStartOpts.prompt || '') : '',
-        images: replayOpeningTurn ? (lastStartOpts.images || []) : [],
-        mentions: replayOpeningTurn ? (lastStartOpts.mentions || []) : [],
-        userMessageUuid: replayOpeningTurn ? (lastStartOpts.userMessageUuid || null) : null,
+        prompt: first?.prompt ?? first?.text ?? '',
+        images: first?.images || [],
+        mentions: first?.mentions || [],
+        userMessageUuid: first?.userMessageUuid || null,
         forkSession: false,
         resumeSessionAt: null,
         resumeDropsTurn: null,
         resumeSessionId: realSid || null,
       };
-      // An opening turn that carried nothing leaves the restart with nothing to
-      // send: the session comes up idle, waiting for the user to type.
-      const replayed = replayOpeningTurn && Boolean(
+      // A restart with nothing to send comes up idle, waiting for the user to
+      // type — so nothing should be spinning at it.
+      const replayed = Boolean(
         (restartOpts.prompt || '').trim() || restartOpts.images.length || restartOpts.mentions.length
       );
-      const notice = realSid
-        ? (t('accounts.switched') || 'Account switched. Resuming…')
-        : replayed
-          ? (t('accounts.switchedResent') || 'Account switched. The previous conversation was never saved, so your message is being sent again on the new account.')
-          : (t('accounts.switchedNoResume') || 'Account switched. The previous conversation could not be resumed — continuing without its context.');
+      const notice = queued.length
+        ? (t('accounts.switchedQueuedResent') || 'Account switched. Your last message never reached the previous account, so it is being sent again.')
+        : realSid
+          ? (t('accounts.switched') || 'Account switched. Resuming…')
+          : replayed
+            ? (t('accounts.switchedResent') || 'Account switched. The previous conversation was never saved, so your message is being sent again on the new account.')
+            : (t('accounts.switchedNoResume') || 'Account switched. The previous conversation could not be resumed — continuing without its context.');
       appendSystemNotice(notice, 'info');
       // Only wait on a turn the SDK will actually run: with nothing queued the
       // spinner would sit there for the life of the tab.
@@ -7991,6 +8003,20 @@ class ChatView extends BaseComponent {
       if (!res.success) {
         appendError(res.error || t('chat.errorOccurred'));
         setStreaming(false);
+      } else {
+        // A restart carries one prompt. Anything else that was still queued
+        // goes back on the new session in the order it was typed, rather than
+        // being dropped for being second.
+        for (const m of queued.slice(1)) {
+          const sent = await api.chat.send({
+            sessionId,
+            text: m.text,
+            images: m.images || [],
+            mentions: m.mentions || [],
+            userMessageUuid: m.userMessageUuid || null,
+          });
+          if (!sent.success) appendError(sent.error || t('chat.errorOccurred'));
+        }
       }
     } finally {
       switchingAccount = false;

--- a/tests/services/chatAccountSwitchQueue.test.js
+++ b/tests/services/chatAccountSwitchQueue.test.js
@@ -63,7 +63,8 @@ describe('account switch with a message still in flight', () => {
 
     const ctx = chatService.prepareSwitchAccount(SID);
 
-    expect(ctx.pendingUserMessage).toMatchObject({
+    expect(ctx.pendingUserMessages).toHaveLength(1);
+    expect(ctx.pendingUserMessages[0]).toMatchObject({
       text: 'and now the tests', userMessageUuid: 'uuid-1',
     });
   });
@@ -76,20 +77,87 @@ describe('account switch with a message still in flight', () => {
 
     const ctx = chatService.prepareSwitchAccount(SID);
 
-    expect(ctx.pendingUserMessage.images).toEqual(images);
-    expect(ctx.pendingUserMessage.mentions).toEqual(mentions);
+    expect(ctx.pendingUserMessages[0].images).toEqual(images);
+    expect(ctx.pendingUserMessages[0].mentions).toEqual(mentions);
   });
 
-  test('hands back nothing once the turn has reported a result', async () => {
+  // The CLI stamps the prompt's uuid on the turn's first reply frame. That is
+  // the acknowledgement that it has been written down, and it is what a usage
+  // limit refused mid-turn never gets to a result for.
+  test('drops a message the CLI acknowledged by uuid', async () => {
     openSession();
     chatService.sendMessage(SID, 'answered already', [], [], 'uuid-3');
+    await chatService._processStream(SID, (async function* () {
+      yield { type: 'assistant', user_message_uuid: 'uuid-3', message: { role: 'assistant', content: [] } };
+    })());
+
+    expect(chatService.prepareSwitchAccount(SID).pendingUserMessages).toEqual([]);
+  });
+
+  test('drops every member of an acknowledged batch', async () => {
+    openSession();
+    chatService.sendMessage(SID, 'first', [], [], 'uuid-a');
+    chatService.sendMessage(SID, 'second', [], [], 'uuid-b');
+    await chatService._processStream(SID, (async function* () {
+      yield {
+        type: 'assistant', user_message_uuid: 'uuid-b',
+        user_message_uuids: ['uuid-a', 'uuid-b'],
+        message: { role: 'assistant', content: [] },
+      };
+    })());
+
+    expect(chatService.prepareSwitchAccount(SID).pendingUserMessages).toEqual([]);
+  });
+
+  // The bug this file exists for, in its original form: the limit throws, so no
+  // result ever arrives, and the message that caused it used to survive as
+  // pending — then get replayed on top of a resume that already held it.
+  test('does not hand back a message the CLI answered before the stream died', async () => {
+    openSession();
+    chatService.sendMessage(SID, 'refais le tri', [], [], 'uuid-5');
+    await chatService._processStream(SID, (async function* () {
+      yield { type: 'assistant', user_message_uuid: 'uuid-5', message: { role: 'assistant', content: [] } };
+      throw new Error('Claude Code process exited with code 1');
+    })());
+
+    expect(chatService.prepareSwitchAccount(SID).pendingUserMessages).toEqual([]);
+  });
+
+  // Two follow-ups typed while the offer is on screen: the second used to
+  // overwrite the first, which then vanished without a trace.
+  test('keeps both messages when two are queued', () => {
+    openSession();
+    chatService.sendMessage(SID, 'first', [], [], 'uuid-x');
+    chatService.sendMessage(SID, 'second', [], [], 'uuid-y');
+
+    expect(chatService.prepareSwitchAccount(SID).pendingUserMessages.map(m => m.text))
+      .toEqual(['first', 'second']);
+  });
+
+  // A message queued behind the turn that just closed has not been written
+  // down, so a result must not clear it on a session that stamps uuids.
+  test('a result does not clear a message the turn never consumed', async () => {
+    openSession();
+    chatService.sendMessage(SID, 'turn A', [], [], 'uuid-A');
+    chatService.sendMessage(SID, 'turn B', [], [], 'uuid-B');
+    await chatService._processStream(SID, (async function* () {
+      yield { type: 'assistant', user_message_uuid: 'uuid-A', message: { role: 'assistant', content: [] } };
+      yield { type: 'result', subtype: 'success', is_error: false };
+    })());
+
+    expect(chatService.prepareSwitchAccount(SID).pendingUserMessages.map(m => m.text))
+      .toEqual(['turn B']);
+  });
+
+  // An older producer stamps nothing, so a closed turn is all it gives us.
+  test('falls back to the result when the producer stamps no uuid', async () => {
+    openSession();
+    chatService.sendMessage(SID, 'answered already', [], [], 'uuid-6');
     await chatService._processStream(SID, (async function* () {
       yield { type: 'result', subtype: 'success', is_error: false };
     })());
 
-    const ctx = chatService.prepareSwitchAccount(SID);
-
-    expect(ctx.pendingUserMessage).toBeNull();
+    expect(chatService.prepareSwitchAccount(SID).pendingUserMessages).toEqual([]);
   });
 
   // An error result is still an answer: the renderer showed it and the CLI
@@ -103,12 +171,12 @@ describe('account switch with a message still in flight', () => {
 
     const ctx = chatService.prepareSwitchAccount(SID);
 
-    expect(ctx.pendingUserMessage).toBeNull();
+    expect(ctx.pendingUserMessages).toEqual([]);
   });
 
   test('hands back nothing when nothing was ever sent', () => {
     openSession();
-    expect(chatService.prepareSwitchAccount(SID).pendingUserMessage).toBeNull();
+    expect(chatService.prepareSwitchAccount(SID).pendingUserMessages).toEqual([]);
   });
 
   test('still carries the context the restart is spawned with', () => {

--- a/tests/services/chatAccountSwitchQueue.test.js
+++ b/tests/services/chatAccountSwitchQueue.test.js
@@ -1,0 +1,127 @@
+/**
+ * A message sent while the account-switch offer is up must survive the switch.
+ *
+ * The offer leaves the session running, so the composer stays usable: what the
+ * user types next goes into the live queue and waits its turn. The switch then
+ * aborts that process, and the resume that follows only brings back what the
+ * CLI wrote down — which is everything except the message that never got its
+ * turn. It used to disappear there, silently, which reads as the whole
+ * conversation having failed to resume.
+ *
+ * So: whatever is still unanswered when the switch happens comes back out of
+ * `prepareSwitchAccount`, and anything already answered does not (sending that
+ * again would post it twice).
+ */
+
+jest.mock('electron', () => ({
+  app: { isPackaged: false, getAppPath: () => '/mock/app' },
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+jest.mock('child_process', () => ({
+  exec: jest.fn(), execSync: jest.fn(), execFileSync: jest.fn(() => ''),
+}));
+jest.mock('@anthropic-ai/claude-agent-sdk', () => ({}), { virtual: true });
+jest.mock('../../src/main/services/AccountManager', () => ({
+  listAccounts: jest.fn(async () => ({ accounts: [], defaultId: 'acc-default' })),
+}));
+
+const chatService = require('../../src/main/services/ChatService');
+
+const SID = 'chat-switch-1';
+
+/** Enough of a session for sendMessage / closeSession to run against. */
+function openSession(extra = {}) {
+  const pushed = [];
+  chatService.sessions.set(SID, {
+    cwd: '/work/project', projectId: 'p1', accountId: 'acc-max',
+    messageQueue: { push: msg => pushed.push(msg), close: () => {} },
+    ...extra,
+  });
+  return pushed;
+}
+
+// Own properties shadowing the prototype rather than jest.spyOn, which refuses
+// a method the object does not have: `_emitEvent` is one the fork adds and
+// upstream does not, and this suite has to run on both.
+const stubs = {
+  _send: () => {},
+  _emitEvent: () => {},
+  _emitMessage: () => {},
+  _flushDeltas: () => {},
+};
+
+beforeEach(() => Object.assign(chatService, stubs));
+afterEach(() => {
+  for (const key of Object.keys(stubs)) delete chatService[key];
+  chatService.sessions.delete(SID);
+});
+
+describe('account switch with a message still in flight', () => {
+  test('hands back the message that never got its turn', () => {
+    openSession();
+    chatService.sendMessage(SID, 'and now the tests', [], [], 'uuid-1');
+
+    const ctx = chatService.prepareSwitchAccount(SID);
+
+    expect(ctx.pendingUserMessage).toMatchObject({
+      text: 'and now the tests', userMessageUuid: 'uuid-1',
+    });
+  });
+
+  test('carries its images and mentions along', () => {
+    openSession();
+    const images = [{ base64: 'aGk=', mediaType: 'image/png' }];
+    const mentions = [{ label: 'README.md', content: '# hi' }];
+    chatService.sendMessage(SID, 'look at this', images, mentions, 'uuid-2');
+
+    const ctx = chatService.prepareSwitchAccount(SID);
+
+    expect(ctx.pendingUserMessage.images).toEqual(images);
+    expect(ctx.pendingUserMessage.mentions).toEqual(mentions);
+  });
+
+  test('hands back nothing once the turn has reported a result', async () => {
+    openSession();
+    chatService.sendMessage(SID, 'answered already', [], [], 'uuid-3');
+    await chatService._processStream(SID, (async function* () {
+      yield { type: 'result', subtype: 'success', is_error: false };
+    })());
+
+    const ctx = chatService.prepareSwitchAccount(SID);
+
+    expect(ctx.pendingUserMessage).toBeNull();
+  });
+
+  // An error result is still an answer: the renderer showed it and the CLI
+  // recorded the turn, so resending would post the message twice.
+  test('hands back nothing when the turn ended on an error result', async () => {
+    openSession();
+    chatService.sendMessage(SID, 'answered with an error', [], [], 'uuid-4');
+    await chatService._processStream(SID, (async function* () {
+      yield { type: 'result', subtype: 'error_max_turns', is_error: true, errors: ['nope'] };
+    })());
+
+    const ctx = chatService.prepareSwitchAccount(SID);
+
+    expect(ctx.pendingUserMessage).toBeNull();
+  });
+
+  test('hands back nothing when nothing was ever sent', () => {
+    openSession();
+    expect(chatService.prepareSwitchAccount(SID).pendingUserMessage).toBeNull();
+  });
+
+  test('still carries the context the restart is spawned with', () => {
+    openSession();
+    expect(chatService.prepareSwitchAccount(SID)).toMatchObject({
+      cwd: '/work/project', projectId: 'p1', accountId: 'acc-max',
+    });
+  });
+
+  test('closes the session either way', () => {
+    openSession();
+    chatService.sendMessage(SID, 'in flight', [], [], 'uuid-5');
+    chatService.prepareSwitchAccount(SID);
+    expect(chatService.sessions.has(SID)).toBe(false);
+  });
+});

--- a/tests/ui/chatAccountSwitch.test.js
+++ b/tests/ui/chatAccountSwitch.test.js
@@ -1,19 +1,23 @@
 /**
  * Account switch after a usage limit — what the restart carries.
  *
- * A limit refused before the SDK's init message leaves no session file behind,
- * so the opening turn exists nowhere but the bubble on screen: the restart has
- * to send it again or the prompt dies with the account that refused it. Once a
- * real session id exists the opposite holds — the turn is already on disk, and
- * re-sending it would post the same message twice.
+ * Almost nothing: the turn that opened the tab is already on disk, and sending
+ * it again would post the same message twice. The exception is a message the
+ * CLI never answered — the offer leaves the composer usable, so a follow-up can
+ * be sent while it is on screen and still be unanswered when the switch aborts
+ * the process. That one exists nowhere but the bubble on screen, so the restart
+ * has to carry it.
  */
 
 jest.mock('../../src/renderer/ui/components/AccountSwitchModal', () => ({
   showAccountSwitchModal: jest.fn(async () => 'acc-team'),
 }));
 
-/** api mock: `on*` captures its callback, everything else records the call. */
-function makeApiMock(listeners, calls) {
+/**
+ * api mock: `on*` captures its callback, everything else records the call and
+ * answers from `responses` (keyed `namespace.method`) or with a bare success.
+ */
+function makeApiMock(listeners, calls, responses = {}) {
   const ns = (namespace) => new Proxy({}, {
     get: (_t, method) => (...args) => {
       if (typeof method === 'string' && method.startsWith('on')) {
@@ -21,7 +25,7 @@ function makeApiMock(listeners, calls) {
         return () => {};
       }
       calls.push({ namespace, method, args });
-      return Promise.resolve({ success: true, messages: [] });
+      return Promise.resolve(responses[`${namespace}.${method}`] || { success: true, messages: [] });
     }
   });
   return new Proxy({}, { get: (_t, namespace) => ns(namespace) });
@@ -35,12 +39,21 @@ Object.defineProperty(global, 'crypto', {
 });
 
 describe('chat account switch', () => {
-  let listeners, calls, wrapper, view, sessionId;
+  let listeners, calls, wrapper, view, sessionId, responses;
 
   const flush = async () => { for (let i = 0; i < 5; i++) await new Promise(r => setTimeout(r, 0)); };
 
   /** The options of the last chat.start — the restart the switch fired. */
   const lastStart = () => [...calls].reverse().find(c => c.namespace === 'chat' && c.method === 'start')?.args[0];
+
+  /** Give the tab a real CLI session id, the way the SDK's first message does. */
+  const giveSessionId = () => listeners.onMessage({
+    sessionId,
+    message: {
+      type: 'assistant', session_id: 'real-uuid-1',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'hi' }] },
+    },
+  });
 
   const hitLimit = async () => {
     listeners.onAccountLimit({
@@ -53,7 +66,8 @@ describe('chat account switch', () => {
     jest.resetModules();
     listeners = {};
     calls = [];
-    window.electron_api = makeApiMock(listeners, calls);
+    responses = {};
+    window.electron_api = makeApiMock(listeners, calls, responses);
     document.body.innerHTML = '';
     wrapper = document.createElement('div');
     document.body.appendChild(wrapper);
@@ -70,24 +84,8 @@ describe('chat account switch', () => {
     try { view?.destroy?.(); } catch (_) { /* teardown is best effort */ }
   });
 
-  it('resends the opening turn when no session was ever written', async () => {
-    await hitLimit();
-
-    const restart = lastStart();
-    expect(restart.accountId).toBe('acc-team');
-    expect(restart.resumeSessionId).toBeNull();
-    // Without this the prompt is lost: nothing on disk to resume, nothing sent.
-    expect(restart.prompt).toBe('contexte Salim');
-  });
-
   it('resumes without resending once the SDK has given a session id', async () => {
-    listeners.onMessage({
-      sessionId,
-      message: {
-        type: 'assistant', session_id: 'real-uuid-1',
-        message: { role: 'assistant', content: [{ type: 'text', text: 'hi' }] },
-      },
-    });
+    giveSessionId();
 
     await hitLimit();
 
@@ -96,5 +94,26 @@ describe('chat account switch', () => {
     expect(restart.resumeSessionId).toBe('real-uuid-1');
     // The resumed transcript already holds it; sending it again would double it.
     expect(restart.prompt).toBe('');
+  });
+
+  it('resends a message that never got its turn, alongside the resume', async () => {
+    giveSessionId();
+    responses['chat.prepareSwitchAccount'] = {
+      success: true,
+      context: {
+        cwd: '/tmp/test', projectId: 'p1', accountId: 'acc-max',
+        pendingUserMessage: {
+          text: 'et maintenant les tests', images: [], mentions: [], userMessageUuid: 'uuid-9',
+        },
+      },
+    };
+
+    await hitLimit();
+
+    const restart = lastStart();
+    expect(restart.resumeSessionId).toBe('real-uuid-1');
+    expect(restart.prompt).toBe('et maintenant les tests');
+    // Same uuid so the bubble already on screen is the one that gets recorded.
+    expect(restart.userMessageUuid).toBe('uuid-9');
   });
 });

--- a/tests/ui/chatAccountSwitch.test.js
+++ b/tests/ui/chatAccountSwitch.test.js
@@ -1,12 +1,20 @@
 /**
  * Account switch after a usage limit — what the restart carries.
  *
- * Almost nothing: the turn that opened the tab is already on disk, and sending
- * it again would post the same message twice. The exception is a message the
- * CLI never answered — the offer leaves the composer usable, so a follow-up can
- * be sent while it is on screen and still be unanswered when the switch aborts
- * the process. That one exists nowhere but the bubble on screen, so the restart
- * has to carry it.
+ * The rule is "whatever the CLI never wrote down", and two different things can
+ * fall under it.
+ *
+ * A message the CLI never answered: the offer leaves the composer usable, so a
+ * follow-up can be sent while it is on screen and still be unanswered when the
+ * switch aborts the process. Main hands those back.
+ *
+ * The turn that opened the tab, but only when a limit was refused before the
+ * SDK's init message — no CLI session existed, so no session file holds it, and
+ * it exists nowhere but the bubble on screen.
+ *
+ * Once a real session id exists the opposite holds for anything acknowledged:
+ * it is already on disk, and sending it again would post the same message
+ * twice.
  */
 
 jest.mock('../../src/renderer/ui/components/AccountSwitchModal', () => ({
@@ -102,9 +110,9 @@ describe('chat account switch', () => {
       success: true,
       context: {
         cwd: '/tmp/test', projectId: 'p1', accountId: 'acc-max',
-        pendingUserMessage: {
+        pendingUserMessages: [{
           text: 'et maintenant les tests', images: [], mentions: [], userMessageUuid: 'uuid-9',
-        },
+        }],
       },
     };
 
@@ -115,5 +123,55 @@ describe('chat account switch', () => {
     expect(restart.prompt).toBe('et maintenant les tests');
     // Same uuid so the bubble already on screen is the one that gets recorded.
     expect(restart.userMessageUuid).toBe('uuid-9');
+  });
+
+  it('resends the opening turn when no session was ever written', async () => {
+    // A limit refused before the SDK's init message: nothing on disk to resume,
+    // so without this the prompt dies with the account that refused it.
+    await hitLimit();
+
+    const restart = lastStart();
+    expect(restart.accountId).toBe('acc-team');
+    expect(restart.resumeSessionId).toBeNull();
+    expect(restart.prompt).toBe('contexte Salim');
+  });
+
+  it('prefers the unanswered message over the opening turn', async () => {
+    // Both could apply. The queued one is the one the CLI never got to.
+    responses['chat.prepareSwitchAccount'] = {
+      success: true,
+      context: {
+        cwd: '/tmp/test', projectId: 'p1', accountId: 'acc-max',
+        pendingUserMessages: [{
+          text: 'en fait, annule', images: [], mentions: [], userMessageUuid: 'uuid-10',
+        }],
+      },
+    };
+
+    await hitLimit();
+
+    expect(lastStart().prompt).toBe('en fait, annule');
+  });
+
+  it('sends the messages queued behind the first one too', async () => {
+    giveSessionId();
+    responses['chat.prepareSwitchAccount'] = {
+      success: true,
+      context: {
+        cwd: '/tmp/test', projectId: 'p1', accountId: 'acc-max',
+        pendingUserMessages: [
+          { text: 'first', images: [], mentions: [], userMessageUuid: 'uuid-1a' },
+          { text: 'second', images: [], mentions: [], userMessageUuid: 'uuid-1b' },
+        ],
+      },
+    };
+
+    await hitLimit();
+
+    // A restart carries one prompt; the rest go back on the new session rather
+    // than being dropped for being second.
+    expect(lastStart().prompt).toBe('first');
+    const sends = calls.filter(c => c.namespace === 'chat' && c.method === 'send');
+    expect(sends.map(c => c.args[0].text)).toEqual(['second']);
   });
 });


### PR DESCRIPTION
Fixes #161

## The defect

The switch offer leaves the composer usable. A follow-up sent while it is on
screen goes into the live queue and waits its turn — and accepting the switch
aborts that process before the turn ever runs.

The message never reached the CLI, so it is in no transcript file, so the resume
cannot bring it back. And the restart deliberately sends nothing:

```js
prompt: '', images: [], mentions: [], userMessageUuid: null,
```

which is right for the turn that opened the tab (already on disk, resending
would double it) and wrong for a turn that was never answered. Nothing anywhere
recorded that the message existed, so nothing could replay it.

What the user sees is not "one message was dropped" — it is a conversation that
came back without the thing they had just asked for, which reads as the resume
having failed.

## The change

The session already knows what it is waiting on; it just never said so.

- **`ChatService.sendMessage`** records the message it is pushing, in the shape
  the renderer handed over (text, images, mentions, uuid) rather than the SDK
  content blocks it becomes.
- **`_processStream` clears it on `result`**, error results included: an
  answered turn is on disk and on screen, and resending it would post it twice.
  Only an unanswered message survives to the switch.
- **`prepareSwitchAccount` hands it back** alongside the cwd / projectId /
  accountId the restart already reuses. It is the single close point every path
  to the offer goes through, so this covers the thrown-error path and #153's
  in-band one alike.
- **The restart carries it**, with its uuid, so the bubble already on screen is
  the one that ends up recorded — same reasoning as the opening turn's uuid.
  `accounts.switchedQueuedResent` says so in the transcript, in all five
  locales.

## Tests

`tests/services/chatAccountSwitchQueue.test.js` drives the main-process path:
the message comes back when the turn never answered, with its images and
mentions; it does not come back after a success result, after an error result,
or when nothing was sent; the context the restart is spawned with is unchanged;
and the session is closed either way.

`tests/ui/chatAccountSwitch.test.js` covers the renderer half over a mocked
`electron_api`: a resume with nothing pending still sends no prompt, and a
resume with a pending message sends it — with the same uuid, on the same
`resumeSessionId`.