### PR TITLE
test(setup): retry every recursive teardown so Windows cannot fail a green suite

### DIFF
--- a/tests/helpers/fsRemovalRetry.js
+++ b/tests/helpers/fsRemovalRetry.js
@@ -1,0 +1,59 @@
+// Windows fails a recursive removal while a handle inside the tree is still
+// closing. A stream released with destroy() closes its descriptor
+// asynchronously, so a teardown that runs right after the last test can hit
+// ENOTEMPTY / EBUSY / EPERM even though every test passed. Unlinking an open
+// file is legal on POSIX, which is why this only ever shows up on
+// windows-latest, and always in afterAll - never in a test.
+//
+// `force: true` does not help: it only suppresses "does not exist", it never
+// retries. Node's answer is maxRetries / retryDelay, which retry exactly those
+// Windows errors. Rather than ask every suite to remember that, this installs
+// the retry as the default for recursive removals, so the suites that exist and
+// the ones written next both inherit it.
+
+const REMOVAL_RETRY = { maxRetries: 10, retryDelay: 50 };
+
+const INSTALLED = Symbol.for('claude-terminal.tests.fsRemovalRetry');
+
+// Only recursive removals are touched, and only when the caller has not already
+// chosen its own retry policy.
+function withRemovalRetry(options) {
+  if (!options || options.recursive !== true) return options;
+  if (options.maxRetries !== undefined) return options;
+  return { ...options, ...REMOVAL_RETRY };
+}
+
+function installFsRemovalRetry(fs) {
+  if (!fs || fs[INSTALLED]) return fs;
+
+  const { rmSync, rm } = fs;
+
+  if (typeof rmSync === 'function') {
+    fs.rmSync = function (target, options) {
+      return rmSync.call(this, target, withRemovalRetry(options));
+    };
+  }
+
+  if (typeof rm === 'function') {
+    fs.rm = function (target, options, callback) {
+      // fs.rm(target, callback) - nothing to inject into.
+      if (typeof options === 'function' || options === undefined) {
+        return rm.call(this, target, options, callback);
+      }
+      return rm.call(this, target, withRemovalRetry(options), callback);
+    };
+  }
+
+  const promises = fs.promises;
+  if (promises && typeof promises.rm === 'function') {
+    const promisesRm = promises.rm;
+    promises.rm = function (target, options) {
+      return promisesRm.call(this, target, withRemovalRetry(options));
+    };
+  }
+
+  Object.defineProperty(fs, INSTALLED, { value: true, enumerable: false });
+  return fs;
+}
+
+module.exports = { REMOVAL_RETRY, withRemovalRetry, installFsRemovalRetry };

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -33,3 +33,7 @@ window.electron_api = {
 
 // Mock requestAnimationFrame (used by State._notify)
 global.requestAnimationFrame = (cb) => setTimeout(cb, 0);
+
+// Give every recursive removal a Windows retry, so a temp-dir teardown cannot
+// fail a suite whose tests all passed. See tests/helpers/fsRemovalRetry.js.
+require('./helpers/fsRemovalRetry').installFsRemovalRetry(require('fs'));

--- a/tests/utils/fsRemovalRetry.test.js
+++ b/tests/utils/fsRemovalRetry.test.js
@@ -1,0 +1,92 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  REMOVAL_RETRY,
+  withRemovalRetry,
+  installFsRemovalRetry,
+} = require('../helpers/fsRemovalRetry');
+
+describe('withRemovalRetry', () => {
+  it('gives a recursive removal a retry policy', () => {
+    expect(withRemovalRetry({ recursive: true, force: true })).toEqual({
+      recursive: true,
+      force: true,
+      ...REMOVAL_RETRY,
+    });
+  });
+
+  it('leaves a caller that chose its own retry alone', () => {
+    const options = { recursive: true, force: true, maxRetries: 2, retryDelay: 10 };
+    expect(withRemovalRetry(options)).toEqual(options);
+  });
+
+  it('leaves a single-file removal alone', () => {
+    expect(withRemovalRetry({ force: true })).toEqual({ force: true });
+    expect(withRemovalRetry(undefined)).toBeUndefined();
+  });
+});
+
+describe('installFsRemovalRetry', () => {
+  const fakeFs = () => ({
+    rmSync: jest.fn(),
+    rm: jest.fn(),
+    promises: { rm: jest.fn() },
+  });
+
+  it('injects the retry into rmSync, rm and promises.rm', () => {
+    const target = fakeFs();
+    const { rmSync, rm, promises } = { ...target, promises: { ...target.promises } };
+    installFsRemovalRetry(target);
+
+    const callback = () => {};
+    target.rmSync('/tmp/tree', { recursive: true, force: true });
+    target.rm('/tmp/tree', { recursive: true }, callback);
+    target.promises.rm('/tmp/tree', { recursive: true });
+
+    expect(rmSync).toHaveBeenCalledWith('/tmp/tree', {
+      recursive: true,
+      force: true,
+      ...REMOVAL_RETRY,
+    });
+    expect(rm).toHaveBeenCalledWith('/tmp/tree', { recursive: true, ...REMOVAL_RETRY }, callback);
+    expect(promises.rm).toHaveBeenCalledWith('/tmp/tree', { recursive: true, ...REMOVAL_RETRY });
+  });
+
+  it('passes a callback-only rm through untouched', () => {
+    const target = fakeFs();
+    const { rm } = target;
+    installFsRemovalRetry(target);
+
+    const callback = () => {};
+    target.rm('/tmp/tree', callback);
+
+    expect(rm).toHaveBeenCalledWith('/tmp/tree', callback, undefined);
+  });
+
+  it('does not wrap twice', () => {
+    const target = fakeFs();
+    installFsRemovalRetry(target);
+    const wrapped = target.rmSync;
+    installFsRemovalRetry(target);
+
+    expect(target.rmSync).toBe(wrapped);
+  });
+});
+
+describe('the installed default', () => {
+  it('is already in place for every suite, via tests/setup.js', () => {
+    expect(fs[Symbol.for('claude-terminal.tests.fsRemovalRetry')]).toBe(true);
+  });
+
+  it('still removes the tree it is given', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ct-removal-retry-'));
+    fs.mkdirSync(path.join(root, 'nested', 'deeper'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'nested', 'deeper', 'file.txt'), 'x');
+
+    fs.rmSync(root, { recursive: true, force: true });
+
+    expect(fs.existsSync(root)).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #172

## The flake

On `windows-latest` a suite is reported as failed while every test in it passed, because the failure is in `afterAll`:

```
● Test suite failed to run
  ENOTEMPTY: directory not empty, rmdir 'C:\...\Temp\ct-claude-ipc-Ks5T0r\.claude\projects\-tmp-demo-project'
  > 62 |   fs.rmSync(TMP_HOME, { recursive: true, force: true });
```

A stream released with `destroy()` closes its descriptor asynchronously, so the teardown can run while a handle is still open inside the temp tree. Unlinking an open file is legal on POSIX — which is why this never shows on ubuntu or macOS — and fails on Windows. `force: true` does not help: it only suppresses "does not exist", it never retries.

Because the release matrix is fail-fast, one such flake also cancels the other legs, so a green PR reads as red.

## What changed

`tests/setup.js` installs the retry Node already provides (`maxRetries` / `retryDelay`, which retry exactly the Windows `EBUSY` / `ENOTEMPTY` / `EPERM` cases) as the **default for recursive removals**, wrapping `fs.rmSync`, `fs.rm` and `fs.promises.rm` for the test process only.

I went this way rather than editing the ~24 unretried call sites because the sweep fixes the suites that exist today and leaves the next one to remember; a default is inherited. The wrapper is deliberately narrow:

- only `recursive: true` removals are touched — a single-file `rmSync(file, { force: true })` is passed through unchanged;
- a caller that already chose `maxRetries` keeps its own policy, so the two suites that hand-roll it (`claudeMoveSession`, `claudeSessionChanges`) are untouched;
- `fs.rm(target, callback)` is forwarded as-is;
- installing twice is a no-op.

`tests/ipc/claude.ipc.test.js` — the suite that actually broke run [34329934967](https://github.com/Sterll/claude-terminal/actions/runs/34329934967) — is not edited here: its inline fix rides in #171, and it inherits this default either way.

Out of scope, but worth a look someday: `src/` has the same unretried `rmSync(..., { recursive: true, force: true })` pattern in `MarketplaceService`, `PluginService`, `ParallelTaskService`, `git.js` and `file.node.js`, where on Windows it is a user-visible "uninstall failed" rather than a CI flake.

## Tests

8 new cases in `tests/utils/fsRemovalRetry.test.js`: the option rewrite (injects, respects an explicit policy, leaves single-file removals alone), the three wrapped entry points, the callback-only form, idempotence, and that the default is actually in place for every suite via `tests/setup.js`.

```
Test Suites: 115 passed, 115 total
Tests:       2806 passed, 2806 total
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)