### PR TITLE
fix(shortcuts): stop the default push-to-talk bind freezing the keyboard on Linux

### DIFF
--- a/main.js
+++ b/main.js
@@ -66,6 +66,7 @@ function bootstrapApp() {
 
   const fs = require('fs');
   const { loadAccentColor, settingsFile } = require('./src/main/utils/paths');
+  const { resolveGlobalShortcuts } = require('./src/shared/global-shortcuts');
   const { initializeServices, cleanupServices, hookEventServer } = require('./src/main/services');
   const { registerAllHandlers } = require('./src/main/ipc');
   const {
@@ -179,25 +180,16 @@ function bootstrapApp() {
   });
 
   /**
-   * Default global shortcut keybindings
-   */
-  const GLOBAL_SHORTCUT_DEFAULTS = {
-    globalQuickPicker: 'CommandOrControl+Shift+P',
-    globalNewTerminal: 'CommandOrControl+Shift+T',
-    globalNewWorktree: 'CommandOrControl+Shift+W',
-    // F13 by default: no game binds it, and any gaming mouse can map a side
-    // button to it — so it can be pressed mid-game without freeing a hand.
-    globalPushToTalk: 'F13'
-  };
-
-  /**
    * Global shortcut action handlers
    */
   const GLOBAL_SHORTCUT_ACTIONS = {
     /**
-     * Push-to-talk. Unlike every other global action this must NOT call
-     * showMainWindow(): the whole point is to dictate while a fullscreen game
-     * holds focus, and raising the window would minimise the game.
+     * Push-to-talk. Unbound by default — the user has to pick a key, see
+     * GLOBAL_SHORTCUT_DEFAULTS in src/shared/global-shortcuts.js.
+     *
+     * Unlike every other global action this must NOT call showMainWindow():
+     * the whole point is to dictate while a fullscreen game holds focus, and
+     * raising the window would minimise the game.
      *
      * It toggles rather than holds because globalShortcut only reports the key
      * press — Electron exposes no key-release event — so the renderer stops on
@@ -240,15 +232,6 @@ function bootstrapApp() {
   };
 
   /**
-   * Convert renderer-style key string (Ctrl+Shift+P) to Electron accelerator format
-   */
-  function toElectronAccelerator(key) {
-    if (!key) return null;
-    return key.replace(/Ctrl/gi, 'CommandOrControl')
-      .replace(/Meta/gi, 'CommandOrControl');
-  }
-
-  /**
    * Load global shortcut overrides from settings.json
    */
   function loadGlobalShortcutSettings() {
@@ -280,19 +263,20 @@ function bootstrapApp() {
     registeredAccelerators.clear();
 
     const config = overrides || loadGlobalShortcutSettings();
-    if (!config.enabled) return;
+    const { resolved, rejected } = resolveGlobalShortcuts(config);
 
-    for (const [id, defaultKey] of Object.entries(GLOBAL_SHORTCUT_DEFAULTS)) {
-      const customKey = config.overrides[id];
-      const accelerator = customKey ? toElectronAccelerator(customKey) : defaultKey;
+    for (const { id, accelerator, reason } of rejected) {
+      console.warn(`[GlobalShortcuts] Refusing to register ${id} (${accelerator}): ${reason}`);
+    }
+
+    for (const { id, accelerator } of resolved) {
       const action = GLOBAL_SHORTCUT_ACTIONS[id];
-      if (accelerator && action) {
-        try {
-          globalShortcut.register(accelerator, action);
-          registeredAccelerators.add(accelerator);
-        } catch (e) {
-          console.error(`[GlobalShortcuts] Failed to register ${id} (${accelerator}):`, e);
-        }
+      if (!action) continue;
+      try {
+        globalShortcut.register(accelerator, action);
+        registeredAccelerators.add(accelerator);
+      } catch (e) {
+        console.error(`[GlobalShortcuts] Failed to register ${id} (${accelerator}):`, e);
       }
     }
   }

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -596,6 +596,7 @@
     "waiting": "Waiting...",
     "pressEscapeToCancel": "Press Escape to cancel",
     "modifierRequired": "A modifier (Ctrl, Alt, Shift) is required",
+    "unsafeKeyOnLinux": "On Linux this key is often unmapped, and binding it would capture the entire keyboard. Pick another key.",
     "conflictWith": "Conflict with: {label}",
     "openSettings": "Open settings",
     "closeTerminal": "Close terminal",

--- a/src/renderer/i18n/locales/es.json
+++ b/src/renderer/i18n/locales/es.json
@@ -596,6 +596,7 @@
     "waiting": "Esperando...",
     "pressEscapeToCancel": "Pulsa Escape para cancelar",
     "modifierRequired": "Se requiere un modificador (Ctrl, Alt, Shift)",
+    "unsafeKeyOnLinux": "En Linux esta tecla suele no estar asignada, y vincularla capturaría todo el teclado. Elige otra tecla.",
     "conflictWith": "Conflicto con: {label}",
     "openSettings": "Abrir ajustes",
     "closeTerminal": "Cerrar terminal",

--- a/src/renderer/i18n/locales/fr.json
+++ b/src/renderer/i18n/locales/fr.json
@@ -691,6 +691,7 @@
     "waiting": "En attente...",
     "pressEscapeToCancel": "Appuyez sur Échap pour annuler",
     "modifierRequired": "Un modificateur (Ctrl, Alt, Shift) est requis",
+    "unsafeKeyOnLinux": "Sous Linux cette touche est souvent non mappée, et l'assigner capturerait le clavier entier. Choisissez une autre touche.",
     "conflictWith": "Conflit avec: {label}",
     "openSettings": "Ouvrir les paramètres",
     "closeTerminal": "Fermer le terminal",

--- a/src/renderer/i18n/locales/id.json
+++ b/src/renderer/i18n/locales/id.json
@@ -596,6 +596,7 @@
     "waiting": "Menunggu...",
     "pressEscapeToCancel": "Tekan Escape untuk membatalkan",
     "modifierRequired": "Diperlukan tombol modifier (Ctrl, Alt, Shift)",
+    "unsafeKeyOnLinux": "Di Linux tombol ini sering tidak terpetakan, dan menetapkannya akan menangkap seluruh papan ketik. Pilih tombol lain.",
     "conflictWith": "Bentrok dengan: {label}",
     "openSettings": "Buka pengaturan",
     "closeTerminal": "Tutup terminal",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -596,6 +596,7 @@
     "waiting": "等待...",
     "pressEscapeToCancel": "按 Esc 键取消",
     "modifierRequired": "需要修饰键（Ctrl、Alt、Shift）",
+    "unsafeKeyOnLinux": "在 Linux 上此键通常未映射，绑定它会捕获整个键盘。请另选一个按键。",
     "conflictWith": "冲突：{label}",
     "openSettings": "打开设置",
     "closeTerminal": "关闭终端",

--- a/src/renderer/ui/panels/ShortcutsManager.js
+++ b/src/renderer/ui/panels/ShortcutsManager.js
@@ -12,6 +12,7 @@ const {
   getKeyFromEvent,
   normalizeKey
 } = require('../../features/KeyboardShortcuts');
+const { isUnsafeAccelerator } = require('../../../shared/global-shortcuts');
 
 const DEFAULT_SHORTCUTS = {
   openSettings: { key: 'Ctrl+,', labelKey: 'shortcuts.openSettings' },
@@ -202,6 +203,18 @@ class ShortcutsManager extends BasePanel {
 
       if (['ctrl', 'alt', 'shift', 'meta', 'control'].includes(e.key.toLowerCase())) {
         preview.textContent = this.formatKeyForDisplay(key) + '...';
+        return;
+      }
+
+      // A global shortcut becomes an OS-level key grab. On X11 a key the layout
+      // leaves unmapped grabs the whole keyboard instead of one combination, so
+      // the main process refuses those — say so here rather than storing a
+      // binding that will silently never register.
+      if (GLOBAL_SHORTCUTS[id] && isUnsafeAccelerator(key, window.electron_nodeModules?.process?.platform)) {
+        preview.textContent = this.formatKeyForDisplay(key);
+        conflictDiv.style.display = 'block';
+        conflictDiv.textContent = t('shortcuts.unsafeKeyOnLinux');
+        conflictDiv.className = 'shortcut-capture-conflict warning';
         return;
       }
 

--- a/src/shared/global-shortcuts.js
+++ b/src/shared/global-shortcuts.js
@@ -1,0 +1,122 @@
+'use strict';
+
+/**
+ * Global shortcut resolution.
+ *
+ * Turns the stored settings (defaults + user overrides) into the list of
+ * accelerators to hand to Electron's `globalShortcut`. Shared with the
+ * renderer, which reuses `isUnsafeAccelerator` so the shortcut capture UI
+ * rejects the same keys the main process would refuse — and free of any
+ * electron import, so the rules that decide what gets grabbed at the OS level
+ * can be tested directly.
+ */
+
+/**
+ * Default keybindings, in Electron accelerator form.
+ *
+ * `globalPushToTalk` is deliberately unbound. It shipped as `F13`, which froze
+ * the keyboard system-wide on Linux (issue #166, see X11_UNSAFE_KEYS), and a
+ * global grab has no business existing for a feature the user never configured:
+ * binding a key is the opt-in.
+ */
+const GLOBAL_SHORTCUT_DEFAULTS = {
+  globalQuickPicker: 'CommandOrControl+Shift+P',
+  globalNewTerminal: 'CommandOrControl+Shift+T',
+  globalNewWorktree: 'CommandOrControl+Shift+W',
+  globalPushToTalk: null
+};
+
+/**
+ * Keys that X11 layouts commonly leave unmapped.
+ *
+ * Electron resolves an accelerator to an X11 keycode through
+ * `XKeysymToKeycode`, which returns 0 when the keysym is absent from the
+ * current layout — and in X11 keycode 0 is `AnyKey`. The resulting `XGrabKey`
+ * then swallows *every* keystroke on the machine rather than one combination,
+ * so the keyboard stays dead until the app quits. `register()` returns true
+ * throughout: the grab really did succeed, it was just far wider than asked.
+ *
+ * Node cannot query the XKB layout, so the hazardous keys are refused outright.
+ * F13-F24 have no key on a standard board and are missing from the default
+ * `pc` symbols map, which is exactly why they look attractive as a global bind.
+ */
+const X11_UNSAFE_KEYS = new Set([
+  'F13', 'F14', 'F15', 'F16', 'F17', 'F18',
+  'F19', 'F20', 'F21', 'F22', 'F23', 'F24'
+]);
+
+/**
+ * Convert a renderer-style key string (`Ctrl+Shift+P`) to an Electron accelerator.
+ *
+ * @param {string} key
+ * @returns {string|null}
+ */
+function toElectronAccelerator(key) {
+  if (!key) return null;
+  return key.replace(/Ctrl/gi, 'CommandOrControl')
+    .replace(/Meta/gi, 'CommandOrControl');
+}
+
+/**
+ * Whether grabbing this accelerator risks taking the whole keyboard down.
+ *
+ * @param {string} accelerator - Electron accelerator form
+ * @param {string} platform - `process.platform` value
+ * @returns {boolean}
+ */
+function isUnsafeAccelerator(accelerator, platform) {
+  if (platform !== 'linux' || !accelerator) return false;
+  const key = String(accelerator).split('+').pop().trim().toUpperCase();
+  return X11_UNSAFE_KEYS.has(key);
+}
+
+/**
+ * Resolve the accelerators to register.
+ *
+ * An override is honoured only when the id is actually present in the stored
+ * overrides: an absent id falls back to the default, while an id present with
+ * an empty value means the user unbound it on purpose and nothing is grabbed.
+ * Without that distinction clearing a binding silently restored the default.
+ *
+ * @param {{ overrides?: Object, enabled?: boolean }} config
+ * @param {string} [platform] - defaults to the running platform
+ * @returns {{ resolved: Array<{ id: string, accelerator: string }>, rejected: Array<{ id: string, accelerator: string, reason: string }> }}
+ */
+function resolveGlobalShortcuts(config = {}, platform = process.platform) {
+  const resolved = [];
+  const rejected = [];
+
+  if (config.enabled === false) return { resolved, rejected };
+
+  const overrides = config.overrides || {};
+
+  for (const [id, defaultAccelerator] of Object.entries(GLOBAL_SHORTCUT_DEFAULTS)) {
+    const hasOverride = Object.prototype.hasOwnProperty.call(overrides, id);
+    const accelerator = hasOverride
+      ? toElectronAccelerator(overrides[id])
+      : defaultAccelerator;
+
+    if (!accelerator) continue;
+
+    if (isUnsafeAccelerator(accelerator, platform)) {
+      rejected.push({
+        id,
+        accelerator,
+        reason: 'This key is often unmapped on X11, where grabbing it would capture the entire keyboard. Pick another key.'
+      });
+      continue;
+    }
+
+    resolved.push({ id, accelerator });
+  }
+
+  return { resolved, rejected };
+}
+
+module.exports = {
+  GLOBAL_SHORTCUT_DEFAULTS,
+  X11_UNSAFE_KEYS,
+  toElectronAccelerator,
+  isUnsafeAccelerator,
+  resolveGlobalShortcuts
+};

--- a/tests/shared/globalShortcuts.test.js
+++ b/tests/shared/globalShortcuts.test.js
@@ -1,0 +1,152 @@
+const {
+  GLOBAL_SHORTCUT_DEFAULTS,
+  toElectronAccelerator,
+  isUnsafeAccelerator,
+  resolveGlobalShortcuts
+} = require('../../src/shared/global-shortcuts');
+
+const ids = (result) => result.resolved.map(r => r.id);
+const accelerators = (result) => result.resolved.map(r => r.accelerator);
+
+describe('global shortcut defaults', () => {
+  test('every default carries a modifier', () => {
+    // A modifier-less global grab catches every keystroke on X11 when the key
+    // turns out to be unmapped (issue #166).
+    for (const [id, accelerator] of Object.entries(GLOBAL_SHORTCUT_DEFAULTS)) {
+      if (!accelerator) continue;
+      expect(accelerator.includes('+')).toBe(true);
+      expect(id).toBeTruthy();
+    }
+  });
+
+  test('no default is a key X11 commonly leaves unmapped', () => {
+    for (const accelerator of Object.values(GLOBAL_SHORTCUT_DEFAULTS)) {
+      if (!accelerator) continue;
+      expect(isUnsafeAccelerator(accelerator, 'linux')).toBe(false);
+    }
+  });
+
+  test('push-to-talk is unbound by default', () => {
+    expect(GLOBAL_SHORTCUT_DEFAULTS.globalPushToTalk).toBeNull();
+  });
+});
+
+describe('toElectronAccelerator', () => {
+  test('maps Ctrl and Meta to CommandOrControl', () => {
+    expect(toElectronAccelerator('Ctrl+Shift+P')).toBe('CommandOrControl+Shift+P');
+    expect(toElectronAccelerator('Meta+K')).toBe('CommandOrControl+K');
+  });
+
+  test('empty input yields null', () => {
+    expect(toElectronAccelerator('')).toBeNull();
+    expect(toElectronAccelerator(null)).toBeNull();
+    expect(toElectronAccelerator(undefined)).toBeNull();
+  });
+});
+
+describe('isUnsafeAccelerator', () => {
+  test('F13-F24 are unsafe on linux', () => {
+    for (const key of ['F13', 'F16', 'F24']) {
+      expect(isUnsafeAccelerator(key, 'linux')).toBe(true);
+      expect(isUnsafeAccelerator(`CommandOrControl+${key}`, 'linux')).toBe(true);
+    }
+  });
+
+  test('keys a standard layout maps are safe', () => {
+    expect(isUnsafeAccelerator('F12', 'linux')).toBe(false);
+    expect(isUnsafeAccelerator('CommandOrControl+Shift+P', 'linux')).toBe(false);
+  });
+
+  test('other platforms resolve these keys natively', () => {
+    expect(isUnsafeAccelerator('F13', 'win32')).toBe(false);
+    expect(isUnsafeAccelerator('F13', 'darwin')).toBe(false);
+  });
+
+  test('case and stray whitespace do not slip through', () => {
+    expect(isUnsafeAccelerator('f13', 'linux')).toBe(true);
+    expect(isUnsafeAccelerator('CommandOrControl+ f13 ', 'linux')).toBe(true);
+  });
+
+  test('empty accelerator is not unsafe', () => {
+    expect(isUnsafeAccelerator('', 'linux')).toBe(false);
+    expect(isUnsafeAccelerator(null, 'linux')).toBe(false);
+  });
+});
+
+describe('resolveGlobalShortcuts', () => {
+  test('no settings yields the bound defaults', () => {
+    const result = resolveGlobalShortcuts({}, 'linux');
+    expect(ids(result)).toEqual([
+      'globalQuickPicker',
+      'globalNewTerminal',
+      'globalNewWorktree'
+    ]);
+    expect(result.rejected).toEqual([]);
+  });
+
+  test('the master toggle registers nothing', () => {
+    const result = resolveGlobalShortcuts({ enabled: false }, 'linux');
+    expect(result.resolved).toEqual([]);
+    expect(result.rejected).toEqual([]);
+  });
+
+  test('an override replaces the default and is converted', () => {
+    const result = resolveGlobalShortcuts(
+      { overrides: { globalQuickPicker: 'Ctrl+Alt+K' } },
+      'darwin'
+    );
+    expect(accelerators(result)).toContain('CommandOrControl+Alt+K');
+    expect(accelerators(result)).not.toContain('CommandOrControl+Shift+P');
+  });
+
+  test('an empty override unbinds instead of restoring the default', () => {
+    const result = resolveGlobalShortcuts(
+      { overrides: { globalQuickPicker: '' } },
+      'darwin'
+    );
+    expect(ids(result)).not.toContain('globalQuickPicker');
+    expect(ids(result)).toContain('globalNewTerminal');
+  });
+
+  test('null and undefined overrides also unbind', () => {
+    for (const value of [null, undefined]) {
+      const result = resolveGlobalShortcuts(
+        { overrides: { globalNewTerminal: value } },
+        'darwin'
+      );
+      expect(ids(result)).not.toContain('globalNewTerminal');
+    }
+  });
+
+  test('an unsafe override is rejected on linux, with a reason', () => {
+    const result = resolveGlobalShortcuts(
+      { overrides: { globalPushToTalk: 'F13' } },
+      'linux'
+    );
+    expect(ids(result)).not.toContain('globalPushToTalk');
+    expect(result.rejected).toHaveLength(1);
+    expect(result.rejected[0]).toMatchObject({
+      id: 'globalPushToTalk',
+      accelerator: 'F13'
+    });
+    expect(result.rejected[0].reason).toMatch(/keyboard/i);
+  });
+
+  test('the same override is honoured off linux', () => {
+    const result = resolveGlobalShortcuts(
+      { overrides: { globalPushToTalk: 'F13' } },
+      'win32'
+    );
+    expect(ids(result)).toContain('globalPushToTalk');
+    expect(result.rejected).toEqual([]);
+  });
+
+  test('one rejected binding does not drop the others', () => {
+    const result = resolveGlobalShortcuts(
+      { overrides: { globalQuickPicker: 'F14' } },
+      'linux'
+    );
+    expect(ids(result)).toEqual(['globalNewTerminal', 'globalNewWorktree']);
+    expect(result.rejected.map(r => r.id)).toEqual(['globalQuickPicker']);
+  });
+});


### PR DESCRIPTION
Fixes #166.

## The bug

Push-to-talk ships bound to `F13`. On X11 that freezes the keyboard system-wide — in every application, including this one — until the app quits.

Electron resolves an accelerator to an X11 keycode through `XKeysymToKeycode`, which returns `0` when the keysym is not on the current layout. In X11, keycode 0 is `AnyKey`. `F13` is absent from the default `pc` symbols map, so the `XGrabKey` that gets installed grabs *every* keystroke on the machine rather than one combination — and since the accelerator carries no modifier, the grab matches unconditionally.

`globalShortcut.register()` returns `true` throughout: the grab genuinely succeeded, it was just far wider than asked for. Nothing in the logs hinted at it.

It matches the reporter's bisect exactly: the bind arrived in 5d0edf5, after 1.2.18, so 1.3.0 was the first affected release. Linux only — Windows (`RegisterHotKey` / `VK_F13`) and macOS (Carbon keycode 105) both resolve F13 natively.

The bind also existed for a feature the user had never configured: voice needs a Groq key in the OS credential store, and nothing gated the grab on it. On current `main` the renderer does not even instantiate `VoiceCaptureService` and nothing listens for `voice:push-to-talk`, so the grab served a code path that cannot fire.

## The fix

Shortcut resolution moves into `src/shared/global-shortcuts.js`, free of any electron import so the rules deciding what gets grabbed at OS level are directly testable:

- **`globalPushToTalk` is unbound by default.** Binding a key is the opt-in; no global grab exists for an unconfigured feature.
- **F13-F24 are refused on Linux**, with a logged reason instead of an `AnyKey` grab. Node cannot query the XKB layout, so the check names the keys that are unmapped often enough to be a real hazard — which is exactly why they look attractive as a global bind in the first place.
- **An override that is present but empty now means "unbound"** rather than falling back to the default. Previously `customKey ? … : defaultKey` made clearing a binding silently restore it, so a global shortcut could not be cleared at all — which also meant editing `settings.json` was no escape from the freeze.

The capture UI reuses `isUnsafeAccelerator` to reject those keys up front. It waived the modifier requirement for function keys, so a Linux user could re-create the freeze by rebinding any global shortcut to a bare `F13`; now they are told why instead of storing a binding that silently never registers.

I deliberately left out gating the bind on the Groq key being present: reading the credential store during `whenReady` would add a keychain prompt at startup.

## Tests

`tests/shared/globalShortcuts.test.js`, 18 cases, including the regression guards that no default accelerator is modifier-less and none is a key X11 commonly leaves unmapped.

```
Test Suites: 115 passed, 115 total
Tests:       2816 passed, 2816 total
```

`npm run build:renderer` passes; the shared module bundles into the renderer cleanly. New i18n key added to all five locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
