### PR TITLE
fix(sessions): keep a session that entered a worktree in its project

### DIFF
--- a/resources/mcp-servers/tools/sessions.js
+++ b/resources/mcp-servers/tools/sessions.js
@@ -22,9 +22,26 @@ function log(...args) {
   process.stderr.write(`[ct-mcp:sessions] ${args.join(' ')}\n`);
 }
 
-// -- Project path helpers (mirrored from claude.ipc.js) -----------------------
+// -- Project path helpers -----------------------------------------------------
+//
+// Shared with the app rather than mirrored: the app reads a project's sessions
+// out of its own directory AND its worktrees', because the CLI re-files a
+// transcript when the session enters a worktree. A local copy of just the path
+// encoding would put these tools back to seeing a fraction of the history.
+// Same dual-path resolution as artifacts.js: packaged app → dev repo.
+let sessionDirs = null;
+try {
+  sessionDirs = require(path.join(__dirname, '..', 'shared', 'session-dirs'));
+} catch (_) {
+  try {
+    sessionDirs = require(path.join(__dirname, '..', '..', '..', 'src', 'shared', 'session-dirs'));
+  } catch (e) {
+    process.stderr.write(`[ct-mcp:sessions] session-dirs unavailable, worktree sessions hidden: ${e.message}\n`);
+  }
+}
 
 function encodeProjectPath(projectPath) {
+  if (sessionDirs) return sessionDirs.encodeProjectPath(projectPath);
   const MAX_LEN = 200;
   const encoded = projectPath.replace(/[^a-zA-Z0-9]/g, '-');
   if (encoded.length <= MAX_LEN) return encoded;
@@ -37,6 +54,18 @@ function encodeProjectPath(projectPath) {
 
 function getProjectSessionsDir(projectPath) {
   return path.join(os.homedir(), '.claude', 'projects', encodeProjectPath(projectPath));
+}
+
+/**
+ * Every directory this project's sessions can be in: its own, then one per
+ * worktree. Falls back to the project's own directory alone when the shared
+ * module is missing, which is the pre-worktree behaviour.
+ * @param {string} projectPath
+ * @returns {Array<{dir: string, cwd: string|null, worktree: string|null, missing: boolean}>}
+ */
+function projectSessionDirs(projectPath) {
+  if (sessionDirs) return sessionDirs.listProjectSessionDirs(projectPath);
+  return [{ dir: getProjectSessionsDir(projectPath), cwd: projectPath, worktree: null, missing: false }];
 }
 
 // -- Utility: read first N lines of a file (sync-ish via readline) ------------
@@ -62,7 +91,29 @@ function readFirstLines(filePath, n) {
 // -- Session listing (mirrored from getClaudeSessions in claude.ipc.js) -------
 
 async function listSessions(projectPath, limit = 20) {
-  const sessionsDir = getProjectSessionsDir(projectPath);
+  const perSource = await Promise.all(
+    projectSessionDirs(projectPath).map(source => listSessionsIn(source))
+  );
+
+  // A session that ran in the project and then in a worktree left a transcript
+  // in both; only the most recent one is the live conversation.
+  const byId = new Map();
+  for (const session of perSource.flat()) {
+    const seen = byId.get(session.sessionId);
+    if (!seen || new Date(session.modified) > new Date(seen.modified)) byId.set(session.sessionId, session);
+  }
+
+  return [...byId.values()]
+    .sort((a, b) => new Date(b.modified) - new Date(a.modified))
+    .slice(0, limit);
+}
+
+/**
+ * The sessions in one transcript directory, tagged with where they ran.
+ * @param {{dir: string, cwd: string|null, worktree: string|null}} source
+ */
+async function listSessionsIn(source) {
+  const sessionsDir = source.dir;
 
   let files;
   try {
@@ -116,6 +167,9 @@ async function listSessions(projectPath, limit = 20) {
         messageCount,
         modified: stat.mtime.toISOString(),
         gitBranch,
+        // Where it has to be resumed, and under which worktree it was filed.
+        cwd: source.cwd || undefined,
+        worktree: source.worktree || undefined,
       };
     } catch {
       return null;
@@ -138,9 +192,7 @@ async function listSessions(projectPath, limit = 20) {
     }
   } catch (_) {}
 
-  return sessions
-    .sort((a, b) => new Date(b.modified) - new Date(a.modified))
-    .slice(0, limit);
+  return sessions;
 }
 
 // -- Session replay parser (mirrored from parseSessionReplay in claude.ipc.js) -
@@ -165,17 +217,26 @@ function sanitizeInput(input) {
 }
 
 async function parseReplay(projectPath, sessionId) {
-  const sessionsDir = getProjectSessionsDir(projectPath);
-  let filePath = path.join(sessionsDir, `${sessionId}.jsonl`);
+  const searchDirs = projectSessionDirs(projectPath).map(source => source.dir);
+  let filePath = null;
+  for (const dir of searchDirs) {
+    const direct = path.join(dir, `${sessionId}.jsonl`);
+    try {
+      await fs.promises.access(direct);
+      filePath = direct;
+      break;
+    } catch { /* keep looking */ }
+  }
 
   // Fall back to scanning for the sessionId in file headers
-  try {
-    await fs.promises.access(filePath);
-  } catch {
-    const files = (await fs.promises.readdir(sessionsDir).catch(() => []))
-      .filter(f => f.endsWith('.jsonl'));
-    for (const f of files) {
-      const candidate = path.join(sessionsDir, f);
+  if (!filePath) {
+    const files = [];
+    for (const dir of searchDirs) {
+      const names = (await fs.promises.readdir(dir).catch(() => []))
+        .filter(f => f.endsWith('.jsonl'));
+      for (const name of names) files.push(path.join(dir, name));
+    }
+    for (const candidate of files) {
       const head = await readFirstLines(candidate, 5);
       for (const line of head) {
         try {
@@ -184,6 +245,8 @@ async function parseReplay(projectPath, sessionId) {
       }
     }
   }
+
+  if (!filePath) return null;
 
   const rawLines = await new Promise((resolve) => {
     const lines = [];
@@ -502,41 +565,48 @@ async function searchSessions({ query, projectPath, days, limit, maxSnippets }) 
  * recently touched session of the project.
  */
 async function resolveSessionFile(projectPath, sessionId) {
-  const sessionsDir = getProjectSessionsDir(projectPath);
+  // The project's own directory and its worktrees': "the most recent session of
+  // this project" has to mean the same thing here as it does in the app, or a
+  // recap of work done in a worktree answers about some older conversation.
+  const searchDirs = projectSessionDirs(projectPath).map(source => source.dir);
+
+  const jsonlIn = async (dir) => (await fs.promises.readdir(dir).catch(() => []))
+    .filter(f => f.endsWith('.jsonl'))
+    .map(name => path.join(dir, name));
 
   if (sessionId) {
-    const direct = path.join(sessionsDir, `${sessionId}.jsonl`);
-    try {
-      await fs.promises.access(direct);
-      return direct;
-    } catch (_) {}
+    for (const dir of searchDirs) {
+      const direct = path.join(dir, `${sessionId}.jsonl`);
+      try {
+        await fs.promises.access(direct);
+        return direct;
+      } catch (_) {}
+    }
 
-    const names = (await fs.promises.readdir(sessionsDir).catch(() => []))
-      .filter(f => f.endsWith('.jsonl'));
-    for (const name of names) {
-      const candidate = path.join(sessionsDir, name);
-      const head = await readFirstLines(candidate, 5);
-      for (const line of head) {
-        try {
-          if (JSON.parse(line).sessionId === sessionId) return candidate;
-        } catch (_) {}
+    for (const dir of searchDirs) {
+      for (const candidate of await jsonlIn(dir)) {
+        const head = await readFirstLines(candidate, 5);
+        for (const line of head) {
+          try {
+            if (JSON.parse(line).sessionId === sessionId) return candidate;
+          } catch (_) {}
+        }
       }
     }
     return null;
   }
 
-  const names = (await fs.promises.readdir(sessionsDir).catch(() => []))
-    .filter(f => f.endsWith('.jsonl'));
   let newest = null;
-  for (const name of names) {
-    const candidate = path.join(sessionsDir, name);
-    try {
-      const stat = await fs.promises.stat(candidate);
-      if (stat.size < 200) continue;
-      if (!newest || stat.mtimeMs > newest.mtimeMs) {
-        newest = { filePath: candidate, mtimeMs: stat.mtimeMs };
-      }
-    } catch (_) {}
+  for (const dir of searchDirs) {
+    for (const candidate of await jsonlIn(dir)) {
+      try {
+        const stat = await fs.promises.stat(candidate);
+        if (stat.size < 200) continue;
+        if (!newest || stat.mtimeMs > newest.mtimeMs) {
+          newest = { filePath: candidate, mtimeMs: stat.mtimeMs };
+        }
+      } catch (_) {}
+    }
   }
   return newest ? newest.filePath : null;
 }
@@ -765,6 +835,7 @@ async function handle(name, args) {
           `   Date: ${date}`,
           `   Messages: ${s.messageCount}`,
           s.gitBranch ? `   Branch: ${s.gitBranch}` : '',
+          s.worktree ? `   Worktree: ${s.worktree} (resumes in ${s.cwd || 'the project root'})` : '',
           `   Prompt: ${label.slice(0, 120)}`,
         ].filter(Boolean).join('\n');
       });
@@ -895,7 +966,9 @@ async function handle(name, args) {
       if (!args.session_id) return fail('Missing required parameter: session_id');
       if (!projectPath) return fail('No project path provided. Pass project_path or set CT_PROJECT_PATH.');
 
-      const { steps, summary } = await parseReplay(projectPath, args.session_id);
+      const replay = await parseReplay(projectPath, args.session_id);
+      if (!replay) return ok(`Session ${args.session_id} was not found in this project or its worktrees.`);
+      const { steps, summary } = replay;
 
       if (!steps.length) return ok(`No steps found in session ${args.session_id}. The session may be empty or the file could not be read.`);
 

--- a/src/main/ipc/claude.ipc.js
+++ b/src/main/ipc/claude.ipc.js
@@ -10,40 +10,11 @@ const os = require('os');
 const readline = require('readline');
 const { contextTokensFromMessage } = require('../../shared/context-usage');
 const { isApiErrorMessage } = require('../../shared/api-error');
-
-/**
- * Encode project path to match Claude's folder naming convention.
- * Uses a broad [^a-zA-Z0-9] class (instead of the old 3-char class)
- * so that dots, spaces, and other special characters are replaced.
- * This fixes session lookup for projects
- * whose paths contain dots or other special chars (e.g. "ConfigHub.Server").
- *
- * @param {string} projectPath - The project path
- * @returns {string} - Encoded path for folder name
- */
-function encodeProjectPath(projectPath) {
-  const MAX_LEN = 200;
-  const encoded = projectPath.replace(/[^a-zA-Z0-9]/g, '-');
-  if (encoded.length <= MAX_LEN) return encoded;
-  // For paths exceeding 200 chars: truncate + append a simple hash
-  // (mirrors Claude Code's hMK hash — DJB2-style string hash in base36)
-  let hash = 0;
-  for (let i = 0; i < projectPath.length; i++) {
-    hash = ((hash << 5) - hash + projectPath.charCodeAt(i)) | 0;
-  }
-  return `${encoded.slice(0, MAX_LEN)}-${Math.abs(hash).toString(36)}`;
-}
-
-/**
- * Get the project sessions directory path
- * @param {string} projectPath - The project path
- * @returns {string} - Path to project sessions directory
- */
-function getProjectSessionsDir(projectPath) {
-  const claudeDir = path.join(os.homedir(), '.claude', 'projects');
-  const encodedPath = encodeProjectPath(projectPath);
-  return path.join(claudeDir, encodedPath);
-}
+const {
+  encodeProjectPath,
+  getProjectSessionsDir,
+  listProjectSessionDirs,
+} = require('../../shared/session-dirs');
 
 /**
  * Extract first user prompt from a .jsonl session file (reads only first few lines)
@@ -168,13 +139,13 @@ async function readSessionTitle(filePath, size) {
 // reads the tail of the fifty it returns. Holding the result briefly collapses
 // those bursts into one scan.
 //
-// A cached listing is only reused while the sessions directory has not been
-// touched: its mtime moves when a transcript is created, renamed or deleted, so
-// a session appearing from anywhere is picked up on the next call rather than up
-// to a timeout later. The time bound is what covers appends to an existing
+// A cached listing is only reused while none of the sessions directories has
+// been touched: an mtime moves when a transcript is created, renamed or deleted,
+// so a session appearing from anywhere is picked up on the next call rather than
+// up to a timeout later. The time bound is what covers appends to an existing
 // transcript, which change the file but not the directory.
 const SESSIONS_CACHE_MS = 5000;
-const _sessionsCache = new Map(); // projectPath -> { at, dirMtimeMs, sessions }
+const _sessionsCache = new Map(); // projectPath -> { at, signature, sessions }
 
 /** Drop a project's cached listing, or every project's when called bare. */
 function invalidateSessionsCache(projectPath) {
@@ -182,91 +153,119 @@ function invalidateSessionsCache(projectPath) {
   else _sessionsCache.clear();
 }
 
-/** mtime of the sessions directory, or null when it cannot be read. */
-async function _sessionsDirMtime(sessionsDir) {
-  try {
-    return (await fs.promises.stat(sessionsDir)).mtimeMs;
-  } catch {
-    return null;
-  }
+/**
+ * A value that changes as soon as any of the project's sessions directories does.
+ * A directory that does not exist counts as absent rather than as a failure, so a
+ * worktree gaining its first transcript also moves the signature.
+ * @param {Array<{dir: string}>} sources
+ * @returns {Promise<string>}
+ */
+async function _sessionsSignature(sources) {
+  const stamps = await Promise.all(sources.map(async ({ dir }) => {
+    try {
+      return `${dir}:${(await fs.promises.stat(dir)).mtimeMs}`;
+    } catch {
+      return `${dir}:-`;
+    }
+  }));
+  return stamps.join('|');
 }
 
 async function getClaudeSessions(projectPath) {
-  const sessionsDirForCache = getProjectSessionsDir(projectPath);
+  // The project's own directory plus one per worktree — a session that moved
+  // into a worktree was re-filed there by the CLI, history and all.
+  const sources = listProjectSessionDirs(projectPath);
   const cached = _sessionsCache.get(projectPath);
   if (cached && Date.now() - cached.at < SESSIONS_CACHE_MS) {
-    const mtime = await _sessionsDirMtime(sessionsDirForCache);
-    if (mtime !== null && mtime === cached.dirMtimeMs) return cached.sessions;
+    if (await _sessionsSignature(sources) === cached.signature) return cached.sessions;
   }
 
   try {
-    const sessionsDir = sessionsDirForCache;
-
-    let files;
-    try {
-      files = await fs.promises.readdir(sessionsDir);
-    } catch {
-      return [];
-    }
-
-    // Filter .jsonl files only
-    const jsonlFiles = files.filter(f => f.endsWith('.jsonl'));
-
-    if (jsonlFiles.length === 0) return [];
-
-    // Get file stats and parse session info in parallel
-    const sessionsPromises = jsonlFiles.map(async (file) => {
-      const filePath = path.join(sessionsDir, file);
+    const perSource = await Promise.all(sources.map(async (source) => {
+      let files;
       try {
-        const [stat, info] = await Promise.all([
-          fs.promises.stat(filePath),
-          extractSessionInfo(filePath)
-        ]);
-
-        // Skip sidechain sessions
-        if (info.isSidechain) return null;
-
-        // Skip files that are too small (empty/aborted sessions)
-        if (stat.size < 200) return null;
-
-        const sessionId = info.sessionId || file.replace('.jsonl', '');
-
-        return {
-          sessionId,
-          summary: '',
-          title: '',
-          customTitle: '',
-          aiTitle: '',
-          firstPrompt: info.firstPrompt || '',
-          messageCount: info.messageCount || 0,
-          modified: stat.mtime.toISOString(),
-          size: stat.size,
-          filePath,
-          gitBranch: info.gitBranch
-        };
+        files = await fs.promises.readdir(source.dir);
       } catch {
-        return null;
+        return []; // a worktree that never ran a session has no directory
       }
-    });
 
-    const allSessions = (await Promise.all(sessionsPromises)).filter(Boolean);
+      const jsonlFiles = files.filter(f => f.endsWith('.jsonl'));
+      if (jsonlFiles.length === 0) return [];
 
-    // Try to enrich with summaries from sessions-index.json
-    try {
-      const indexPath = path.join(sessionsDir, 'sessions-index.json');
-      const rawData = await fs.promises.readFile(indexPath, 'utf8');
-      const data = JSON.parse(rawData);
-      if (data.entries && Array.isArray(data.entries)) {
-        const indexMap = new Map(data.entries.map(e => [e.sessionId, e]));
-        for (const session of allSessions) {
-          const indexed = indexMap.get(session.sessionId);
-          if (indexed) {
-            session.summary = indexed.summary || '';
-            if (indexed.messageCount) session.messageCount = indexed.messageCount;
+      // Get file stats and parse session info in parallel
+      const sessionsPromises = jsonlFiles.map(async (file) => {
+        const filePath = path.join(source.dir, file);
+        try {
+          const [stat, info] = await Promise.all([
+            fs.promises.stat(filePath),
+            extractSessionInfo(filePath)
+          ]);
+
+          // Skip sidechain sessions
+          if (info.isSidechain) return null;
+
+          // Skip files that are too small (empty/aborted sessions)
+          if (stat.size < 200) return null;
+
+          const sessionId = info.sessionId || file.replace('.jsonl', '');
+
+          return {
+            sessionId,
+            summary: '',
+            title: '',
+            customTitle: '',
+            aiTitle: '',
+            firstPrompt: info.firstPrompt || '',
+            messageCount: info.messageCount || 0,
+            modified: stat.mtime.toISOString(),
+            size: stat.size,
+            filePath,
+            gitBranch: info.gitBranch,
+            // Where this session has to be resumed. Left at the project path for
+            // a worktree that no longer exists: its transcript is still readable,
+            // but the checkout it ran in is gone.
+            cwd: source.cwd || projectPath,
+            worktree: source.worktree,
+            worktreeMissing: source.missing,
+          };
+        } catch {
+          return null;
+        }
+      });
+
+      const sessions = (await Promise.all(sessionsPromises)).filter(Boolean);
+
+      // Try to enrich with summaries from sessions-index.json
+      try {
+        const indexPath = path.join(source.dir, 'sessions-index.json');
+        const rawData = await fs.promises.readFile(indexPath, 'utf8');
+        const data = JSON.parse(rawData);
+        if (data.entries && Array.isArray(data.entries)) {
+          const indexMap = new Map(data.entries.map(e => [e.sessionId, e]));
+          for (const session of sessions) {
+            const indexed = indexMap.get(session.sessionId);
+            if (indexed) {
+              session.summary = indexed.summary || '';
+              if (indexed.messageCount) session.messageCount = indexed.messageCount;
+            }
           }
         }
+      } catch { /* index may not exist or be stale, that's ok */ }
+
+      return sessions;
+    }));
+
+    // A session that ran in the project and then in a worktree can have left a
+    // transcript in both. They are two halves of one conversation and only the
+    // last one is live, so the most recent wins and the id appears once.
+    const byId = new Map();
+    for (const session of perSource.flat()) {
+      const existing = byId.get(session.sessionId);
+      if (!existing || new Date(session.modified) > new Date(existing.modified)) {
+        byId.set(session.sessionId, session);
       }
-    } catch { /* index may not exist or be stale, that's ok */ }
+    }
+    const allSessions = [...byId.values()];
 
     // Pre-rank by mtime and read tails only for the head of that ranking: a
     // 128 KB tail read per file is wasted on sessions that can't make the cut.
@@ -293,7 +292,7 @@ async function getClaudeSessions(projectPath) {
     const sessions = top.map(({ size, filePath, ...session }) => session);
     _sessionsCache.set(projectPath, {
       at: Date.now(),
-      dirMtimeMs: await _sessionsDirMtime(sessionsDir),
+      signature: await _sessionsSignature(sources),
       sessions,
     });
     return sessions;
@@ -369,12 +368,11 @@ function interpretUserText(raw) {
  * @returns {Promise<{messages: Array, total: number, truncated: boolean, contextTokens: number}>}
  */
 async function loadSessionHistory(projectPath, sessionId, options = {}) {
-  const sessionsDir = getProjectSessionsDir(projectPath);
   const limit = options.limit === 0 ? 0 : (options.limit || DEFAULT_HISTORY_LIMIT);
   const until = options.until || null;
 
   // Find the JSONL file — uses indexed lookup
-  const filePath = await resolveSessionFile(sessionsDir, sessionId);
+  const filePath = await resolveSessionFileInProject(projectPath, sessionId);
   if (!filePath) return { messages: [], total: 0, truncated: false, contextTokens: 0 };
 
   // Read the JSONL file, keeping only a bounded window of messages in memory
@@ -622,7 +620,6 @@ const MAX_PENDING_TOOLS = 500;
  * @returns {Promise<{steps: Array, summary: object}>}
  */
 async function parseSessionReplay(projectPath, sessionId, options = {}) {
-  const sessionsDir = getProjectSessionsDir(projectPath);
   const offset = Math.max(0, options.offset || 0);
   const limit = options.limit === 0 ? 0 : (options.limit || DEFAULT_REPLAY_LIMIT);
 
@@ -632,7 +629,7 @@ async function parseSessionReplay(projectPath, sessionId, options = {}) {
   });
 
   // Find the JSONL file — uses indexed lookup
-  const filePath = await resolveSessionFile(sessionsDir, sessionId);
+  const filePath = await resolveSessionFileInProject(projectPath, sessionId);
   if (!filePath) return { steps: [], summary: emptySummary() };
 
   // Single streaming pass: summary counters cover the whole file, but only the
@@ -855,10 +852,9 @@ function patchForCreatedFile(content) {
  */
 async function parseSessionFileChanges(projectPath, sessionId, options = {}) {
   const statsOnly = !!options.statsOnly;
-  const sessionsDir = getProjectSessionsDir(projectPath);
   const empty = () => ({ files: [], totals: { files: 0, additions: 0, deletions: 0, edits: 0, truncated: false } });
 
-  const filePath = await resolveSessionFile(sessionsDir, sessionId);
+  const filePath = await resolveSessionFileInProject(projectPath, sessionId);
   if (!filePath) return empty();
 
   return new Promise((resolve) => {
@@ -1037,14 +1033,52 @@ async function resolveSessionFile(sessionsDir, sessionId) {
 }
 
 /**
+ * Resolve a session's transcript anywhere in the project — its own directory or
+ * one of its worktrees'. Every read path uses this, so a session that moved into
+ * a worktree still opens, replays, exports and deletes from the project it
+ * belongs to, without its callers having to know where it ended up.
+ *
+ * @param {string} projectPath
+ * @param {string} sessionId
+ * @returns {Promise<string|null>}
+ */
+async function resolveSessionFileInProject(projectPath, sessionId) {
+  const dirs = listProjectSessionDirs(projectPath).map(source => source.dir);
+
+  // A transcript is normally named after its session, so one `access` per
+  // directory answers this. Worth doing across all of them before any index is
+  // built: `resolveSessionFile` rebuilds a directory's index when it misses,
+  // and paying that for every worktree of a large repository is minutes of I/O
+  // on the path that reports "session not found".
+  for (const dir of dirs) {
+    const direct = path.join(dir, `${sessionId}.jsonl`);
+    try {
+      await fs.promises.access(direct);
+      return direct;
+    } catch { /* keep looking */ }
+  }
+
+  // A renamed or forked transcript only carries the id inside, so fall back to
+  // the index. Each directory is scanned at most once and the result is reused.
+  for (const dir of dirs) {
+    await buildSessionIndex(dir);
+    const cached = _sessionIndex.get(sessionId);
+    if (cached && path.dirname(cached) === dir) return cached;
+  }
+
+  // Still nothing: the session may have been created since the project's own
+  // directory was indexed. Only that one is worth re-reading.
+  return resolveSessionFile(dirs[0], sessionId);
+}
+
+/**
  * Delete a session .jsonl file
  * @param {string} projectPath
  * @param {string} sessionId
  * @returns {Promise<{success: boolean, error?: string}>}
  */
 async function deleteSession(projectPath, sessionId) {
-  const sessionsDir = getProjectSessionsDir(projectPath);
-  const filePath = await resolveSessionFile(sessionsDir, sessionId);
+  const filePath = await resolveSessionFileInProject(projectPath, sessionId);
   if (!filePath) {
     return { success: false, error: 'Session file not found' };
   }
@@ -1134,15 +1168,19 @@ async function moveSession(sessionId, fromProjectPath, toProjectPath) {
     return { success: false, code: 'bad-request', error: 'sessionId, fromProjectPath and toProjectPath are required' };
   }
 
-  const fromDir = getProjectSessionsDir(fromProjectPath);
   const toDir = getProjectSessionsDir(toProjectPath);
-  if (fromDir === toDir) {
-    return { success: false, code: 'same-project', error: 'Source and target project are the same' };
-  }
 
-  const sourceFile = await resolveSessionFile(fromDir, sessionId);
+  // The source is looked up across the project's worktrees too, and the move
+  // starts from wherever the transcript actually is. Moving a session out of a
+  // worktree is the one way to re-attach it to a project for good, so refusing
+  // exactly those would be refusing the useful case.
+  const sourceFile = await resolveSessionFileInProject(fromProjectPath, sessionId);
   if (!sourceFile) {
     return { success: false, code: 'not-found', error: 'Session file not found' };
+  }
+  const fromDir = path.dirname(sourceFile);
+  if (fromDir === toDir) {
+    return { success: false, code: 'same-project', error: 'Source and target project are the same' };
   }
 
   const fileName = path.basename(sourceFile);

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -731,6 +731,8 @@
     "rename": "Rename",
     "renamePlaceholder": "Session name...",
     "untitled": "Untitled session",
+    "worktreeRan": "Ran in the worktree {{name}} — resumes there",
+    "worktreeGone": "Ran in the worktree {{name}}, which no longer exists",
     "delete": "Delete session",
     "confirmDelete": "Are you sure you want to delete this session? This cannot be undone.",
     "deleted": "Session deleted",

--- a/src/renderer/i18n/locales/es.json
+++ b/src/renderer/i18n/locales/es.json
@@ -728,6 +728,8 @@
     "rename": "Renombrar",
     "renamePlaceholder": "Nombre de sesión...",
     "untitled": "Sesión sin título",
+    "worktreeRan": "Se ejecutó en el worktree {{name}}: se reanuda allí",
+    "worktreeGone": "Se ejecutó en el worktree {{name}}, que ya no existe",
     "delete": "Eliminar sesión",
     "confirmDelete": "¿Realmente desea eliminar esta sesión? Esta acción es irreversible.",
     "deleted": "Sesión eliminada",

--- a/src/renderer/i18n/locales/fr.json
+++ b/src/renderer/i18n/locales/fr.json
@@ -826,6 +826,8 @@
     "rename": "Renommer",
     "renamePlaceholder": "Nom de la session...",
     "untitled": "Session sans titre",
+    "worktreeRan": "S'est déroulée dans le worktree {{name}} — y reprend",
+    "worktreeGone": "S'est déroulée dans le worktree {{name}}, qui n'existe plus",
     "delete": "Supprimer la session",
     "confirmDelete": "Voulez-vous vraiment supprimer cette session ? Cette action est irréversible.",
     "deleted": "Session supprimée",

--- a/src/renderer/i18n/locales/id.json
+++ b/src/renderer/i18n/locales/id.json
@@ -731,6 +731,8 @@
     "rename": "Ganti nama",
     "renamePlaceholder": "Nama sesi...",
     "untitled": "Sesi tanpa judul",
+    "worktreeRan": "Berjalan di worktree {{name}} — dilanjutkan di sana",
+    "worktreeGone": "Berjalan di worktree {{name}}, yang sudah tidak ada",
     "delete": "Hapus sesi",
     "confirmDelete": "Anda yakin ingin menghapus sesi ini? Tindakan ini tidak dapat dibatalkan.",
     "deleted": "Sesi dihapus",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -731,6 +731,8 @@
     "rename": "重命名",
     "renamePlaceholder": "会话名称...",
     "untitled": "未命名会话",
+    "worktreeRan": "在工作树 {{name}} 中运行，将在此处恢复",
+    "worktreeGone": "在工作树 {{name}} 中运行，该工作树已不存在",
     "delete": "删除会话",
     "confirmDelete": "您确定要删除此会话吗？此操作无法撤消。",
     "deleted": "会话已删除",

--- a/src/renderer/ui/components/TerminalManager.js
+++ b/src/renderer/ui/components/TerminalManager.js
@@ -403,6 +403,14 @@ function buildSessionCardHtml(s, index) {
   const pinTitle = s.pinned ? (t('sessions.unpin') || 'Unpin') : (t('sessions.pin') || 'Pin');
   const renameTitle = t('sessions.rename') || 'Rename';
   const moveTitle = t('sessions.move.title');
+  // A session the CLI re-filed under a worktree: say where it ran, because it
+  // will resume there and not in the project root.
+  const worktreeTitle = s.worktreeMissing
+    ? t('sessions.worktreeGone', { name: s.worktree })
+    : t('sessions.worktreeRan', { name: s.worktree });
+  const worktreeHtml = s.worktree
+    ? `<span class="session-meta-worktree${s.worktreeMissing ? ' session-meta-worktree--gone' : ''}" title="${escapeHtml(worktreeTitle)}"><svg width="10" height="10" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="3" cy="3" r="1.5"/><circle cx="8" cy="3" r="1.5"/><circle cx="3" cy="8" r="1.5"/><path d="M3 4.5v3M4.5 3h3M8 4.5v1a2 2 0 01-2 2H4.5"/></svg>${escapeHtml(s.worktree)}</span>`
+    : '';
 
   return `<div class="session-card${freshClass}${pinnedClass}${renamedClass}${animClass}" data-sid="${s.sessionId}" style="--ci:${index < MAX_ANIMATED ? index : 0}">
 <div class="session-card-icon${skillClass}"><svg width="16" height="16"><use href="#${iconId}"/></svg></div>
@@ -414,6 +422,7 @@ ${s.displaySubtitle ? `<span class="session-card-subtitle">${escapeHtml(truncate
 <span class="session-meta-item"><svg width="11" height="11"><use href="#s-msg"/></svg>${s.messageCount}</span>
 <span class="session-meta-item"><svg width="11" height="11"><use href="#s-clock"/></svg>${formatRelativeTime(s.modified)}</span>
 ${s.gitBranch ? `<span class="session-meta-branch"><svg width="10" height="10"><use href="#s-branch"/></svg>${escapeHtml(s.gitBranch)}</span>` : ''}
+${worktreeHtml}
 </div>
 <div class="session-card-actions">
 <button class="session-card-rename" data-rename-sid="${s.sessionId}" title="${escapeHtml(renameTitle)}" aria-label="${escapeHtml(renameTitle)}"><svg width="12" height="12"><use href="#s-rename"/></svg></button>
@@ -2840,7 +2849,7 @@ class TerminalManager extends BaseComponent {
       const freshness = hoursAgo < 1 ? 'hot' : hoursAgo < 24 ? 'warm' : '';
 
       const searchText = (displayTitle + ' ' + displaySubtitle + ' ' + (session.gitBranch || '')
-        + ' ' + customName).toLowerCase();
+        + ' ' + (session.worktree || '') + ' ' + customName).toLowerCase();
 
       const pinned = await this._isSessionPinned(session.sessionId);
       results.push({ ...session, displayTitle, displaySubtitle, isSkill, isRenamed, nameLocked: Boolean(lockedName), freshness, searchText, pinned });
@@ -3082,7 +3091,10 @@ class TerminalManager extends BaseComponent {
         self.resumeSession(project, sessionId, {
           skipPermissions,
           name: tabLabel || null,
-          nameCustom: !!session?.nameLocked
+          nameCustom: !!session?.nameLocked,
+          // The CLI resolves --resume against the cwd it is launched with, so a
+          // session that ran in a worktree only reopens from that worktree.
+          cwd: session?.cwd || null
         });
       });
 
@@ -3143,16 +3155,22 @@ class TerminalManager extends BaseComponent {
   // ── Resume session ──
 
   async resumeSession(project, sessionId, options = {}) {
-    const { skipPermissions = false, name: sessionName = null, nameCustom = false } = options;
+    const { skipPermissions = false, name: sessionName = null, nameCustom = false, cwd: overrideCwd = null } = options;
+    // A worktree session keeps running where it ran; anything else is the project.
+    const resumeCwd = overrideCwd && overrideCwd !== project.path ? overrideCwd : null;
 
     const mode = getSetting('defaultTerminalMode') || 'terminal';
     if (mode === 'chat') {
       console.log(`[TerminalManager] Resuming in chat mode — sessionId: ${sessionId}`);
-      return this._createChatTerminal(project, { skipPermissions, resumeSessionId: sessionId, name: sessionName, nameCustom });
+      const chatProject = resumeCwd ? { ...project, path: resumeCwd } : project;
+      return this._createChatTerminal(chatProject, {
+        skipPermissions, resumeSessionId: sessionId, name: sessionName, nameCustom,
+        parentProjectId: resumeCwd ? project.id : null
+      });
     }
 
     const result = await this._api.terminal.create({
-      cwd: project.path,
+      cwd: resumeCwd || project.path,
       runClaude: true,
       resumeSessionId: sessionId,
       skipPermissions
@@ -3197,9 +3215,11 @@ class TerminalManager extends BaseComponent {
       isBasic: false,
       mode: 'terminal',
       claudeSessionId: sessionId,
+      cwd: resumeCwd || project.path,
       tabId: generateTabId(project.id),
       createdAt: nowIsoResume,
       lastActivityAt: nowIsoResume,
+      ...(resumeCwd ? { parentProjectId: project.id } : {})
     };
 
     addTerminal(id, termData);
@@ -3214,10 +3234,11 @@ class TerminalManager extends BaseComponent {
 
     const tabsContainer = document.getElementById('terminals-tabs');
     const tab = document.createElement('div');
-    tab.className = 'terminal-tab status-working';
+    tab.className = `terminal-tab status-working${resumeCwd ? ' worktree-tab' : ''}`;
     tab.dataset.id = id;
     tab.innerHTML = `
     <span class="status-dot"></span>
+    ${resumeCwd ? `<span class="tab-worktree-icon" title="Worktree"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="4" cy="4" r="1.5"/><circle cx="12" cy="4" r="1.5"/><circle cx="4" cy="12" r="1.5"/><path d="M4 5.5v5M5.5 4h5M12 5.5v2.5a2 2 0 01-2 2H7"/></svg></span>` : ''}
     <span class="tab-name">${escapeHtml(sessionName || t('terminals.resuming'))}</span>
     <button class="tab-close" aria-label="${escapeHtml(t('common.close'))}"><svg viewBox="0 0 12 12"><path d="M1 1l10 10M11 1L1 11" stroke="currentColor" stroke-width="1.5" fill="none"/></svg></button>`;
     tabsContainer.appendChild(tab);

--- a/src/shared/session-dirs.js
+++ b/src/shared/session-dirs.js
@@ -1,0 +1,227 @@
+'use strict';
+
+/**
+ * Where a project's transcripts live.
+ *
+ * Claude Code files a transcript under the directory encoding of the cwd it is
+ * running in, and it re-files the whole file when that cwd changes. A session
+ * that enters a worktree — `EnterWorktree`, or a worktree tab — therefore moves
+ * out of the project's directory and into the worktree's, taking its history
+ * with it. Reading only `getProjectSessionsDir(project.path)` made those
+ * sessions disappear from the project they belong to, with no way back to them
+ * from the app at all.
+ *
+ * So a project's sessions are the union of its own directory and the
+ * directories of its worktrees, and every session carries the cwd it must be
+ * resumed in.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+/** Root of Claude Code's per-project transcript directories. */
+function claudeProjectsRoot() {
+  return path.join(os.homedir(), '.claude', 'projects');
+}
+
+/**
+ * Encode a project path the way Claude Code names its transcript directory.
+ * Every non-alphanumeric character becomes a dash, so the encoding is lossy and
+ * cannot be reversed — a directory name only ever tells you what a path would
+ * encode to, never what the path was.
+ *
+ * @param {string} projectPath
+ * @returns {string}
+ */
+function encodeProjectPath(projectPath) {
+  const MAX_LEN = 200;
+  const encoded = projectPath.replace(/[^a-zA-Z0-9]/g, '-');
+  if (encoded.length <= MAX_LEN) return encoded;
+  // For paths exceeding 200 chars: truncate + append a simple hash
+  // (mirrors Claude Code's hMK hash — DJB2-style string hash in base36)
+  let hash = 0;
+  for (let i = 0; i < projectPath.length; i++) {
+    hash = ((hash << 5) - hash + projectPath.charCodeAt(i)) | 0;
+  }
+  return `${encoded.slice(0, MAX_LEN)}-${Math.abs(hash).toString(36)}`;
+}
+
+/**
+ * The transcript directory for one cwd.
+ * @param {string} projectPath
+ * @returns {string}
+ */
+function getProjectSessionsDir(projectPath) {
+  return path.join(claudeProjectsRoot(), encodeProjectPath(projectPath));
+}
+
+/**
+ * The repository's common git directory, from any of its worktrees.
+ *
+ * In the main checkout `.git` is a directory. In a linked worktree it is a file
+ * holding `gitdir: <common>/worktrees/<name>`, so the common directory is two
+ * levels up from what it points at.
+ *
+ * @param {string} repoPath
+ * @returns {string|null}
+ */
+function commonGitDir(repoPath) {
+  const dotGit = path.join(repoPath, '.git');
+  let stat;
+  try {
+    stat = fs.statSync(dotGit);
+  } catch {
+    return null;
+  }
+  if (stat.isDirectory()) return dotGit;
+
+  try {
+    const pointer = fs.readFileSync(dotGit, 'utf8').trim();
+    const match = /^gitdir:\s*(.+)$/.exec(pointer);
+    if (!match) return null;
+    // <common>/worktrees/<name> -> <common>
+    const linked = path.resolve(repoPath, match[1].trim());
+    return path.dirname(path.dirname(linked));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Paths of every worktree linked to this repository, excluding `repoPath`.
+ *
+ * Read from `.git/worktrees/<name>/gitdir` rather than by running
+ * `git worktree list`: this is on the path of every session listing, and the
+ * files say the same thing without a subprocess. It also works from inside a
+ * worktree, and finds worktrees checked out anywhere on disk.
+ *
+ * @param {string} repoPath
+ * @returns {string[]}
+ */
+function linkedWorktreePaths(repoPath) {
+  const common = commonGitDir(repoPath);
+  if (!common) return [];
+
+  let entries;
+  try {
+    entries = fs.readdirSync(path.join(common, 'worktrees'), { withFileTypes: true });
+  } catch {
+    return []; // repository has no linked worktrees
+  }
+
+  const found = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    try {
+      // Points at `<worktree>/.git`, so the worktree is its parent.
+      const gitdir = fs.readFileSync(path.join(common, 'worktrees', entry.name, 'gitdir'), 'utf8').trim();
+      if (!gitdir) continue;
+      const worktreePath = path.dirname(gitdir);
+      if (worktreePath && worktreePath !== repoPath) found.push(worktreePath);
+    } catch { /* half-written or pruned entry */ }
+  }
+  return found;
+}
+
+// A worktree Claude Code created for itself lives at `<repo>/.claude/worktrees/<name>`,
+// which encodes to `<repo dir>--claude-worktrees-<name>`. Matching that prefix is
+// what still finds the transcripts of a worktree that has since been removed:
+// `git worktree remove` deletes the checkout and the `.git/worktrees` entry, but
+// never the conversations that ran there.
+const CLAUDE_WORKTREE_INFIX = '--claude-worktrees-';
+
+/**
+ * Transcript directories of removed `<repo>/.claude/worktrees/*` worktrees.
+ *
+ * Only worktrees under the repository itself can be recovered this way. A
+ * removed worktree checked out elsewhere encodes to a directory name with
+ * nothing left tying it to the project, and the encoding cannot be reversed.
+ *
+ * @param {string} repoPath
+ * @param {Set<string>} known - Directory names already accounted for
+ * @returns {Array<{dir: string, name: string}>}
+ */
+function orphanedWorktreeDirs(repoPath, known) {
+  const prefix = encodeProjectPath(repoPath) + CLAUDE_WORKTREE_INFIX;
+  let entries;
+  try {
+    entries = fs.readdirSync(claudeProjectsRoot(), { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const found = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (!entry.name.startsWith(prefix) || entry.name.length === prefix.length) continue;
+    if (known.has(entry.name)) continue;
+    found.push({
+      dir: path.join(claudeProjectsRoot(), entry.name),
+      name: entry.name.slice(prefix.length),
+    });
+  }
+  return found;
+}
+
+/**
+ * Every transcript directory a project's sessions can be in.
+ *
+ * The project's own directory comes first, then one entry per worktree. A
+ * `cwd` of null marks a worktree that no longer exists: its transcripts are
+ * still readable, but there is nowhere to resume them except the project root.
+ *
+ * @param {string} projectPath
+ * @returns {Array<{dir: string, cwd: string|null, worktree: string|null, missing: boolean}>}
+ */
+// Resolving a session's file, listing a project and answering an `@session`
+// mention all ask for this within the same interaction, and each answer walks
+// `.git/worktrees` and the projects root. A repository with dozens of worktrees
+// makes that measurable, so the shape of the layout is held briefly.
+const LAYOUT_CACHE_MS = 5000;
+const _layoutCache = new Map(); // projectPath -> { at, dirs }
+
+/** Drop the memoized layout, for tests and for a worktree just created. */
+function invalidateSessionDirs(projectPath) {
+  if (projectPath) _layoutCache.delete(projectPath);
+  else _layoutCache.clear();
+}
+
+function listProjectSessionDirs(projectPath) {
+  const cached = _layoutCache.get(projectPath);
+  if (cached && Date.now() - cached.at < LAYOUT_CACHE_MS) return cached.dirs;
+
+  const dirs = [{
+    dir: getProjectSessionsDir(projectPath),
+    cwd: projectPath,
+    worktree: null,
+    missing: false,
+  }];
+  const seen = new Set([path.basename(dirs[0].dir)]);
+
+  for (const worktreePath of linkedWorktreePaths(projectPath)) {
+    const name = path.basename(worktreePath);
+    const dir = getProjectSessionsDir(worktreePath);
+    if (seen.has(path.basename(dir))) continue;
+    seen.add(path.basename(dir));
+    dirs.push({ dir, cwd: worktreePath, worktree: name, missing: false });
+  }
+
+  for (const { dir, name } of orphanedWorktreeDirs(projectPath, seen)) {
+    dirs.push({ dir, cwd: null, worktree: name, missing: true });
+  }
+
+  _layoutCache.set(projectPath, { at: Date.now(), dirs });
+  return dirs;
+}
+
+module.exports = {
+  claudeProjectsRoot,
+  encodeProjectPath,
+  getProjectSessionsDir,
+  commonGitDir,
+  linkedWorktreePaths,
+  orphanedWorktreeDirs,
+  listProjectSessionDirs,
+  invalidateSessionDirs,
+  CLAUDE_WORKTREE_INFIX,
+};

--- a/styles/projects.css
+++ b/styles/projects.css
@@ -1633,6 +1633,46 @@ body.compact-projects .project-item:not(.active):hover {
   flex-shrink: 0;
 }
 
+/* ── Worktree chip ──
+   Marks a session the CLI re-filed under a worktree of this project. It reads
+   as a sibling of the branch chip rather than a warning: the session is not
+   misplaced, it simply resumes somewhere other than the project root, and the
+   chip is the only thing on the card that says so.
+
+   `--gone` is the worktree that has since been removed. Its transcript is still
+   readable, so the chip is dimmed rather than coloured like an error. */
+.session-meta-worktree {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10.5px;
+  color: var(--accent);
+  background: var(--accent-dim);
+  padding: 2px 8px;
+  border-radius: 6px;
+  font-family: 'Cascadia Code', monospace;
+  max-width: 140px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  opacity: 0.85;
+}
+
+.session-meta-worktree svg {
+  width: 10px;
+  height: 10px;
+  max-width: 10px;
+  max-height: 10px;
+  flex-shrink: 0;
+}
+
+.session-meta-worktree--gone {
+  color: var(--text-muted);
+  background: var(--bg-tertiary);
+  opacity: 0.6;
+  text-decoration: line-through;
+}
+
 /* ── Card action buttons (rename, move, pin) ──
    One rule for the three: they are the same control with a different glyph.
 

--- a/tests/ipc/claudeWorktreeSessions.test.js
+++ b/tests/ipc/claudeWorktreeSessions.test.js
@@ -1,0 +1,154 @@
+// A session that moved into a worktree still belongs to its project.
+//
+// Claude Code files a transcript under the directory encoding of the cwd it runs
+// in, and re-files the whole file when that cwd changes. Entering a worktree
+// therefore moved a session out of the project's directory — and out of the app,
+// which only ever read that one directory. These tests pin it back in place:
+// listed, readable, resumable in the right cwd, and deletable.
+
+const realOs = require('os');
+const fs = require('fs');
+const path = require('path');
+
+const TMP_HOME = fs.mkdtempSync(path.join(realOs.tmpdir(), 'ct-worktree-sessions-'));
+
+jest.mock('electron', () => ({
+  ipcMain: { handle: jest.fn(), removeHandler: jest.fn() }
+}));
+
+jest.mock('os', () => ({
+  ...jest.requireActual('os'),
+  homedir: () => global.__CT_TMP_HOME__
+}));
+
+global.__CT_TMP_HOME__ = TMP_HOME;
+
+const {
+  getClaudeSessions,
+  loadSessionHistory,
+  moveSession,
+  invalidateSessionsCache,
+} = require('../../src/main/ipc/claude.ipc');
+const { getProjectSessionsDir, invalidateSessionDirs } = require('../../src/shared/session-dirs');
+
+const REPO = path.join(TMP_HOME, 'repo');
+const WORKTREE = path.join(REPO, '.claude', 'worktrees', 'snapshot-retention');
+const OTHER_PROJECT = path.join(TMP_HOME, 'other');
+
+const IN_PROJECT = 'aaaaaaaa-0000-0000-0000-000000000001';
+const IN_WORKTREE = 'bbbbbbbb-0000-0000-0000-000000000002';
+
+function addWorktree(name, worktreePath) {
+  const entry = path.join(REPO, '.git', 'worktrees', name);
+  fs.mkdirSync(entry, { recursive: true });
+  fs.writeFileSync(path.join(entry, 'gitdir'), `${path.join(worktreePath, '.git')}\n`);
+  fs.mkdirSync(worktreePath, { recursive: true });
+  fs.writeFileSync(path.join(worktreePath, '.git'), `gitdir: ${entry}\n`);
+}
+
+/** A transcript long enough to clear the "empty session" floor. */
+function writeSession(cwd, sessionId, prompt) {
+  const dir = getProjectSessionsDir(cwd);
+  fs.mkdirSync(dir, { recursive: true });
+  const lines = [
+    JSON.stringify({
+      type: 'user', uuid: 'u-1', sessionId, cwd, gitBranch: 'main',
+      message: { role: 'user', content: prompt }
+    }),
+    JSON.stringify({
+      type: 'assistant', uuid: 'a-1', sessionId,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'x'.repeat(300) }] }
+    }),
+  ];
+  const file = path.join(dir, `${sessionId}.jsonl`);
+  fs.writeFileSync(file, lines.join('\n') + '\n');
+  return file;
+}
+
+beforeEach(() => {
+  fs.rmSync(REPO, { recursive: true, force: true });
+  fs.rmSync(path.join(TMP_HOME, '.claude'), { recursive: true, force: true });
+  fs.mkdirSync(path.join(REPO, '.git'), { recursive: true });
+  addWorktree('snapshot-retention', WORKTREE);
+  invalidateSessionDirs();
+  invalidateSessionsCache();
+});
+
+test('lists sessions that ran in a worktree alongside the project\'s own', async () => {
+  writeSession(REPO, IN_PROJECT, 'started at the root');
+  writeSession(WORKTREE, IN_WORKTREE, 'moved into the worktree');
+
+  const sessions = await getClaudeSessions(REPO);
+  const ids = sessions.map(s => s.sessionId);
+
+  expect(ids).toContain(IN_PROJECT);
+  expect(ids).toContain(IN_WORKTREE);
+});
+
+test('says where a worktree session runs, so it can be resumed there', async () => {
+  writeSession(REPO, IN_PROJECT, 'started at the root');
+  writeSession(WORKTREE, IN_WORKTREE, 'moved into the worktree');
+
+  const sessions = await getClaudeSessions(REPO);
+  const own = sessions.find(s => s.sessionId === IN_PROJECT);
+  const moved = sessions.find(s => s.sessionId === IN_WORKTREE);
+
+  expect(own).toMatchObject({ cwd: REPO, worktree: null, worktreeMissing: false });
+  expect(moved).toMatchObject({
+    cwd: WORKTREE, worktree: 'snapshot-retention', worktreeMissing: false
+  });
+});
+
+test('a removed worktree keeps its history, resumable from the project root', async () => {
+  writeSession(WORKTREE, IN_WORKTREE, 'ran in a worktree that is now gone');
+  // `git worktree remove` takes the checkout and the .git/worktrees entry.
+  fs.rmSync(path.join(REPO, '.git', 'worktrees', 'snapshot-retention'), { recursive: true });
+  fs.rmSync(WORKTREE, { recursive: true });
+  invalidateSessionDirs();
+  invalidateSessionsCache();
+
+  const [session] = await getClaudeSessions(REPO);
+  expect(session).toMatchObject({
+    sessionId: IN_WORKTREE, cwd: REPO, worktree: 'snapshot-retention', worktreeMissing: true
+  });
+});
+
+test('reads the history of a worktree session from the project', async () => {
+  writeSession(WORKTREE, IN_WORKTREE, 'moved into the worktree');
+
+  const { messages } = await loadSessionHistory(REPO, IN_WORKTREE);
+  expect(messages[0]).toMatchObject({ role: 'user', text: 'moved into the worktree' });
+});
+
+test('reports a genuinely unknown session as absent', async () => {
+  writeSession(REPO, IN_PROJECT, 'started at the root');
+
+  const { messages, total } = await loadSessionHistory(REPO, 'cccccccc-0000-0000-0000-000000000003');
+  expect(messages).toEqual([]);
+  expect(total).toBe(0);
+});
+
+test('the same session in both places is listed once, at its latest', async () => {
+  // The project's copy is what the CLI left behind when the session moved on.
+  writeSession(REPO, IN_WORKTREE, 'the half that stayed behind');
+  const moved = writeSession(WORKTREE, IN_WORKTREE, 'the half that kept going');
+  const later = new Date(Date.now() + 60_000);
+  fs.utimesSync(moved, later, later);
+  invalidateSessionsCache();
+
+  const sessions = await getClaudeSessions(REPO);
+  expect(sessions.filter(s => s.sessionId === IN_WORKTREE)).toHaveLength(1);
+  expect(sessions[0].worktree).toBe('snapshot-retention');
+});
+
+test('moves a worktree session out to another project', async () => {
+  writeSession(WORKTREE, IN_WORKTREE, 'moved into the worktree');
+  fs.mkdirSync(OTHER_PROJECT, { recursive: true });
+
+  const result = await moveSession(IN_WORKTREE, REPO, OTHER_PROJECT);
+  expect(result.success).toBe(true);
+
+  const target = path.join(getProjectSessionsDir(OTHER_PROJECT), `${IN_WORKTREE}.jsonl`);
+  expect(fs.existsSync(target)).toBe(true);
+  expect(fs.existsSync(path.join(getProjectSessionsDir(WORKTREE), `${IN_WORKTREE}.jsonl`))).toBe(false);
+});

--- a/tests/shared/sessionDirs.test.js
+++ b/tests/shared/sessionDirs.test.js
@@ -1,0 +1,162 @@
+// Where a project's transcripts live.
+//
+// Claude Code re-files a transcript when the session's cwd changes, so a session
+// that enters a worktree leaves the project's directory. These tests pin the
+// layout discovery that puts it back in the project's listing.
+
+const realOs = require('os');
+const fs = require('fs');
+const path = require('path');
+
+const TMP_HOME = fs.mkdtempSync(path.join(realOs.tmpdir(), 'ct-session-dirs-'));
+
+jest.mock('os', () => ({
+  ...jest.requireActual('os'),
+  homedir: () => global.__CT_TMP_HOME__
+}));
+
+global.__CT_TMP_HOME__ = TMP_HOME;
+
+const {
+  encodeProjectPath,
+  getProjectSessionsDir,
+  commonGitDir,
+  linkedWorktreePaths,
+  listProjectSessionDirs,
+  invalidateSessionDirs,
+} = require('../../src/shared/session-dirs');
+
+const REPO = path.join(TMP_HOME, 'repo');
+
+function projectsRoot() {
+  return path.join(TMP_HOME, '.claude', 'projects');
+}
+
+/** Register a linked worktree the way `git worktree add` does. */
+function addWorktree(name, worktreePath) {
+  const entry = path.join(REPO, '.git', 'worktrees', name);
+  fs.mkdirSync(entry, { recursive: true });
+  fs.writeFileSync(path.join(entry, 'gitdir'), `${path.join(worktreePath, '.git')}\n`);
+  fs.mkdirSync(worktreePath, { recursive: true });
+  fs.writeFileSync(path.join(worktreePath, '.git'), `gitdir: ${entry}\n`);
+}
+
+/** Give a cwd a transcript directory holding one session. */
+function seedTranscripts(cwd) {
+  const dir = getProjectSessionsDir(cwd);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'a.jsonl'), '{}\n');
+  return dir;
+}
+
+beforeEach(() => {
+  fs.rmSync(REPO, { recursive: true, force: true });
+  fs.rmSync(projectsRoot(), { recursive: true, force: true });
+  fs.mkdirSync(path.join(REPO, '.git'), { recursive: true });
+  fs.mkdirSync(projectsRoot(), { recursive: true });
+  invalidateSessionDirs();
+});
+
+describe('encodeProjectPath', () => {
+  test('replaces every non-alphanumeric character', () => {
+    expect(encodeProjectPath('/a/b.c d')).toBe('-a-b-c-d');
+  });
+
+  test('truncates and hashes paths beyond 200 characters', () => {
+    const long = '/' + 'x'.repeat(300);
+    const encoded = encodeProjectPath(long);
+    expect(encoded.length).toBeGreaterThan(200);
+    expect(encoded.slice(0, 200)).toBe('-' + 'x'.repeat(199));
+    expect(encodeProjectPath(long)).toBe(encoded);
+  });
+});
+
+describe('commonGitDir', () => {
+  test('is .git itself in the main checkout', () => {
+    expect(commonGitDir(REPO)).toBe(path.join(REPO, '.git'));
+  });
+
+  test('resolves back to the repository from inside a worktree', () => {
+    const wt = path.join(REPO, '.claude', 'worktrees', 'feature');
+    addWorktree('feature', wt);
+    expect(commonGitDir(wt)).toBe(path.join(REPO, '.git'));
+  });
+
+  test('is null outside a repository', () => {
+    expect(commonGitDir(path.join(TMP_HOME, 'not-a-repo'))).toBeNull();
+  });
+});
+
+describe('linkedWorktreePaths', () => {
+  test('finds worktrees wherever they are checked out', () => {
+    const inside = path.join(REPO, '.claude', 'worktrees', 'feature');
+    const outside = path.join(TMP_HOME, 'elsewhere', 'hotfix');
+    addWorktree('feature', inside);
+    addWorktree('hotfix', outside);
+    expect(linkedWorktreePaths(REPO).sort()).toEqual([inside, outside].sort());
+  });
+
+  test('is empty for a repository without worktrees', () => {
+    expect(linkedWorktreePaths(REPO)).toEqual([]);
+  });
+
+  test('skips a half-pruned entry rather than throwing', () => {
+    fs.mkdirSync(path.join(REPO, '.git', 'worktrees', 'ghost'), { recursive: true });
+    expect(linkedWorktreePaths(REPO)).toEqual([]);
+  });
+});
+
+describe('listProjectSessionDirs', () => {
+  test('puts the project first and carries the cwd of each worktree', () => {
+    const wt = path.join(REPO, '.claude', 'worktrees', 'feature');
+    addWorktree('feature', wt);
+
+    const dirs = listProjectSessionDirs(REPO);
+    expect(dirs[0]).toEqual({
+      dir: getProjectSessionsDir(REPO), cwd: REPO, worktree: null, missing: false
+    });
+    expect(dirs).toContainEqual({
+      dir: getProjectSessionsDir(wt), cwd: wt, worktree: 'feature', missing: false
+    });
+  });
+
+  test('still finds the transcripts of a removed worktree', () => {
+    // `git worktree remove` deletes the checkout and the .git/worktrees entry.
+    // The conversations that ran there are not deleted with it.
+    const wt = path.join(REPO, '.claude', 'worktrees', 'gone');
+    const dir = seedTranscripts(wt);
+    invalidateSessionDirs();
+
+    const orphan = listProjectSessionDirs(REPO).find(source => source.dir === dir);
+    expect(orphan).toEqual({ dir, cwd: null, worktree: 'gone', missing: true });
+  });
+
+  test('does not claim a sibling project whose name extends this one', () => {
+    // `<repo>-old` encodes to a directory name starting with `<repo>`, and a
+    // prefix match alone would fold its sessions into this project's listing.
+    seedTranscripts(REPO + '-old');
+    invalidateSessionDirs();
+
+    expect(listProjectSessionDirs(REPO)).toHaveLength(1);
+  });
+
+  test('lists a live worktree once, not also as a removed one', () => {
+    const wt = path.join(REPO, '.claude', 'worktrees', 'feature');
+    addWorktree('feature', wt);
+    seedTranscripts(wt);
+    invalidateSessionDirs();
+
+    const dirs = listProjectSessionDirs(REPO);
+    const forWorktree = dirs.filter(source => source.dir === getProjectSessionsDir(wt));
+    expect(forWorktree).toHaveLength(1);
+    expect(forWorktree[0].missing).toBe(false);
+  });
+
+  test('a project outside any repository is just its own directory', () => {
+    const plain = path.join(TMP_HOME, 'plain');
+    fs.mkdirSync(plain, { recursive: true });
+    expect(listProjectSessionDirs(plain)).toEqual([
+      { dir: getProjectSessionsDir(plain), cwd: plain, worktree: null, missing: false }
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes #167

## The defect

Claude Code files a transcript under the directory encoding of the cwd it is running in, and re-files the whole file when that cwd changes. A session that enters a worktree therefore leaves the project's directory for the worktree's, history and all.

The app read exactly one directory per project, so those sessions did not just lose their place in the list — they had no entry point left anywhere in the app. On the repository this was found in, 32 of 115 conversations were unreachable, including one that had been worked in that morning.

## The change

A project's sessions are now the union of its own directory and its worktrees'.

**`src/shared/session-dirs.js` (new)** owns the layout: the path encoding (previously duplicated between `claude.ipc.js` and the MCP tool) and `listProjectSessionDirs(projectPath)`, which returns the project's directory followed by one entry per worktree, each carrying the cwd it stands for.

The worktree list is read from `.git/worktrees/*/gitdir` rather than by running `git worktree list`: this sits on the path of every session listing, the files say the same thing without a subprocess, and it finds worktrees checked out anywhere on disk. Transcripts of a worktree that has *since been removed* are recovered from the encoded directory name — only for worktrees under the repository itself, since the encoding is lossy and a removed worktree elsewhere leaves nothing tying it to the project.

**Resuming follows the session.** The CLI resolves `--resume` against the cwd it is launched with, so listing these sessions without reopening them in the right place would have traded an invisible session for one that opens empty. Each session carries its cwd; `resumeSession` uses it, reusing the worktree-tab mechanism already in `createTerminal` (`termData.cwd`, `parentProjectId`, the `worktree-tab` glyph). A removed worktree falls back to the project root.

**One resolver for the read paths.** `resolveSessionFileInProject` spans the project and its worktrees, so history, replay, per-session diffs, export and delete all follow without their callers knowing where the file ended up. It tries the direct filename across every directory before building any index — `resolveSessionFile` rebuilds a directory's index when it misses, and paying that per worktree on a large repository would be minutes of I/O on the path that reports "not found".

**Moving a session** now starts from wherever the transcript actually is, which makes "move to another project" the way to re-attach one for good instead of failing on exactly the sessions this makes visible.

**The MCP tools** (`session_list`, `session_recap`, `session_replay`) require the shared module rather than mirroring the encoding, so they see the same history the app does.

## What it looks like

The session card gains a worktree chip next to the branch chip, and the tab wears the worktree glyph. A removed worktree is struck through and dimmed rather than coloured as an error — the conversation is still readable.

## Cost

The cached listing is validated against the mtimes of every source directory instead of one, so a worktree gaining its first transcript still shows up on the next call. The layout itself is memoized for 5s, because resolving a file, listing a project and answering an `@session` mention all ask for it within one interaction.

## Tests

`tests/shared/sessionDirs.test.js` (13) covers the encoding, the common git dir from inside a worktree, worktrees checked out elsewhere, half-pruned entries, and the two ways this could go wrong: a sibling project whose name extends the repository's must not be folded in, and a live worktree must not also be listed as a removed one.

`tests/ipc/claudeWorktreeSessions.test.js` (7) covers the listing, the cwd each session reports, a removed worktree, reading history from the project, an unknown session still reporting absent, one session left in both places being listed once at its latest, and moving a worktree session out.

Full suite: 2818 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)