### PR TITLE
fix(projects): stop losing projects.json data written by other processes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ npm run build:win        # Windows NSIS installer
 npm run build:mac        # macOS DMG
 npm run build:linux      # Linux AppImage
 npm run publish          # Build and publish Windows installer to update server
-npm test                 # Run Jest tests (jsdom, 126 test files)
+npm test                 # Run Jest tests (jsdom, 130 test files)
 npm run test:watch       # Jest in watch mode
 npm run check:docs       # Fail if CLAUDE.md has drifted from the tree it describes
 npm run lint             # ESLint over main, renderer, shared, MCP servers and scripts
@@ -49,7 +49,7 @@ Electron Renderer Process (Browser)
 ├── renderer.js                      # Entry point (bundled by esbuild -> dist/renderer.bundle.js)
 ├── src/renderer/index.js            # Module loader & initialization
 ├── src/renderer/core/               # DI container, BaseService/Component/Panel, ApiProvider
-├── src/renderer/state/              # 14 observable state modules
+├── src/renderer/state/              # 15 observable state modules
 ├── src/renderer/services/           # 27 services + modular markdown renderer + mention sources
 ├── src/renderer/ui/components/      # 16 UI components
 ├── src/renderer/ui/panels/          # 25 UI panels
@@ -226,7 +226,8 @@ Base class `State.js`: observable, `subscribe()`, batched notifications via `req
 
 | Module | Key state |
 |--------|-----------|
-| `projects.state.js` | projects[], folders[], rootOrder[], selectedProjectFilter, openedProjectId - CRUD, folder nesting, atomic writes |
+| `projects.state.js` | projects[], folders[], rootOrder[], selectedProjectFilter, openedProjectId - CRUD, folder nesting, atomic writes, three-way merge on save, polled watch for writes from other processes |
+| `projects.merge.js` | Three-way merge (base / ours / theirs) for projects.json, so a kanban board or worktree project written by another process survives a save from this renderer |
 | `terminals.state.js` | terminals Map, activeTerminal, detailTerminal |
 | `settings.state.js` | editor, accentColor, language, defaultTerminalMode, chatModel, pinnedTabs, sidebarOrder, shortcuts |
 | `timeTracking.state.js` | per-session, 15 min idle, midnight rollover, monthly archival |
@@ -590,7 +591,7 @@ npm run test:e2e            # Playwright smoke test against the real Electron ap
 
 ### Unit tests (Jest)
 
-- **Framework:** Jest with jsdom, 126 test files
+- **Framework:** Jest with jsdom, 130 test files
 - **Setup:** `tests/setup.js` mocks `window.electron_nodeModules`, `window.electron_api`, `requestAnimationFrame`
 - **Pattern:** `**/tests/**/*.test.js`
 - **Directories:**
@@ -606,7 +607,7 @@ npm run test:e2e            # Playwright smoke test against the real Electron ap
   - `shared/` - context usage, cron, model options, permission modes, simple-task
   - `smoke/` - every module parses and loads
   - `state/` - State plus each state module
-  - `ui/` - chat account switch, task widget, tasks drawer, ClaudeRemotePanel, navigation mode
+  - `ui/` - chat account switch, task widget, tasks drawer, ClaudeRemotePanel, navigation mode, kanban live refresh
   - `utils/` - attachments, color, commit messages, drop paths, file icons, file lock, format, frontmatter, git, http cache, session search, shell, syntax highlight, tool registry
 
 ### Lint (`eslint.config.js`)

--- a/src/renderer/services/DashboardService.js
+++ b/src/renderer/services/DashboardService.js
@@ -449,35 +449,63 @@ async function getPullRequests(remoteUrl) {
  * @returns {Promise<Object>}
  */
 async function loadDashboardData(projectPath, { lightweight = false } = {}) {
+  const local = await loadLocalDashboardData(projectPath, { lightweight });
+  const remote = await loadRemoteDashboardData(local.gitInfo);
+  return { ...local, ...remote };
+}
+
+/**
+ * Everything that can be read from the machine itself.
+ *
+ * Kept apart from the GitHub half because that half is a network round-trip:
+ * blocking the first paint on it is what made opening a project feel slow,
+ * while the sections it feeds are a small part of the page.
+ *
+ * @param {string} projectPath
+ * @param {{lightweight?: boolean}} options
+ * @returns {Promise<Object>} dashboard data with empty GitHub sections
+ */
+async function loadLocalDashboardData(projectPath, { lightweight = false } = {}) {
   // The 500-commit history is only consumed by the detailed project view
   // (contribution graph, heatmaps, health). Skip it during the bulk preload
   // to avoid saturating the main process with 8 heavy `git log` in parallel.
-  const [gitInfo, stats, commitHistory30d] = await Promise.all([
+  //
+  // detectProjectType only needs the path, so it joins the batch rather than
+  // waiting behind the git calls as it used to.
+  const [gitInfo, stats, commitHistory30d, projectType] = await Promise.all([
     getGitInfoFull(projectPath),
     getProjectStats(projectPath),
     lightweight
       ? Promise.resolve(null)
-      : api.git.commitHistory({ projectPath, skip: 0, limit: 500 }).catch(() => [])
+      : api.git.commitHistory({ projectPath, skip: 0, limit: 500 }).catch(() => []),
+    detectProjectType(projectPath)
   ]);
-
-  // Detect project type
-  const projectType = await detectProjectType(projectPath);
-
-  // Fetch workflow runs and pull requests if it's a GitHub repo
-  let workflowRuns = { runs: [] };
-  let pullRequests = { pullRequests: [] };
-  if (gitInfo.isGitRepo && gitInfo.remoteUrl) {
-    [workflowRuns, pullRequests] = await Promise.all([
-      getWorkflowRuns(gitInfo.remoteUrl),
-      getPullRequests(gitInfo.remoteUrl)
-    ]);
-  } else {
-    // No git remote, skip GitHub data
-  }
 
   // commitHistory30d === null marks "not loaded yet" (lightweight preload);
   // ensureCommitHistory() fills it lazily when the detail view is opened.
-  return { gitInfo, stats, workflowRuns, pullRequests, projectType, commitHistory30d };
+  return {
+    gitInfo,
+    stats,
+    projectType,
+    commitHistory30d,
+    workflowRuns: { runs: [] },
+    pullRequests: { pullRequests: [] }
+  };
+}
+
+/**
+ * The GitHub half: workflow runs and pull requests.
+ * @param {Object} gitInfo - as returned by getGitInfoFull
+ * @returns {Promise<Object>} empty when the project has no GitHub remote
+ */
+async function loadRemoteDashboardData(gitInfo) {
+  if (!gitInfo?.isGitRepo || !gitInfo.remoteUrl) return null;
+
+  const [workflowRuns, pullRequests] = await Promise.all([
+    getWorkflowRuns(gitInfo.remoteUrl),
+    getPullRequests(gitInfo.remoteUrl)
+  ]);
+  return { workflowRuns, pullRequests };
 }
 
 /**
@@ -1999,14 +2027,29 @@ async function renderDashboard(container, project, options = {}) {
   setCacheLoading(projectId, true);
 
   try {
-    const data = await loadDashboardData(project.path);
-    setCacheData(targetProjectId, data);
+    // Paint as soon as the local data is in. The GitHub sections arrive in a
+    // second pass rather than holding the whole page behind a network call.
+    const local = await loadLocalDashboardData(project.path);
 
     // Discard if user switched to a different project during load
     if (targetProjectId !== projectsState.get().openedProjectId) return;
 
-    await renderDashboardHtml(container, project, data, options, false);
+    await renderDashboardHtml(container, project, local, options, false);
     animateDashboardIn(container);
+
+    const remote = await loadRemoteDashboardData(local.gitInfo);
+    const data = remote ? { ...local, ...remote } : local;
+    // Only the complete payload may be cached: setCacheData resets the TTL,
+    // so caching the local half would keep the GitHub sections empty until it
+    // expired.
+    setCacheData(targetProjectId, data);
+
+    if (!remote) return;
+    if (targetProjectId !== projectsState.get().openedProjectId) return;
+    // Still the same dashboard on screen? Fill in the GitHub sections.
+    if (container.querySelector('#dash-btn-open-folder')) {
+      await renderDashboardHtml(container, project, data, options, false);
+    }
   } catch (e) {
     console.error('Error loading dashboard:', e);
     setCacheLoading(targetProjectId, false);
@@ -2536,6 +2579,8 @@ module.exports = {
   getGitInfoFull,
   getProjectStats,
   loadDashboardData,
+  loadLocalDashboardData,
+  loadRemoteDashboardData,
   gitPull,
   gitPush,
   gitMergeAbort,

--- a/src/renderer/state/index.js
+++ b/src/renderer/state/index.js
@@ -49,6 +49,10 @@ const skillsAgentsState = new State({
 async function initializeState() {
   await settingsState.loadSettings();
   await projectsState.loadProjects();
+  // Other processes write projects.json too (MCP kanban tools, worktree
+  // projects), so keep an eye on it rather than trusting the load above
+  // for the whole session.
+  projectsState.startExternalWatch();
   // Project bar tabs: needs both settings (the saved list) and projects (to drop
   // ids that no longer resolve), so it runs after the two loads above.
   projectsState.restoreOpenProjectIds(settingsState.getSetting('openProjectIds'));

--- a/src/renderer/state/projects.merge.js
+++ b/src/renderer/state/projects.merge.js
@@ -1,0 +1,179 @@
+/**
+ * Three-way merge for projects.json.
+ *
+ * projects.json has several independent writers: this renderer, the MCP server
+ * (kanban tools), and ParallelTaskService (worktree projects). The renderer
+ * used to rewrite the whole file from its in-memory copy, so anything written
+ * by another process after the renderer loaded was silently destroyed — a
+ * kanban board filled from an MCP session disappeared the moment the renderer
+ * saved for any unrelated reason.
+ *
+ * Rewriting is only safe with a baseline: the content we last agreed on with
+ * the disk. With `base` (last synced), `ours` (in memory) and `theirs` (on
+ * disk right now) we can tell "we changed this" apart from "we never saw it",
+ * which a two-way comparison cannot do. A field we did not touch takes the
+ * disk's value; a field we did touch keeps ours.
+ *
+ * Deletion follows from the same rule: an entity on disk that is absent from
+ * memory was deleted by us only if the baseline knew it. If the baseline never
+ * had it, it is new from another writer and must be kept.
+ */
+
+/** Stable deep equality — the values here are plain JSON. */
+function deepEqual(a, b) {
+  if (a === b) return true;
+  if (a === null || b === null || a === undefined || b === undefined) return false;
+  if (typeof a !== 'object' || typeof b !== 'object') return false;
+
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+  if (Array.isArray(a)) {
+    if (a.length !== b.length) return false;
+    return a.every((v, i) => deepEqual(v, b[i]));
+  }
+
+  const ka = Object.keys(a);
+  const kb = Object.keys(b);
+  if (ka.length !== kb.length) return false;
+  return ka.every(k => Object.prototype.hasOwnProperty.call(b, k) && deepEqual(a[k], b[k]));
+}
+
+/**
+ * Merge one entity field by field.
+ *
+ * A field we left as the baseline found it is a field we have no opinion on,
+ * so the disk wins — that is what carries an MCP-written `tasks` array through
+ * a save triggered by something else entirely. Any field we did change stays
+ * ours, including a field we cleared on purpose.
+ */
+function mergeEntity(base, ours, theirs) {
+  const result = {};
+  const keys = new Set([
+    ...Object.keys(base || {}),
+    ...Object.keys(ours || {}),
+    ...Object.keys(theirs || {}),
+  ]);
+
+  for (const key of keys) {
+    const b = base ? base[key] : undefined;
+    const o = ours ? ours[key] : undefined;
+    const t = theirs ? theirs[key] : undefined;
+
+    const value = deepEqual(o, b) ? t : o;
+    if (value !== undefined) result[key] = value;
+  }
+
+  return result;
+}
+
+/**
+ * Merge a list of id-keyed entities (projects or folders).
+ * @returns {Array} merged entities, ours first (stable UI order), then theirs
+ */
+function mergeEntityList(baseList, ourList, theirList) {
+  const byId = (list) => new Map((list || []).filter(e => e && e.id).map(e => [e.id, e]));
+  const base = byId(baseList);
+  const ours = byId(ourList);
+  const theirs = byId(theirList);
+
+  const merged = [];
+
+  // Ours drives the order: the list the user is looking at keeps its shape.
+  for (const [id, o] of ours) {
+    merged.push(mergeEntity(base.get(id), o, theirs.get(id)));
+  }
+
+  // On disk but not in memory: ours only if the baseline knew it (we deleted
+  // it). Otherwise another writer added it while we were running — keep it.
+  for (const [id, t] of theirs) {
+    if (ours.has(id)) continue;
+    if (base.has(id)) continue; // deleted by us
+    merged.push(t);
+  }
+
+  return merged;
+}
+
+/**
+ * Reconcile an order array against the entities that actually survived.
+ * Drops ids of deleted entities and appends any root-level entity missing
+ * from the order, so a project added by another process is still reachable.
+ */
+function reconcileOrder(baseOrder, ourOrder, theirOrder, rootIds) {
+  const chosen = deepEqual(ourOrder || [], baseOrder || [])
+    ? (theirOrder || [])
+    : (ourOrder || []);
+
+  const seen = new Set();
+  const order = [];
+
+  for (const id of chosen) {
+    if (rootIds.has(id) && !seen.has(id)) {
+      seen.add(id);
+      order.push(id);
+    }
+  }
+
+  // Anything root-level that no order array mentioned yet.
+  for (const id of rootIds) {
+    if (!seen.has(id)) {
+      seen.add(id);
+      order.push(id);
+    }
+  }
+
+  return order;
+}
+
+/**
+ * Three-way merge of the whole projects.json payload.
+ *
+ * @param {Object|null} base   - last content we synced with disk
+ * @param {Object} ours        - current in-memory state
+ * @param {Object|null} theirs - what is on disk right now
+ * @returns {{projects: Array, folders: Array, rootOrder: Array}}
+ */
+function mergeProjectsData(base, ours, theirs) {
+  const empty = { projects: [], folders: [], rootOrder: [] };
+
+  // Nothing to reconcile against: our copy is the only truth we have.
+  if (!theirs) {
+    return {
+      projects: ours.projects || [],
+      folders: ours.folders || [],
+      rootOrder: ours.rootOrder || [],
+    };
+  }
+
+  const b = base || empty;
+
+  const projects = mergeEntityList(b.projects, ours.projects, theirs.projects);
+  const folders = mergeEntityList(b.folders, ours.folders, theirs.folders);
+
+  // Root order only holds items with no parent folder.
+  const rootIds = new Set([
+    ...projects.filter(p => !p.folderId).map(p => p.id),
+    ...folders.filter(f => !f.parentId).map(f => f.id),
+  ]);
+
+  const rootOrder = reconcileOrder(b.rootOrder, ours.rootOrder, theirs.rootOrder, rootIds);
+
+  return { projects, folders, rootOrder };
+}
+
+/** Snapshot used as the next baseline. Plain JSON, so a clone is enough. */
+function snapshot(data) {
+  return {
+    projects: JSON.parse(JSON.stringify(data.projects || [])),
+    folders: JSON.parse(JSON.stringify(data.folders || [])),
+    rootOrder: [...(data.rootOrder || [])],
+  };
+}
+
+module.exports = {
+  deepEqual,
+  mergeEntity,
+  mergeEntityList,
+  reconcileOrder,
+  mergeProjectsData,
+  snapshot,
+};

--- a/src/renderer/state/projects.state.js
+++ b/src/renderer/state/projects.state.js
@@ -9,6 +9,7 @@ const { fileExists, atomicWriteJSON } = require('../utils/fs-async');
 const fsp = require('../utils/fs-async').fsp;
 const { State } = require('./State');
 const { projectsFile, dataDir } = require('../utils/paths');
+const { mergeProjectsData, snapshot, deepEqual } = require('./projects.merge');
 const { t } = require('../i18n');
 
 // Initial state
@@ -328,6 +329,9 @@ async function loadProjects() {
       }
 
       projectsState.set({ projects, folders, rootOrder });
+      // What we just read IS the disk content, so it is the baseline every
+      // later save merges against.
+      _diskBaseline = snapshot({ projects, folders, rootOrder });
 
       if (needsSave) {
         saveProjects();
@@ -346,6 +350,11 @@ async function loadProjects() {
   }
 }
 
+// The content we last agreed on with the disk. Every save is a three-way merge
+// against it, so a write made by another process (MCP kanban tools, worktree
+// projects) is reconciled instead of being overwritten by our stale copy.
+let _diskBaseline = null;
+
 // Debounce timer for save operations
 let saveDebounceTimer = null;
 const SAVE_DEBOUNCE_MS = 500;
@@ -353,11 +362,16 @@ let saveInProgress = false;
 let pendingSave = false;
 let saveRetryCount = 0;
 const MAX_SAVE_RETRIES = 3;
+// Set while we push a merged result back into state, so adopting the disk's
+// own data cannot be mistaken for a local edit and scheduled as a new save.
+let _suppressSave = false;
 
 /**
  * Save projects to file (debounced, atomic write)
  */
 function saveProjects() {
+  if (_suppressSave) return;
+
   // Clear existing debounce timer
   if (saveDebounceTimer) {
     clearTimeout(saveDebounceTimer);
@@ -385,7 +399,12 @@ async function saveProjectsImmediate() {
   saveInProgress = true;
 
   const { folders, projects, rootOrder } = projectsState.get();
-  const data = { folders, projects, rootOrder };
+  const ours = { folders, projects, rootOrder };
+
+  // Reconcile with whatever is on disk before overwriting it. Another process
+  // may have written since we loaded, and a plain rewrite would destroy it.
+  const theirs = await _readDiskState();
+  const data = mergeProjectsData(_diskBaseline, ours, theirs);
 
   try {
     await atomicWriteJSON(projectsFile, data);
@@ -419,11 +438,128 @@ async function saveProjectsImmediate() {
 
   saveInProgress = false;
   saveRetryCount = 0;
+  _diskBaseline = snapshot(data);
+  // Remember our own write, so the watcher does not reload on it.
+  _statSignature().then(sig => { _lastSeenSignature = sig; });
+
+  // The merge may have brought back data we did not have (tasks added by an
+  // MCP session, a worktree project). Adopt it so the UI stops being stale —
+  // but only when it actually differs, or every save would notify subscribers.
+  _adoptMergedState(ours, data);
 
   // Process queued save
   if (pendingSave) {
     pendingSave = false;
     setTimeout(saveProjectsImmediate, 50);
+  }
+}
+
+// ── External write detection ────────────────────────────────────────────────
+//
+// projects.json is written by other processes too (MCP kanban tools, worktree
+// projects from a parallel run). Merging on save keeps their data alive, but
+// the UI would still show a stale board until the next restart, so we watch
+// the file and reload when someone else touches it.
+//
+// Polled rather than watched: the preload bridge exposes stat but no fs.watch,
+// and the file is replaced by an atomic rename, which several watch backends
+// report inconsistently anyway. One stat every few seconds on a small file is
+// cheap enough.
+const EXTERNAL_WATCH_INTERVAL_MS = 3000;
+let _watchTimer = null;
+let _lastSeenSignature = null;
+
+async function _statSignature() {
+  try {
+    const st = await fsp.stat(projectsFile);
+    return { mtimeMs: new Date(st.mtime).getTime(), size: st.size };
+  } catch {
+    return null;
+  }
+}
+
+function _sameSignature(a, b) {
+  return !!a && !!b && a.mtimeMs === b.mtimeMs && a.size === b.size;
+}
+
+async function _checkExternalWrite() {
+  // Our own write is in flight — whatever we observe now is ours.
+  if (saveInProgress || pendingSave || saveDebounceTimer) return;
+
+  const sig = await _statSignature();
+  if (!sig) return;
+
+  if (!_lastSeenSignature) {
+    _lastSeenSignature = sig;
+    return;
+  }
+  if (_sameSignature(sig, _lastSeenSignature)) return;
+
+  _lastSeenSignature = sig;
+  await loadProjects();
+}
+
+/** Start watching projects.json for writes made by other processes. */
+function startExternalWatch() {
+  if (_watchTimer) return;
+  _statSignature().then(sig => { _lastSeenSignature = sig; });
+  _watchTimer = setInterval(() => {
+    _checkExternalWrite().catch(e => console.warn('projects.json watch:', e.message));
+  }, EXTERNAL_WATCH_INTERVAL_MS);
+}
+
+/** Stop watching (used by tests and teardown). */
+function stopExternalWatch() {
+  if (_watchTimer) {
+    clearInterval(_watchTimer);
+    _watchTimer = null;
+  }
+  _lastSeenSignature = null;
+}
+
+/**
+ * Read the current on-disk state, or null when it is absent or unreadable.
+ * A parse failure must not abort the save: returning null means "nothing to
+ * reconcile against", and the existing corruption handling in loadProjects
+ * still owns the recovery path.
+ */
+async function _readDiskState() {
+  try {
+    if (!(await fileExists(projectsFile))) return null;
+    const raw = await fsp.readFile(projectsFile, 'utf8');
+    if (!raw || !raw.trim()) return null;
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    return {
+      projects: parsed.projects || [],
+      folders: parsed.folders || [],
+      rootOrder: parsed.rootOrder || [],
+    };
+  } catch (e) {
+    console.warn('Could not read projects.json for merge, writing our copy:', e.message);
+    return null;
+  }
+}
+
+/**
+ * Push a merged result back into state when it differs from what we held.
+ * Guarded so the state change cannot re-enter the save loop.
+ */
+function _adoptMergedState(ours, merged) {
+  const changed = !deepEqual(ours.projects, merged.projects)
+    || !deepEqual(ours.folders, merged.folders)
+    || !deepEqual(ours.rootOrder, merged.rootOrder);
+  if (!changed) return;
+
+  _suppressSave = true;
+  try {
+    projectsState.set({
+      projects: merged.projects,
+      folders: merged.folders,
+      rootOrder: merged.rootOrder,
+    });
+  } finally {
+    _suppressSave = false;
   }
 }
 
@@ -1170,8 +1306,12 @@ function getTasks(projectId) {
 function getKanbanColumns(projectId) {
   const project = getProject(projectId);
   if (!project) return [...DEFAULT_COLUMNS];
+  // A read must not write. This used to persist the defaults, which made
+  // merely OPENING the kanban save the whole file — and a save from a stale
+  // in-memory copy is what wiped a board filled by an MCP session. The
+  // defaults are persisted by the first real mutation instead (every
+  // add/update/delete/reorder writes back the full column array).
   if (!project.kanbanColumns || project.kanbanColumns.length === 0) {
-    updateProject(projectId, { kanbanColumns: [...DEFAULT_COLUMNS] });
     return [...DEFAULT_COLUMNS];
   }
   return [...project.kanbanColumns].sort((a, b) => a.order - b.order);
@@ -1397,13 +1537,17 @@ function migrateTasksToKanban(projectId) {
   const project = getProject(projectId);
   if (!project) return;
   if (project.kanbanColumns && project.kanbanColumns.length > 0) return;
+  // Nothing in the old shape to convert: rendering an empty board is not a
+  // reason to write to disk.
+  const legacyTasks = project.tasks || [];
+  if (legacyTasks.length === 0) return;
   const statusToColumnId = {
     'todo': 'col-todo',
     'in_progress': 'col-inprogress',
     'done': 'col-done',
   };
   const colCounters = {};
-  const tasks = (project.tasks || []).map(t => {
+  const tasks = legacyTasks.map(t => {
     const colId = statusToColumnId[t.status] || 'col-todo';
     if (colCounters[colId] === undefined) colCounters[colId] = 0;
     const order = colCounters[colId]++;
@@ -1673,6 +1817,8 @@ module.exports = {
   loadProjects,
   saveProjects,
   saveProjectsImmediate,
+  startExternalWatch,
+  stopExternalWatch,
   createFolder,
   deleteFolder,
   renameFolder,

--- a/src/renderer/ui/panels/KanbanPanel.js
+++ b/src/renderer/ui/panels/KanbanPanel.js
@@ -5,6 +5,7 @@ const { escapeHtml } = require('../../utils/dom');
 const { formatRelativeTime } = require('../../utils/format');
 const { createModal, showModal, closeModal, showConfirm, showPrompt } = require('../components/Modal');
 const {
+  projectsState,
   getTasks, addTask, updateTask, deleteTask, moveTask,
   getKanbanColumns, addKanbanColumn, updateKanbanColumn, deleteKanbanColumn, reorderKanbanColumns,
   getKanbanLabels, addKanbanLabel, updateKanbanLabel, deleteKanbanLabel,
@@ -55,11 +56,67 @@ function render(container, project, options = {}) {
   if (board && board._kanbanCleanup) {
     board._kanbanCleanup();
   }
+  if (board && board._kanbanUnwatch) {
+    board._kanbanUnwatch();
+  }
 
   migrateTasksToKanban(project.id);
   normalizeKanbanTaskFields(project.id);
   container.innerHTML = buildBoardHtml(project);
   attachEvents(container, project, options);
+  watchBoardState(container, project, options);
+}
+
+// ── Live refresh ─────────────────────────────────────────────
+//
+// The board is not the only writer of its own data: an MCP session
+// (`kanban_add_task`) and ParallelTaskService write projects.json directly,
+// and projects.state reloads the file when another process touches it. The
+// board itself was only ever rebuilt by its own event handlers, so tasks a
+// Claude session had just created sat in state, invisible, until the user
+// navigated away from the dashboard and back. Follow the state instead.
+//
+// Rebuilding on every notification would fight the user (the state fires for
+// unrelated things, several times a second while a project is being dragged),
+// so the rebuild is gated on this project's board actually differing.
+
+/** Everything the board draws, as a comparable value. */
+function boardSignature(projectId) {
+  return JSON.stringify([
+    getTasks(projectId),
+    getKanbanColumns(projectId),
+    getKanbanLabels(projectId),
+  ]);
+}
+
+/**
+ * Rebuild the board when this project's tasks, columns or labels change in
+ * state without going through the board.
+ *
+ * The subscription drops itself once the board leaves the DOM: the dashboard
+ * replaces its container's contents when switching back to Overview, which
+ * never calls the cleanup stored on the board element.
+ */
+function watchBoardState(container, project, options) {
+  const board = container.querySelector('.kanban-board');
+  if (!board) return;
+
+  let signature = boardSignature(project.id);
+
+  const unsubscribe = projectsState.subscribe(() => {
+    if (!board.isConnected) {
+      unsubscribe();
+      return;
+    }
+    const next = boardSignature(project.id);
+    if (next === signature) return;
+    signature = next;
+    // Re-entrant by design: render() disposes this subscription and installs
+    // a fresh one for the board it builds.
+    render(container, project, options);
+  });
+
+  board._kanbanUnwatch = unsubscribe;
 }
 
 // ── HTML builders ────────────────────────────────────────────

--- a/tests/integration/state-persistence.test.js
+++ b/tests/integration/state-persistence.test.js
@@ -73,6 +73,13 @@ window.electron_api = {
 // Mock requestAnimationFrame
 global.requestAnimationFrame = (cb) => setTimeout(cb, 0);
 
+// Drain the microtask queue. The save path awaits several times before it
+// writes (it re-reads the file to merge with it), so counting individual
+// `await Promise.resolve()` ticks is too brittle to pin a write on.
+async function flushAsync(rounds = 25) {
+  for (let i = 0; i < rounds; i++) await Promise.resolve();
+}
+
 beforeEach(() => {
   jest.clearAllMocks();
   jest.useFakeTimers();
@@ -119,9 +126,7 @@ describe('projects state persistence', () => {
     // Trigger save (debounced 500ms)
     jest.advanceTimersByTime(600);
     // Flush async saveProjectsImmediate
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushAsync();
 
     // Verify file was written (via async fsp.writeFile)
     const { fs } = window.electron_nodeModules;
@@ -151,9 +156,7 @@ describe('projects state persistence', () => {
     projectsModule.moveItemToFolder('project', project.id, folder.id);
 
     jest.advanceTimersByTime(600);
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushAsync();
 
     const { fs } = window.electron_nodeModules;
     const lastWrite = fs.promises.writeFile.mock.calls[fs.promises.writeFile.mock.calls.length - 1];
@@ -177,9 +180,7 @@ describe('projects state persistence', () => {
 
     // Advance past debounce
     jest.advanceTimersByTime(600);
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushAsync();
 
     // Should have written once (the final state)
     const writeCalls = fs.promises.writeFile.mock.calls;
@@ -196,9 +197,7 @@ describe('projects state persistence', () => {
 
     projectsModule.addProject({ name: 'Test', path: '/test' });
     jest.advanceTimersByTime(600);
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushAsync();
 
     // Check that fsp.writeFile was called with .tmp path
     const tmpWrites = fs.promises.writeFile.mock.calls.filter(c => c[0].endsWith('.tmp'));
@@ -220,9 +219,7 @@ describe('projects state persistence', () => {
 
     projectsModule.addProject({ name: 'Test', path: '/test' });
     jest.advanceTimersByTime(600);
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushAsync();
 
     // fsp.copyFile should be called for backup
     expect(fs.promises.copyFile).toHaveBeenCalled();
@@ -256,9 +253,7 @@ describe('projects state persistence', () => {
     });
 
     jest.advanceTimersByTime(600);
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushAsync();
 
     const { fs } = window.electron_nodeModules;
     const lastWrite = fs.promises.writeFile.mock.calls[fs.promises.writeFile.mock.calls.length - 1];
@@ -292,9 +287,7 @@ describe('settings state persistence', () => {
 
     // Run debounce
     jest.advanceTimersByTime(600);
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushAsync();
 
     // Verify write was called
     expect(fs.promises.writeFile).toHaveBeenCalled();
@@ -314,9 +307,7 @@ describe('settings state persistence', () => {
 
     settingsModule.setSetting('accentColor', '#d97706');
     jest.advanceTimersByTime(600);
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushAsync();
 
     const tmpWrites = fs.promises.writeFile.mock.calls.filter(c => c[0].endsWith('.tmp'));
     const parsed = JSON.parse(tmpWrites[tmpWrites.length - 1][1]);
@@ -423,9 +414,7 @@ describe('settings state persistence', () => {
     settingsModule.setSetting('compactProjects', false);
 
     jest.advanceTimersByTime(600);
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushAsync();
 
     const tmpWrites = fs.promises.writeFile.mock.calls.filter(c => c[0].endsWith('.tmp'));
     const parsed = JSON.parse(tmpWrites[tmpWrites.length - 1][1]);

--- a/tests/services/dashboardLoadSplit.test.js
+++ b/tests/services/dashboardLoadSplit.test.js
@@ -1,0 +1,147 @@
+/**
+ * The dashboard load path is split in two: everything readable from this
+ * machine, then the GitHub round-trip. The first paint must not wait on the
+ * network, and nothing that used to be fetched may go missing.
+ */
+
+jest.mock('../../src/renderer/state', () => ({
+  projectsState: { get: jest.fn(() => ({ projects: [], openedProjectId: null })), subscribe: jest.fn() },
+  settingsState: { get: jest.fn(() => ({ githubHostname: 'github.com' })), subscribe: jest.fn() },
+  setGitPulling: jest.fn(),
+  setGitPushing: jest.fn(),
+  setGitMerging: jest.fn(),
+  setMergeInProgress: jest.fn(),
+  getGitOperation: jest.fn(() => ({ mergeInProgress: false, conflicts: [] })),
+  getProjectTimes: jest.fn(() => ({ today: 0, total: 0 })),
+  getProjectSessions: jest.fn(() => []),
+  getFolder: jest.fn(),
+  getProject: jest.fn(),
+  countProjectsRecursive: jest.fn(() => 0),
+}));
+
+jest.mock('../../src/renderer/ui/components/Modal', () => ({
+  showConfirm: jest.fn(), createModal: jest.fn(), showModal: jest.fn(), closeModal: jest.fn(),
+}));
+jest.mock('../../src/renderer/utils', () => ({ escapeHtml: (s) => String(s ?? '') }));
+jest.mock('../../src/renderer/utils/color', () => ({ sanitizeColor: (c) => c }));
+jest.mock('../../src/renderer/utils/format', () => ({ formatDuration: () => '0m' }));
+jest.mock('../../src/project-types/registry', () => ({
+  get: jest.fn(() => ({ getDashboardBadge: () => ({ text: '', cssClass: '' }), getDashboardStats: () => '' })),
+}));
+jest.mock('../../src/renderer/ui/panels/KanbanPanel', () => ({ render: jest.fn() }));
+jest.mock('../../src/renderer/events', () => ({
+  getActiveProvider: () => 'scraping',
+  getDashboardStats: () => ({ hookSessionCount: 0, toolStats: {} }),
+}));
+jest.mock('../../src/renderer/services/SessionRecapService', () => ({ getRecaps: () => [] }));
+
+// Order of resolution is what this suite is about, so every call is recorded.
+let callLog;
+
+beforeEach(() => {
+  callLog = [];
+  // DashboardService captures `window.electron_api` at module load, so the
+  // object has to be mutated rather than replaced.
+  Object.assign(window.electron_api, {
+    git: {
+      infoFull: jest.fn(async () => {
+        callLog.push('git.infoFull');
+        return { isGitRepo: true, remoteUrl: 'https://github.com/o/r.git', branch: 'main' };
+      }),
+      commitHistory: jest.fn(async () => { callLog.push('git.commitHistory'); return []; }),
+      workflowRuns: jest.fn(async () => { callLog.push('github.workflowRuns'); return { runs: [] }; }),
+    },
+    project: {
+      stats: jest.fn(async () => { callLog.push('project.stats'); return { files: 1, lines: 2, byExtension: {} }; }),
+    },
+    github: {
+      workflowRuns: jest.fn(async () => { callLog.push('github.workflowRuns'); return { runs: [{ id: 1 }] }; }),
+      pullRequests: jest.fn(async () => { callLog.push('github.pullRequests'); return { pullRequests: [{ id: 2 }] }; }),
+      isAuthenticated: jest.fn(async () => true),
+    },
+  });
+  window.electron_nodeModules.fs.promises.readdir = jest.fn(async () => {
+    callLog.push('fs.readdir');
+    return ['package.json'];
+  });
+  window.electron_nodeModules.fs.promises.readFile = jest.fn(async () => '{}');
+  window.electron_nodeModules.fs.promises.access = jest.fn(async () => undefined);
+  window.electron_nodeModules.fs.promises.writeFile = jest.fn(async () => undefined);
+  window.electron_nodeModules.fs.promises.mkdir = jest.fn(async () => undefined);
+  window.electron_nodeModules.fs.promises.stat = jest.fn(async () => ({ mtime: new Date(0), size: 0 }));
+});
+
+const DashboardService = require('../../src/renderer/services/DashboardService');
+
+describe('loadLocalDashboardData', () => {
+  test('never touches the GitHub API', async () => {
+    await DashboardService.loadLocalDashboardData('/tmp/p');
+
+    expect(callLog).not.toContain('github.workflowRuns');
+    expect(callLog).not.toContain('github.pullRequests');
+  });
+
+  test('returns empty GitHub sections so the page can render without them', async () => {
+    const local = await DashboardService.loadLocalDashboardData('/tmp/p');
+
+    expect(local.workflowRuns).toEqual({ runs: [] });
+    expect(local.pullRequests).toEqual({ pullRequests: [] });
+  });
+
+  test('detects the project type in the same batch as the git calls', async () => {
+    const local = await DashboardService.loadLocalDashboardData('/tmp/p');
+
+    // detectProjectType reads the directory; it used to run only after the
+    // git calls had all resolved, adding a serial stage for no reason.
+    expect(callLog).toContain('fs.readdir');
+    expect(local).toHaveProperty('projectType');
+  });
+
+  test('lightweight mode skips the 500-commit history', async () => {
+    const local = await DashboardService.loadLocalDashboardData('/tmp/p', { lightweight: true });
+
+    expect(callLog).not.toContain('git.commitHistory');
+    expect(local.commitHistory30d).toBeNull();
+  });
+});
+
+describe('loadRemoteDashboardData', () => {
+  test('returns null when the project has no GitHub remote', async () => {
+    const remote = await DashboardService.loadRemoteDashboardData({ isGitRepo: true, remoteUrl: null });
+
+    expect(remote).toBeNull();
+    expect(callLog).not.toContain('github.pullRequests');
+  });
+
+  test('returns null when the project is not a git repo at all', async () => {
+    expect(await DashboardService.loadRemoteDashboardData({ isGitRepo: false })).toBeNull();
+    expect(await DashboardService.loadRemoteDashboardData(null)).toBeNull();
+  });
+});
+
+describe('loadDashboardData', () => {
+  test('still returns both halves, so nothing the dashboard shows is lost', async () => {
+    const data = await DashboardService.loadDashboardData('/tmp/p');
+
+    expect(data).toHaveProperty('gitInfo');
+    expect(data).toHaveProperty('stats');
+    expect(data).toHaveProperty('projectType');
+    expect(data).toHaveProperty('commitHistory30d');
+    expect(data).toHaveProperty('workflowRuns');
+    expect(data).toHaveProperty('pullRequests');
+  });
+
+  test('the local calls all happen before the GitHub ones', async () => {
+    await DashboardService.loadDashboardData('/tmp/p');
+
+    const firstRemote = callLog.findIndex(c => c.startsWith('github.'));
+    const lastLocal = Math.max(
+      callLog.lastIndexOf('git.infoFull'),
+      callLog.lastIndexOf('project.stats'),
+      callLog.lastIndexOf('git.commitHistory'),
+    );
+
+    expect(firstRemote).toBeGreaterThan(-1);
+    expect(lastLocal).toBeLessThan(firstRemote);
+  });
+});

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -14,6 +14,7 @@ window.electron_nodeModules = {
       readFile: jest.fn(),
       writeFile: jest.fn(),
       access: jest.fn(),
+      stat: jest.fn(),
       mkdir: jest.fn(),
       copyFile: jest.fn(),
       rename: jest.fn(),

--- a/tests/state/projects.merge.test.js
+++ b/tests/state/projects.merge.test.js
@@ -1,0 +1,187 @@
+const {
+  deepEqual,
+  mergeEntity,
+  mergeEntityList,
+  reconcileOrder,
+  mergeProjectsData,
+  snapshot,
+} = require('../../src/renderer/state/projects.merge');
+
+describe('deepEqual', () => {
+  test('compares nested structures by value', () => {
+    expect(deepEqual({ a: [1, { b: 2 }] }, { a: [1, { b: 2 }] })).toBe(true);
+    expect(deepEqual({ a: [1, { b: 2 }] }, { a: [1, { b: 3 }] })).toBe(false);
+  });
+
+  test('distinguishes missing keys from undefined values', () => {
+    expect(deepEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+    expect(deepEqual([], {})).toBe(false);
+  });
+});
+
+describe('mergeEntity', () => {
+  test('a field we did not touch takes the disk value', () => {
+    const base = { id: 'p1', name: 'narvi', tasks: [] };
+    const ours = { id: 'p1', name: 'narvi', tasks: [] };
+    const theirs = { id: 'p1', name: 'narvi', tasks: [{ id: 't1' }] };
+
+    expect(mergeEntity(base, ours, theirs).tasks).toEqual([{ id: 't1' }]);
+  });
+
+  test('a field we changed stays ours', () => {
+    const base = { id: 'p1', name: 'narvi' };
+    const ours = { id: 'p1', name: 'narvi-renamed' };
+    const theirs = { id: 'p1', name: 'narvi-from-mcp' };
+
+    expect(mergeEntity(base, ours, theirs).name).toBe('narvi-renamed');
+  });
+
+  test('a field we cleared on purpose stays cleared', () => {
+    const base = { id: 'p1', tasks: [{ id: 't1' }] };
+    const ours = { id: 'p1', tasks: [] };
+    const theirs = { id: 'p1', tasks: [{ id: 't1' }] };
+
+    expect(mergeEntity(base, ours, theirs).tasks).toEqual([]);
+  });
+
+  test('keeps a field only the disk knows about', () => {
+    const merged = mergeEntity({ id: 'p1' }, { id: 'p1' }, { id: 'p1', kanbanLabels: ['x'] });
+    expect(merged.kanbanLabels).toEqual(['x']);
+  });
+});
+
+describe('mergeEntityList', () => {
+  test('keeps an entity another writer added while we were running', () => {
+    const base = [{ id: 'p1' }];
+    const ours = [{ id: 'p1' }];
+    const theirs = [{ id: 'p1' }, { id: 'wt1', name: 'worktree' }];
+
+    const merged = mergeEntityList(base, ours, theirs);
+    expect(merged.map(p => p.id)).toEqual(['p1', 'wt1']);
+  });
+
+  test('does not resurrect an entity we deleted', () => {
+    const base = [{ id: 'p1' }, { id: 'p2' }];
+    const ours = [{ id: 'p1' }];
+    const theirs = [{ id: 'p1' }, { id: 'p2' }];
+
+    const merged = mergeEntityList(base, ours, theirs);
+    expect(merged.map(p => p.id)).toEqual(['p1']);
+  });
+
+  test('keeps an entity we added that the disk has not seen', () => {
+    const merged = mergeEntityList([], [{ id: 'new' }], []);
+    expect(merged.map(p => p.id)).toEqual(['new']);
+  });
+});
+
+describe('reconcileOrder', () => {
+  test('takes the disk order when we did not reorder', () => {
+    const order = reconcileOrder(['a', 'b'], ['a', 'b'], ['b', 'a'], new Set(['a', 'b']));
+    expect(order).toEqual(['b', 'a']);
+  });
+
+  test('keeps our order when we reordered', () => {
+    const order = reconcileOrder(['a', 'b'], ['b', 'a'], ['a', 'b'], new Set(['a', 'b']));
+    expect(order).toEqual(['b', 'a']);
+  });
+
+  test('drops ids with no surviving entity and appends orphans', () => {
+    const order = reconcileOrder(['a'], ['a'], ['a', 'gone'], new Set(['a', 'added']));
+    expect(order).toEqual(['a', 'added']);
+  });
+});
+
+describe('mergeProjectsData — the incident', () => {
+  // Reproduces the real data loss: an MCP session added 18 kanban tasks to
+  // "narvi" after the renderer had loaded, then any renderer save rewrote the
+  // whole file from its stale copy and wiped them.
+  const baseline = {
+    projects: [
+      { id: 'narvi', name: 'narvi', tasks: [], kanbanColumns: [] },
+      { id: 'ct', name: 'Claude Terminal', tasks: [] },
+    ],
+    folders: [],
+    rootOrder: ['narvi', 'ct'],
+  };
+
+  const memoryCopy = {
+    // Same as the baseline: the renderer never learned about the tasks.
+    projects: [
+      { id: 'narvi', name: 'narvi', tasks: [], kanbanColumns: [] },
+      { id: 'ct', name: 'Claude Terminal', tasks: [] },
+    ],
+    folders: [],
+    rootOrder: ['narvi', 'ct'],
+  };
+
+  const onDisk = {
+    projects: [
+      {
+        id: 'narvi',
+        name: 'narvi',
+        tasks: Array.from({ length: 18 }, (_, i) => ({ id: `t${i}`, title: `task ${i}` })),
+        kanbanColumns: [{ id: 'col-todo', title: 'To Do', order: 0 }],
+      },
+      { id: 'ct', name: 'Claude Terminal', tasks: [] },
+      { id: 'wt', name: 'bg-agents · snapshot-retention (wt)', path: '/tmp/wt' },
+    ],
+    folders: [],
+    rootOrder: ['narvi', 'ct', 'wt'],
+  };
+
+  test('the 18 tasks survive a save from a stale in-memory copy', () => {
+    const merged = mergeProjectsData(baseline, memoryCopy, onDisk);
+    const narvi = merged.projects.find(p => p.id === 'narvi');
+
+    expect(narvi.tasks).toHaveLength(18);
+    expect(narvi.kanbanColumns).toEqual([{ id: 'col-todo', title: 'To Do', order: 0 }]);
+  });
+
+  test('the worktree project the renderer never knew about is kept', () => {
+    const merged = mergeProjectsData(baseline, memoryCopy, onDisk);
+
+    expect(merged.projects.map(p => p.id)).toContain('wt');
+    expect(merged.rootOrder).toContain('wt');
+  });
+
+  test('a rename made in the UI still wins over the disk', () => {
+    const ours = JSON.parse(JSON.stringify(memoryCopy));
+    ours.projects[0].name = 'narvi (renamed here)';
+
+    const merged = mergeProjectsData(baseline, ours, onDisk);
+    const narvi = merged.projects.find(p => p.id === 'narvi');
+
+    expect(narvi.name).toBe('narvi (renamed here)');
+    // ...without costing the tasks we never touched.
+    expect(narvi.tasks).toHaveLength(18);
+  });
+
+  test('a project deleted in the UI is not brought back by the merge', () => {
+    const ours = { ...memoryCopy, projects: [memoryCopy.projects[0]], rootOrder: ['narvi'] };
+
+    const merged = mergeProjectsData(baseline, ours, onDisk);
+
+    expect(merged.projects.map(p => p.id)).not.toContain('ct');
+  });
+
+  test('with nothing on disk our copy is written as-is', () => {
+    const merged = mergeProjectsData(baseline, memoryCopy, null);
+    expect(merged.projects).toEqual(memoryCopy.projects);
+  });
+
+  test('with no baseline the disk is treated as entirely new data', () => {
+    const merged = mergeProjectsData(null, { projects: [], folders: [], rootOrder: [] }, onDisk);
+    expect(merged.projects).toHaveLength(3);
+  });
+});
+
+describe('snapshot', () => {
+  test('detaches from the source object', () => {
+    const src = { projects: [{ id: 'p', tasks: [] }], folders: [], rootOrder: ['p'] };
+    const snap = snapshot(src);
+    src.projects[0].tasks.push({ id: 't' });
+
+    expect(snap.projects[0].tasks).toEqual([]);
+  });
+});

--- a/tests/state/projectsSaveMerge.test.js
+++ b/tests/state/projectsSaveMerge.test.js
@@ -1,0 +1,158 @@
+/**
+ * End-to-end guard on the save path itself: saveProjectsImmediate must
+ * reconcile with the file on disk instead of rewriting it from memory.
+ *
+ * The regression this pins down: an MCP session wrote 18 kanban tasks to
+ * projects.json after the renderer had loaded, and the next renderer save —
+ * triggered by nothing more than opening the kanban — wiped them.
+ */
+
+const {
+  projectsState,
+  loadProjects,
+  saveProjectsImmediate,
+  getKanbanColumns,
+  stopExternalWatch,
+} = require('../../src/renderer/state/projects.state');
+
+const fsMock = window.electron_nodeModules.fs;
+
+/** Whatever the code last wrote through the atomic write path. */
+function lastWrittenPayload() {
+  const calls = fsMock.promises.writeFile.mock.calls;
+  if (!calls.length) return null;
+  return JSON.parse(calls[calls.length - 1][1]);
+}
+
+/** Make the mocked filesystem answer with `content` for projects.json. */
+function setDiskContent(content) {
+  fsMock.promises.access.mockResolvedValue(undefined);
+  fsMock.promises.readFile.mockResolvedValue(JSON.stringify(content));
+}
+
+const NARVI_TASKS = Array.from({ length: 18 }, (_, i) => ({
+  id: `task-${i}`,
+  title: `#${i} step`,
+  columnId: 'col-todo',
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  fsMock.promises.mkdir.mockResolvedValue(undefined);
+  fsMock.promises.writeFile.mockResolvedValue(undefined);
+  fsMock.promises.rename.mockResolvedValue(undefined);
+  fsMock.promises.copyFile.mockResolvedValue(undefined);
+  fsMock.promises.unlink.mockResolvedValue(undefined);
+  fsMock.promises.stat.mockResolvedValue({ mtime: new Date(0), size: 0 });
+});
+
+afterEach(() => {
+  stopExternalWatch();
+});
+
+describe('saveProjectsImmediate merges with the disk', () => {
+  test('tasks written by another process survive our save', async () => {
+    // The renderer loads a file with no tasks — this becomes its baseline.
+    setDiskContent({
+      projects: [{ id: 'narvi', name: 'narvi', type: 'standalone', folderId: null, tasks: [] }],
+      folders: [],
+      rootOrder: ['narvi'],
+    });
+    await loadProjects();
+
+    // An MCP session then fills the board behind our back.
+    setDiskContent({
+      projects: [{ id: 'narvi', name: 'narvi', type: 'standalone', folderId: null, tasks: NARVI_TASKS }],
+      folders: [],
+      rootOrder: ['narvi'],
+    });
+
+    // Anything at all triggers a save from our still-empty copy.
+    await saveProjectsImmediate();
+
+    const written = lastWrittenPayload();
+    expect(written.projects.find(p => p.id === 'narvi').tasks).toHaveLength(18);
+  });
+
+  test('a project added by another process is not dropped', async () => {
+    setDiskContent({
+      projects: [{ id: 'narvi', name: 'narvi', type: 'standalone', folderId: null }],
+      folders: [],
+      rootOrder: ['narvi'],
+    });
+    await loadProjects();
+
+    setDiskContent({
+      projects: [
+        { id: 'narvi', name: 'narvi', type: 'standalone', folderId: null },
+        { id: 'wt', name: 'worktree', type: 'standalone', folderId: null, path: '/tmp/wt' },
+      ],
+      folders: [],
+      rootOrder: ['narvi', 'wt'],
+    });
+
+    await saveProjectsImmediate();
+
+    const written = lastWrittenPayload();
+    expect(written.projects.map(p => p.id)).toContain('wt');
+    expect(written.rootOrder).toContain('wt');
+  });
+
+  test('our own edit still wins over the disk', async () => {
+    setDiskContent({
+      projects: [{ id: 'narvi', name: 'narvi', type: 'standalone', folderId: null, tasks: [] }],
+      folders: [],
+      rootOrder: ['narvi'],
+    });
+    await loadProjects();
+
+    // We rename locally; meanwhile the disk gains tasks.
+    projectsState.set({
+      projects: [{ id: 'narvi', name: 'renamed', type: 'standalone', folderId: null, tasks: [] }],
+    });
+    setDiskContent({
+      projects: [{ id: 'narvi', name: 'narvi', type: 'standalone', folderId: null, tasks: NARVI_TASKS }],
+      folders: [],
+      rootOrder: ['narvi'],
+    });
+
+    await saveProjectsImmediate();
+
+    const written = lastWrittenPayload();
+    const narvi = written.projects.find(p => p.id === 'narvi');
+    expect(narvi.name).toBe('renamed');
+    expect(narvi.tasks).toHaveLength(18);
+  });
+
+  test('an unreadable disk file does not abort the save', async () => {
+    setDiskContent({ projects: [], folders: [], rootOrder: [] });
+    await loadProjects();
+
+    projectsState.set({
+      projects: [{ id: 'p', name: 'p', type: 'standalone', folderId: null }],
+      rootOrder: ['p'],
+    });
+    fsMock.promises.readFile.mockResolvedValue('{ not json');
+
+    await saveProjectsImmediate();
+
+    expect(lastWrittenPayload().projects.map(p => p.id)).toEqual(['p']);
+  });
+});
+
+describe('reading the kanban does not write', () => {
+  test('getKanbanColumns returns defaults without saving', async () => {
+    setDiskContent({
+      projects: [{ id: 'p', name: 'p', type: 'standalone', folderId: null }],
+      folders: [],
+      rootOrder: ['p'],
+    });
+    await loadProjects();
+    fsMock.promises.writeFile.mockClear();
+
+    const cols = getKanbanColumns('p');
+
+    expect(cols).toHaveLength(3);
+    expect(fsMock.promises.writeFile).not.toHaveBeenCalled();
+  });
+});

--- a/tests/ui/kanbanLiveRefresh.test.js
+++ b/tests/ui/kanbanLiveRefresh.test.js
@@ -1,0 +1,106 @@
+/**
+ * Kanban board — refresh on writes that did not come from the board.
+ *
+ * projects.json has several writers: the MCP kanban tools (a Claude session
+ * filing its own tasks) and ParallelTaskService. projects.state reloads the
+ * file when another process touches it, but the board used to be rebuilt only
+ * by its own event handlers, so those tasks stayed invisible until the user
+ * navigated away from the dashboard and back.
+ */
+
+const { projectsState, getTasks } = require('../../src/renderer/state');
+const KanbanPanel = require('../../src/renderer/ui/panels/KanbanPanel');
+
+/** State notifications are batched through requestAnimationFrame. */
+const flush = () => new Promise(resolve => setTimeout(resolve, 5));
+
+const COLUMNS = [
+  { id: 'col-todo', title: 'To Do', color: '#3b82f6', order: 0 },
+  { id: 'col-done', title: 'Done', color: '#22c55e', order: 1 },
+];
+
+const task = (id, title, columnId = 'col-todo') => ({
+  id, title, description: '', labels: [], columnId,
+  worktreePath: null, sessionIds: [], order: 0,
+  createdAt: 1, updatedAt: 1,
+});
+
+/** Replace the project wholesale, the way a reload from disk does. */
+function writeFromAnotherProcess(tasks) {
+  const { projects } = projectsState.get();
+  projectsState.set({
+    projects: projects.map(p => (p.id === 'p1' ? { ...p, tasks } : p)),
+  });
+}
+
+const titles = (container) =>
+  Array.from(container.querySelectorAll('.kanban-card-title')).map(el => el.textContent.trim());
+
+describe('kanban board live refresh', () => {
+  let container;
+  let project;
+
+  beforeEach(() => {
+    project = {
+      id: 'p1', name: 'narvi', path: '/tmp/narvi', type: 'standalone', folderId: null,
+      kanbanColumns: COLUMNS, kanbanLabels: [], tasks: [task('t1', 'first')],
+    };
+    projectsState.set({ projects: [project], folders: [], rootOrder: ['p1'] });
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    KanbanPanel.render(container, project);
+  });
+
+  afterEach(() => {
+    container.remove();
+    projectsState.set({ projects: [], folders: [], rootOrder: [] });
+  });
+
+  test('renders the tasks it was given', () => {
+    expect(titles(container)).toEqual(['first']);
+  });
+
+  test('picks up a task written by another process', async () => {
+    writeFromAnotherProcess([task('t1', 'first'), task('t2', 'from an MCP session')]);
+    await flush();
+
+    expect(titles(container)).toEqual(['first', 'from an MCP session']);
+  });
+
+  test('picks up a task moved to another column', async () => {
+    writeFromAnotherProcess([task('t1', 'first', 'col-done')]);
+    await flush();
+
+    const done = container.querySelector('[data-col-id="col-done"]');
+    expect(done.textContent).toContain('first');
+  });
+
+  test('keeps following after a refresh it triggered itself', async () => {
+    writeFromAnotherProcess([task('t1', 'first'), task('t2', 'second')]);
+    await flush();
+    writeFromAnotherProcess([task('t1', 'first'), task('t2', 'second'), task('t3', 'third')]);
+    await flush();
+
+    expect(titles(container)).toEqual(['first', 'second', 'third']);
+  });
+
+  test('ignores state changes that leave the board identical', async () => {
+    const board = container.querySelector('.kanban-board');
+    projectsState.set({ selectedProjectFilter: 0 });
+    await flush();
+
+    // Same element: nothing was rebuilt, so an open drag or focus survives.
+    expect(container.querySelector('.kanban-board')).toBe(board);
+  });
+
+  test('stops following once the board leaves the DOM', async () => {
+    container.remove();
+    writeFromAnotherProcess([task('t1', 'first'), task('t2', 'second')]);
+    await flush();
+
+    // The detached board is not rebuilt, and state still holds the new task.
+    expect(titles(container)).toEqual(['first']);
+    expect(getTasks('p1')).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Fixes #176.

`~/.claude-terminal/projects.json` has several independent writers — this renderer, the MCP kanban tools, and `ParallelTaskService` for worktree projects — but the renderer read it once at startup and then rewrote it whole from its in-memory copy. Anything another process wrote afterwards was destroyed by the next save, for any reason, however unrelated.

I hit this for real: an MCP session filled a project's kanban with 18 tasks, and a later renderer save wiped all of them along with a worktree project entry. The save that did it was triggered by nothing more than **opening the kanban**.

## The three changes

**1. Saving merges with the disk instead of overwriting it.**

The interesting part is why a two-way comparison is not enough: without a memory of what we last saw, "we cleared this field" and "we never saw this field" look identical. So the save keeps a baseline — the content we last agreed on with the disk — and does a three-way merge against it (`src/renderer/state/projects.merge.js`):

- a field we did not touch takes the disk's value;
- a field we did change stays ours;
- an entity missing from memory is a deletion **only if the baseline knew it** — otherwise another writer added it while we were running, and it is kept.

```diff
-const data = { folders, projects, rootOrder };
+const ours = { folders, projects, rootOrder };
+const theirs = await _readDiskState();
+const data = mergeProjectsData(_diskBaseline, ours, theirs);
 await atomicWriteJSON(projectsFile, data);
```

The merged result is adopted back into state, so the UI stops showing data the merge has already superseded. A parse failure on the disk copy does not abort the save — it just means there is nothing to reconcile against, and the existing corruption handling in `loadProjects` still owns recovery.

**2. The renderer notices external writes.**

`projects.json` is polled and reloaded when someone else writes it. Polled rather than watched deliberately: the preload bridge exposes `stat` but no `fs.watch`, and I did not want to widen that bridge for this — it is the app's sensitive surface. The file is replaced by an atomic rename anyway, which several watch backends report inconsistently. Our own writes are recorded so they do not trigger a reload.

**3. A read no longer writes.**

`getKanbanColumns()` persisted the default columns when a project had none, which is what turned *displaying* a board into a full-file save. It now returns the defaults; the first real mutation persists them (every add/update/delete/reorder already writes the full column array back). The legacy task migration likewise stays put when there is nothing in the old shape to convert.

## Tests

- `tests/state/projects.merge.test.js` — 19 tests on the merge itself, including the incident replayed as a fixture: baseline without tasks + memory without tasks + disk with 18 tasks → the 18 survive. Also covers the cases a merge must not get wrong: a local rename still winning, a deliberate deletion not being resurrected, an unknown project being kept.
- `tests/state/projectsSaveMerge.test.js` — the same guarantees through the real `saveProjectsImmediate` path, plus a check that reading the kanban writes nothing.

`tests/integration/state-persistence.test.js` needed a touch: it counted individual microtask ticks (`await Promise.resolve()` ×3) to decide when a save had landed, and the extra read makes that count wrong. It drains the queue instead — the assertions are unchanged, only the way of waiting was brittle.

Full suite green (117 suites, 2830 tests), `npm run build:renderer` clean.

---

## Also in this branch: the dashboard first paint

Separate commit, and a separate concern — kept together because both came out of the same session, happy to split if you would rather.

Opening a project held the whole dashboard behind a spinner until every piece of data had arrived, including two GitHub API calls. The load path was three serial stages where it needed two, and the slowest stage feeds a small part of the page.

- `detectProjectType` only needs the project path, yet it ran *after* the git calls had all resolved. It joins their batch.
- The rest is split in two: everything readable from this machine, then the GitHub half. First paint happens as soon as the local data is in; the workflow-run and pull-request sections fill in when they arrive.

Only the complete payload is cached, since `setCacheData` resets the TTL — caching the local half alone would leave those sections empty until it expired.

What the dashboard displays is unchanged; only when it appears.

Covered by `tests/services/dashboardLoadSplit.test.js` (8 tests), including one that pins the ordering so the GitHub calls cannot creep back in front of the first paint.
