### PR TITLE
fix(chat): replay a resumed conversation the way it was shown

### DIFF
--- a/src/main/ipc/claude.ipc.js
+++ b/src/main/ipc/claude.ipc.js
@@ -9,6 +9,7 @@ const path = require('path');
 const os = require('os');
 const readline = require('readline');
 const { contextTokensFromMessage } = require('../../shared/context-usage');
+const { isApiErrorMessage } = require('../../shared/api-error');
 
 /**
  * Encode project path to match Claude's folder naming convention.
@@ -309,6 +310,55 @@ async function getClaudeSessions(projectPath) {
 const DEFAULT_HISTORY_LIMIT = 400;
 
 /**
+ * Lines the live stream never shows as a prompt: the CLI's own plumbing
+ * (caveats, injected skills, hook output) and the summary a compaction writes
+ * back into the conversation. Replayed as-is, a resumed tab opened on a wall of
+ * text the user never typed.
+ *
+ * @param {object} obj - A parsed transcript line
+ * @returns {boolean}
+ */
+function isTranscriptOnlyLine(obj) {
+  return obj.isMeta === true
+    || obj.isVisibleInTranscriptOnly === true
+    || obj.isCompactSummary === true;
+}
+
+const COMMAND_NAME_RE = /<command-name>([\s\S]*?)<\/command-name>/;
+const COMMAND_ARGS_RE = /<command-args>([\s\S]*?)<\/command-args>/;
+const LOCAL_STDOUT_RE = /<local-command-stdout>([\s\S]*?)<\/local-command-stdout>/g;
+// Injected by the CLI around a real prompt, or standing alone as a whole line
+const INJECTED_BLOCK_RE = /<(system-reminder|task-notification|local-command-caveat)>[\s\S]*?<\/\1>/g;
+
+/**
+ * What a user-side transcript line actually was in the chat: a typed prompt, a
+ * slash command, or the output that command printed. The CLI stores the parse
+ * (`<command-name>/model</command-name>...`) rather than the line the user
+ * typed, and its output as another user line — neither is a prompt on screen.
+ *
+ * @param {string} raw
+ * @returns {{kind: 'prompt'|'output'|'skip', text?: string}}
+ */
+function interpretUserText(raw) {
+  const text = (raw || '').trim();
+  if (!text) return { kind: 'skip' };
+
+  const name = text.match(COMMAND_NAME_RE);
+  if (name) {
+    const command = name[1].trim();
+    const args = (text.match(COMMAND_ARGS_RE)?.[1] || '').trim();
+    return { kind: 'prompt', text: args ? `${command} ${args}` : command };
+  }
+
+  const printed = [...text.matchAll(LOCAL_STDOUT_RE)].map(m => m[1].trim()).filter(Boolean);
+  if (printed.length) return { kind: 'output', text: printed.join('\n') };
+
+  const stripped = text.replace(INJECTED_BLOCK_RE, '').trim();
+  if (!stripped) return { kind: 'skip' };
+  return { kind: 'prompt', text: stripped };
+}
+
+/**
  * Load conversation history from a session JSONL file.
  * Returns the last `limit` simplified messages for the chat UI replay.
  * @param {string} projectPath - The project path
@@ -367,12 +417,15 @@ async function loadSessionHistory(projectPath, sessionId, options = {}) {
       try {
         const obj = JSON.parse(line);
 
+        const isAssistantLine = obj.type === 'assistant'
+          || (!obj.type && obj.message?.role === 'assistant');
+
         // Sidechain lines are a subagent's own window, not this conversation's.
         const turnTokens = contextTokensFromMessage(obj);
         if (turnTokens > 0) contextTokens = turnTokens;
 
         // User message
-        if (obj.type === 'user' && obj.message) {
+        if (obj.type === 'user' && obj.message && !isTranscriptOnlyLine(obj)) {
           let text = '';
           const images = [];
           const content = obj.message.content;
@@ -389,8 +442,14 @@ async function loadSessionHistory(projectPath, sessionId, options = {}) {
               }
             }
           }
-          if (text || images.length > 0) {
-            const msg = { role: 'user', text: text || '' };
+          // A slash command reaches the transcript as its parse, and its output as
+          // another user line. On screen the first was a prompt and the second a
+          // notice, so replaying either verbatim showed markup the user never saw.
+          const parsed = interpretUserText(text);
+          if (parsed.kind === 'output') {
+            push({ role: 'notice', icon: 'command', text: parsed.text });
+          } else if (parsed.text || images.length > 0) {
+            const msg = { role: 'user', text: parsed.text || '' };
             if (images.length > 0) msg.images = images;
             // Carried so a fork can name the turn it discards (resumeDropsTurn)
             if (obj.uuid) msg.uuid = obj.uuid;
@@ -398,8 +457,35 @@ async function loadSessionHistory(projectPath, sessionId, options = {}) {
           }
         }
 
+        // The CLI reports an API failure as an ordinary assistant message wearing
+        // a flag. The live renderer turns that into its error box; replayed as
+        // text it came back looking like something Claude had chosen to say.
+        if (isAssistantLine && isApiErrorMessage(obj) && obj.message?.content) {
+          const blocks = Array.isArray(obj.message.content) ? obj.message.content : [];
+          const text = blocks.filter(b => b.type === 'text').map(b => b.text).join('\n');
+          push({
+            role: 'error',
+            errorCode: typeof obj.error === 'string' ? obj.error : '',
+            status: obj.apiErrorStatus || 0,
+            text
+          });
+        }
+
+        // Compaction: the boundary is a notice of its own on screen, and the
+        // summary the CLI writes back is transcript-only (skipped above).
+        if (obj.type === 'system' && obj.subtype === 'compact_boundary') {
+          const meta = obj.compactMetadata || obj.compact_metadata || {};
+          push({ role: 'notice', icon: 'compact', preTokens: meta.preTokens || meta.pre_tokens || 0 });
+        }
+
+        // Newer CLIs record a command's output here rather than as a user line
+        if (obj.type === 'system' && obj.subtype === 'local_command' && typeof obj.content === 'string') {
+          const printed = interpretUserText(obj.content);
+          if (printed.kind === 'output') push({ role: 'notice', icon: 'command', text: printed.text });
+        }
+
         // Assistant message
-        if ((obj.type === 'assistant' || (!obj.type && obj.message?.role === 'assistant')) && obj.message?.content) {
+        if (isAssistantLine && obj.message?.content && !isApiErrorMessage(obj)) {
           const blocks = obj.message.content;
           for (const block of blocks) {
             if (block.type === 'text' && block.text) {
@@ -426,11 +512,17 @@ async function loadSessionHistory(projectPath, sessionId, options = {}) {
               if (block.type === 'tool_result') {
                 const output = typeof block.content === 'string' ? block.content
                   : Array.isArray(block.content) ? block.content.map(b => b.text || '').join('\n') : '';
-                push({
+                const msg = {
                   role: 'tool_result',
                   toolUseId: block.tool_use_id,
                   output: output.slice(0, 2000) // Limit output size for IPC
-                });
+                };
+                // What the user picked in an AskUserQuestion card, question by
+                // question — the card replays as the answered summary it became,
+                // rather than as a tool call named after nothing the user saw.
+                const answers = obj.toolUseResult?.answers;
+                if (answers && typeof answers === 'object' && !Array.isArray(answers)) msg.answers = answers;
+                push(msg);
               }
             }
           }

--- a/src/renderer/ui/components/ChatView.js
+++ b/src/renderer/ui/components/ChatView.js
@@ -4167,6 +4167,32 @@ class ChatView extends BaseComponent {
   /**
    * Collect the answer from the currently visible question group
    */
+  /**
+   * The collapsed body of an answered question card: one row per Q&A pair. The
+   * transcript records the same `{ question: answer }` map the live card
+   * collects, so a replayed card is the card the user left behind.
+   *
+   * @param {Record<string, string|string[]>} answers
+   * @returns {string}
+   */
+  function resolvedQuestionHtml(answers) {
+    const pairsHtml = Object.entries(answers).map(([question, answer]) =>
+      `<div class="chat-qa-pair">
+        <span class="chat-qa-question">${escapeHtml(question)}</span>
+        <span class="chat-qa-answer">${escapeHtml(Array.isArray(answer) ? answer.join(', ') : answer)}</span>
+      </div>`
+    ).join('');
+    return `
+      <div class="chat-question-header resolved">
+        <div class="chat-perm-icon">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>
+        </div>
+        <span>${escapeHtml(t('chat.questionAnswered') || 'Answered')}</span>
+      </div>
+      <div class="chat-qa-summary">${pairsHtml}</div>
+    `;
+  }
+
   function collectCurrentAnswer(card) {
     const questions = JSON.parse(card.dataset.questions || '[]');
     const step = parseInt(card.dataset.currentStep, 10);
@@ -4235,25 +4261,8 @@ class ChatView extends BaseComponent {
     if (result) answers[result.question] = result.answer;
 
     // Collapse card into compact answered summary showing each Q&A pair
-    const answerEntries = Object.entries(answers);
-
-    const pairsHtml = answerEntries.map(([question, answer]) =>
-      `<div class="chat-qa-pair">
-        <span class="chat-qa-question">${escapeHtml(question)}</span>
-        <span class="chat-qa-answer">${escapeHtml(answer)}</span>
-      </div>`
-    ).join('');
-
     card.classList.add('resolved');
-    card.innerHTML = `
-      <div class="chat-question-header resolved">
-        <div class="chat-perm-icon">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>
-        </div>
-        <span>${escapeHtml(t('chat.questionAnswered') || 'Answered')}</span>
-      </div>
-      <div class="chat-qa-summary">${pairsHtml}</div>
-    `;
+    card.innerHTML = resolvedQuestionHtml(answers);
 
     _respondPermission({
       requestId,
@@ -4328,6 +4337,28 @@ class ChatView extends BaseComponent {
     scrollToBottom();
   }
 
+  /**
+   * The sentence shown for an API failure code. The transcript records the same
+   * codes as the live stream, so a resumed conversation reads exactly like the
+   * turn did — with the CLI's own wording kept for codes we have no phrasing for.
+   *
+   * @param {string} code - `rate_limit`, `server_error`, ...
+   * @param {string} [recorded] - What the CLI said, when the code is unknown
+   * @returns {string}
+   */
+  function errorTextForCode(code, recorded = '') {
+    const errorMessages = {
+      rate_limit: t('chat.errorRateLimit'),
+      billing_error: t('chat.errorBilling'),
+      authentication_failed: t('chat.errorAuth'),
+      invalid_request: t('chat.errorInvalidRequest'),
+      max_output_tokens: t('chat.errorMaxTokens'),
+      server_error: t('chat.errorServer'),
+      overloaded: t('chat.errorServer'),
+    };
+    return errorMessages[code] || recorded.trim() || t('chat.errorOccurred');
+  }
+
   function appendError(text) {
     const el = document.createElement('div');
     el.className = 'chat-msg chat-msg-error';
@@ -4350,7 +4381,8 @@ class ChatView extends BaseComponent {
     appendSystemNotice(t('chat.sessionStarted', { details: parts.join(' · ') }), 'model');
   }
 
-  function appendSystemNotice(text, icon = 'info') {
+  /** The notice element, built but not placed — replay inserts it into a fragment. */
+  function buildSystemNotice(text, icon = 'info') {
     const icons = {
       info: '&#8505;',      // ℹ
       compact: '&#9879;',   // ⚗
@@ -4361,7 +4393,11 @@ class ChatView extends BaseComponent {
     const el = document.createElement('div');
     el.className = 'chat-system-notice';
     el.innerHTML = `<span class="chat-system-notice-icon">${icons[icon] || icons.info}</span><span class="chat-system-notice-text">${escapeHtml(text)}</span>`;
-    messagesEl.appendChild(el);
+    return el;
+  }
+
+  function appendSystemNotice(text, icon = 'info') {
+    messagesEl.appendChild(buildSystemNotice(text, icon));
     scrollToBottom();
   }
 
@@ -7437,16 +7473,7 @@ class ChatView extends BaseComponent {
 
     // SDK-level errors on the assistant message (rate_limit, billing_error, etc.)
     if (msg.error) {
-      const errorMessages = {
-        rate_limit: t('chat.errorRateLimit'),
-        billing_error: t('chat.errorBilling'),
-        authentication_failed: t('chat.errorAuth'),
-        invalid_request: t('chat.errorInvalidRequest'),
-        max_output_tokens: t('chat.errorMaxTokens'),
-        server_error: t('chat.errorServer'),
-        overloaded: t('chat.errorServer'),
-      };
-      const text = errorMessages[msg.error] || t('chat.errorOccurred');
+      const text = errorTextForCode(msg.error);
       removeThinkingIndicator();
       appendError(text);
       turnErrorShown = true;
@@ -8439,9 +8466,11 @@ class ChatView extends BaseComponent {
 
     // Build a map of tool_use_id -> tool_result output for enriching tool cards
     const toolResults = new Map();
+    const questionAnswers = new Map();
     for (const msg of messages) {
       if (msg.role === 'tool_result' && msg.toolUseId) {
         toolResults.set(msg.toolUseId, msg.output || '');
+        if (msg.answers) questionAnswers.set(msg.toolUseId, msg.answers);
       }
     }
 
@@ -8462,7 +8491,25 @@ class ChatView extends BaseComponent {
           end = Math.min(end + MIN_BATCH, messages.length);
         }
         const msg = messages[idx];
-        if (msg.role === 'user') {
+        if (msg.role === 'error') {
+          // Same box the live turn showed: an API failure is not a reply
+          const el = document.createElement('div');
+          el.className = 'chat-msg chat-msg-error history';
+          el.innerHTML = `<div class="chat-error-content">${escapeHtml(errorTextForCode(msg.errorCode, msg.text || ''))}</div>`;
+          fragment.appendChild(el);
+
+        } else if (msg.role === 'notice') {
+          const text = msg.icon === 'compact'
+            ? (msg.preTokens > 0
+              ? t('chat.compacted', { tokens: msg.preTokens.toLocaleString() })
+              : (t('chat.compactedSimple') || 'Conversation compacted'))
+            : (msg.text || '');
+          if (!text) continue;
+          const el = buildSystemNotice(text, msg.icon || 'info');
+          el.classList.add('history');
+          fragment.appendChild(el);
+
+        } else if (msg.role === 'user') {
           const el = document.createElement('div');
           el.className = 'chat-msg chat-msg-user history';
           let userHtml = '';
@@ -8515,6 +8562,19 @@ class ChatView extends BaseComponent {
 
         } else if (msg.role === 'assistant' && msg.type === 'tool_use') {
           if (msg.toolName === 'TodoWrite' || msg.toolName === 'TaskCreate' || msg.toolName === 'TaskUpdate' || msg.toolName === 'TaskList' || msg.toolName === 'TaskGet') continue;
+
+          // A question was a card, never a tool card — and once answered it
+          // collapsed into its summary, which is what the transcript holds.
+          if (msg.toolName === 'AskUserQuestion') {
+            const answers = questionAnswers.get(msg.toolUseId);
+            if (answers && Object.keys(answers).length) {
+              const el = document.createElement('div');
+              el.className = 'chat-question-card resolved history';
+              el.innerHTML = resolvedQuestionHtml(answers);
+              fragment.appendChild(el);
+            }
+            continue;
+          }
 
           if (msg.toolName === 'Task' || msg.toolName === 'Agent') {
             const input = msg.toolInput || {};

--- a/src/shared/api-error.js
+++ b/src/shared/api-error.js
@@ -1,0 +1,17 @@
+/**
+ * Is this message the CLI reporting an API failure rather than answering — a
+ * spend cap, a refusal, an overloaded upstream?
+ *
+ * The CLI carries the flag as `isApiErrorMessage` internally, which is the
+ * spelling written to the ~/.claude/projects transcript, and serialises it to
+ * stream-json as `is_api_error_message`. Which of the two a caller sees depends
+ * on where it reads from — the live stream or the transcript — so both count.
+ *
+ * @param {object} message
+ * @returns {boolean}
+ */
+function isApiErrorMessage(message) {
+  return message?.isApiErrorMessage === true || message?.is_api_error_message === true;
+}
+
+module.exports = { isApiErrorMessage };

--- a/styles/chat.css
+++ b/styles/chat.css
@@ -870,6 +870,8 @@ mark.chat-search-hit.current {
 .chat-msg.history,
 .chat-tool-card.history,
 .chat-subagent-card.history,
+.chat-system-notice.history,
+.chat-question-card.history,
 .chat-thinking.history {
   --text-primary: #a7a7a7;
   --text-secondary: #969696;
@@ -892,6 +894,30 @@ mark.chat-search-hit.current {
   background: linear-gradient(135deg, rgba(34, 197, 94, 0.05), rgba(34, 197, 94, 0.025));
   border-color: rgba(34, 197, 94, 0.14);
   border-left-color: rgba(34, 197, 94, 0.3);
+}
+
+/* Notices and error boxes state their colours literally too. Same treatment,
+   except the error text, which stops at #d94a4a (4.65:1 on --bg-primary): one
+   notch back from live, still over the AA floor for 12px text. */
+.chat-system-notice.history {
+  background: rgba(var(--accent-color-rgb), 0.03);
+  border-left-color: rgba(var(--accent-color-rgb), 0.2);
+}
+
+.chat-msg-error.history .chat-error-content {
+  background: rgba(239, 68, 68, 0.04);
+  border-left-color: rgba(239, 68, 68, 0.32);
+  color: #d94a4a;
+}
+
+/* An answered question keeps its accent chip and green tick outside the ramp */
+.chat-question-card.history .chat-qa-answer {
+  background: rgba(var(--accent-color-rgb), 0.05);
+  border-color: rgba(var(--accent-color-rgb), 0.1);
+}
+
+.chat-question-card.history .chat-question-header.resolved .chat-perm-icon {
+  color: rgba(34, 197, 94, 0.7);
 }
 
 /* Loading pulse animation for welcome logo */

--- a/tests/ipc/claude.ipc.test.js
+++ b/tests/ipc/claude.ipc.test.js
@@ -191,6 +191,162 @@ describe('loadSessionHistory', () => {
   });
 });
 
+// What the live stream drew, the replay has to draw too. Everything below is a
+// shape the CLI writes to the transcript and the chat renders as something other
+// than a message bubble — an error box, a notice, or nothing at all.
+describe('loadSessionHistory — transcript shapes', () => {
+  /** Write the given raw transcript lines as this project's session file. */
+  function writeLines(lines) {
+    const dir = sessionsDir();
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, `${SESSION_ID}.jsonl`),
+      lines.map(l => JSON.stringify(l)).join('\n') + '\n'
+    );
+  }
+
+  const prompt = (text, extra = {}) => ({
+    type: 'user', uuid: 'u-1', message: { role: 'user', content: text }, ...extra
+  });
+
+  test('an API failure comes back as an error, not as a reply from Claude', async () => {
+    writeLines([
+      prompt('hello'),
+      {
+        type: 'assistant', uuid: 'a-1', isApiErrorMessage: true,
+        error: 'rate_limit', apiErrorStatus: 429,
+        message: { role: 'assistant', content: [{ type: 'text', text: 'API Error: 429 rate limit' }] }
+      }
+    ]);
+    const { messages } = await loadSessionHistory(PROJECT_PATH, SESSION_ID);
+
+    expect(messages).toHaveLength(2);
+    expect(messages[1]).toMatchObject({
+      role: 'error', errorCode: 'rate_limit', status: 429, text: 'API Error: 429 rate limit'
+    });
+    // ...and never also as the assistant text it is dressed up as
+    expect(messages.some(m => m.role === 'assistant')).toBe(false);
+  });
+
+  test('the stream-json spelling of the flag counts too', async () => {
+    writeLines([{
+      type: 'assistant', uuid: 'a-1', is_api_error_message: true, error: 'server_error',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'API Error: 529' }] }
+    }]);
+    const { messages } = await loadSessionHistory(PROJECT_PATH, SESSION_ID);
+    expect(messages[0]).toMatchObject({ role: 'error', errorCode: 'server_error' });
+  });
+
+  test('a compaction replays as its boundary notice, not as the summary it wrote', async () => {
+    writeLines([
+      prompt('hello'),
+      {
+        type: 'system', subtype: 'compact_boundary', uuid: 's-1',
+        compactMetadata: { trigger: 'auto', preTokens: 935547 }
+      },
+      {
+        type: 'user', uuid: 'u-2', isCompactSummary: true, isVisibleInTranscriptOnly: true,
+        message: { role: 'user', content: 'This session is being continued from a previous conversation...' }
+      },
+      prompt('carry on', { uuid: 'u-3' })
+    ]);
+    const { messages } = await loadSessionHistory(PROJECT_PATH, SESSION_ID);
+
+    expect(messages).toHaveLength(3);
+    expect(messages[1]).toMatchObject({ role: 'notice', icon: 'compact', preTokens: 935547 });
+    expect(messages.some(m => m.text?.startsWith('This session is being continued'))).toBe(false);
+  });
+
+  test('a slash command replays as the line the user typed, then its output', async () => {
+    writeLines([
+      {
+        type: 'user', uuid: 'u-0', isMeta: true,
+        message: { role: 'user', content: '<local-command-caveat>Caveat: ...</local-command-caveat>' }
+      },
+      prompt('<command-name>/model</command-name>\n  <command-message>model</command-message>\n  <command-args>opus[1m]</command-args>'),
+      prompt('<local-command-stdout>Set model to claude-opus-5[1m]</local-command-stdout>', { uuid: 'u-2' })
+    ]);
+    const { messages } = await loadSessionHistory(PROJECT_PATH, SESSION_ID);
+
+    expect(messages).toEqual([
+      { role: 'user', text: '/model opus[1m]', uuid: 'u-1' },
+      { role: 'notice', icon: 'command', text: 'Set model to claude-opus-5[1m]' }
+    ]);
+  });
+
+  test('newer CLIs record the command output as a system line', async () => {
+    writeLines([{
+      type: 'system', subtype: 'local_command', uuid: 's-1',
+      content: '<local-command-stdout>## Context Usage</local-command-stdout>'
+    }]);
+    const { messages } = await loadSessionHistory(PROJECT_PATH, SESSION_ID);
+    expect(messages).toEqual([{ role: 'notice', icon: 'command', text: '## Context Usage' }]);
+  });
+
+  test('injected blocks are stripped, and a line that is only injection is dropped', async () => {
+    writeLines([
+      prompt('<system-reminder>\nThe user started a background task\n</system-reminder>'),
+      prompt('<task-notification>\n<task-id>x</task-id>\n</task-notification>', { uuid: 'u-2' }),
+      prompt('real question <system-reminder>ignore me</system-reminder>', { uuid: 'u-3' })
+    ]);
+    const { messages } = await loadSessionHistory(PROJECT_PATH, SESSION_ID);
+
+    expect(messages).toEqual([{ role: 'user', text: 'real question', uuid: 'u-3' }]);
+  });
+
+  test('an answered question carries its answers to the replay', async () => {
+    writeLines([
+      {
+        type: 'assistant', uuid: 'a-1',
+        message: {
+          role: 'assistant',
+          content: [{
+            type: 'tool_use', id: 'q-1', name: 'AskUserQuestion',
+            input: { questions: [{ question: 'Which base?', options: [{ label: 'main' }] }] }
+          }]
+        }
+      },
+      {
+        type: 'user', uuid: 'r-1',
+        toolUseResult: { answers: { 'Which base?': 'main' } },
+        message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'q-1', content: 'answered' }] }
+      }
+    ]);
+    const { messages } = await loadSessionHistory(PROJECT_PATH, SESSION_ID);
+
+    expect(messages[1]).toMatchObject({
+      role: 'tool_result', toolUseId: 'q-1', answers: { 'Which base?': 'main' }
+    });
+  });
+
+  test('an ordinary tool result carries no answers field', async () => {
+    writeLines([
+      {
+        type: 'assistant', uuid: 'a-1',
+        message: { role: 'assistant', content: [{ type: 'tool_use', id: 't-1', name: 'Bash', input: {} }] }
+      },
+      {
+        type: 'user', uuid: 'r-1', toolUseResult: { stdout: 'hi' },
+        message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't-1', content: 'hi' }] }
+      }
+    ]);
+    const { messages } = await loadSessionHistory(PROJECT_PATH, SESSION_ID);
+    expect(messages[1]).not.toHaveProperty('answers');
+  });
+
+  test('an image-only prompt survives having no text left', async () => {
+    writeLines([{
+      type: 'user', uuid: 'u-1',
+      message: {
+        role: 'user',
+        content: [{ type: 'image', source: { type: 'base64', data: 'abc', media_type: 'image/png' } }]
+      }
+    }]);
+    const { messages } = await loadSessionHistory(PROJECT_PATH, SESSION_ID);
+    expect(messages[0]).toMatchObject({ role: 'user', text: '', images: [{ base64: 'abc' }] });
+  });
+});
+
 describe('parseSessionReplay', () => {
   test('counts the whole session but only ships the first page', async () => {
     writeSession(200); // 200 turns -> prompt + thinking + tool + response each


### PR DESCRIPTION
Fixes #164

## The problem

`loadSessionHistory` knows four transcript shapes — a user text line, an assistant `text` block, a `thinking` block, a `tool_use` block — while the live stream renders about a dozen. On resume, everything else is either dropped or squeezed into one of those four.

The visible one is an API failure. The CLI records it as an ordinary assistant message wearing a flag:

```json
{"type":"assistant","isApiErrorMessage":true,"error":"rate_limit","apiErrorStatus":429,
 "message":{"role":"assistant","content":[{"type":"text","text":"API Error: 429 ..."}]}}
```

so a rate limit that had been a red alert box came back as a reply from Claude.

## What changed

The loader emits the shapes the renderer already draws, and the replay path draws them:

- `role: 'error'` for a flagged assistant line, carrying the same `error` code the live stream sends, so the box reads identically. The code-to-sentence mapping is extracted from `handleAssistantMessage` into `errorTextForCode`, shared by both paths, and the CLI's own wording is kept for codes we have no phrasing for.
- `role: 'notice'` for a compact boundary (with `preTokens`, so the notice says the same as live) and for a command's output, whether the CLI recorded it as a user line or as `system/local_command`. `appendSystemNotice` splits into `buildSystemNotice` so replay can put one in a fragment.
- `/model opus[1m]` for the `<command-name>` parse the CLI stores in place of what the user typed.
- Nothing at all for `isMeta`, `isVisibleInTranscriptOnly` and injected `<system-reminder>` / `<task-notification>` / `<local-command-caveat>` blocks, none of which the live path shows. That includes the compaction summary, whose boundary notice now precedes it. Injected blocks wrapped around a real prompt are stripped rather than dropping the prompt.
- `answers` from `toolUseResult` on an AskUserQuestion tool result, which replays as the collapsed "Answered" card. The card's summary markup moves into `resolvedQuestionHtml`, used by both the live collapse and the replay, so they cannot drift. The live path never draws a tool card for `AskUserQuestion`; now neither does the replay.

`src/shared/api-error.js` holds the predicate: the transcript spells the flag `isApiErrorMessage`, stream-json spells it `is_api_error_message`, and a reader of either needs the same answer.

Replayed notices, error boxes and question cards join the `.history` treatment the rest of the transcript already gets. The error red stops at `#d94a4a` rather than following the ramp all the way down: 4.65:1 on `--bg-primary`, still over the AA floor for 12px text.

## Verification

- 16 new tests in `tests/ipc/claude.ipc.test.js` covering each shape, both spellings of the flag, and the two negatives (an ordinary tool result carries no `answers`; an image-only prompt survives having no text left). Full suite green.
- Run over a real 34k-line transcript, the loader now yields 27 compaction notices, 39 command notices and 20 error boxes, with zero leftover markup in user bubbles and zero summary bubbles. Before, those were 27 giant summary bubbles, no boundaries, and 20 replies that were never replies.

## Not in this PR

`ExitPlanMode` still replays as a generic tool card, and subagent cards still replay with an empty body. Both are noted in #164.