### PR TITLE
fix(accounts): make "refresh usage" re-read every account's credential store

### DIFF
--- a/src/main/ipc/accounts.ipc.js
+++ b/src/main/ipc/accounts.ipc.js
@@ -31,12 +31,15 @@ const seededStores = new Set();
  *
  * Bounded to one attempt per account because probing a store costs a Keychain
  * read on macOS, and the settings list asks for these figures on every account
- * change — a rename would otherwise re-probe every account.
+ * change — a rename would otherwise re-probe every account. The explicit
+ * refresh gesture lifts the bound: it exists precisely to re-examine stores
+ * that have changed since (a `claude /login` on an account that had none).
  *
  * @param {string} id
+ * @param {boolean} [force]
  */
-async function seedStoreOnce(id) {
-  if (seededStores.has(id)) return;
+async function seedStoreOnce(id, force = false) {
+  if (seededStores.has(id) && !force) return;
   seededStores.add(id);
   try {
     await AccountManager.ensureAccountStore(id);
@@ -64,12 +67,24 @@ function registerAccountsHandlers() {
   //
   // Fetched in parallel: the calls are independent, and a serial sweep would
   // make the whole list wait out one account's five-second API timeout.
-  ipcMain.handle('accounts-usage', (_event, { maxAgeMs } = {}) => wrap(async () => {
+  //
+  // `force` is the explicit refresh button, and it has to reach all the way
+  // down to the credential store: a stale max-age only re-runs the API call
+  // with the token already cached, which cannot notice an account that was
+  // signed in again outside the app.
+  ipcMain.handle('accounts-usage', (_event, { maxAgeMs, force = false } = {}) => wrap(async () => {
     const { accounts } = await AccountManager.listAccounts();
     const usage = {};
     await Promise.all(accounts.map(async (account) => {
-      await seedStoreOnce(account.id);
-      usage[account.id] = await UsageService.usageForAccount(account.id, maxAgeMs);
+      await seedStoreOnce(account.id, force);
+      try {
+        usage[account.id] = await UsageService.usageForAccount(account.id, maxAgeMs, force);
+      } catch (err) {
+        // One unreadable account must not blank the whole list: report it as
+        // an account whose figures failed, and let the others through.
+        console.warn('[accounts.ipc] usage failed for', account.id, '-', err.message);
+        usage[account.id] = { accountId: account.id, data: null, stale: true, error: err.message };
+      }
     }));
     return usage;
   }));

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -569,7 +569,7 @@ contextBridge.exposeInMainWorld('electron_api', {
   // ==================== ACCOUNTS (multi Claude OAuth) ====================
   accounts: {
     list: () => ipcRenderer.invoke('accounts-list'),
-    usage: (maxAgeMs) => ipcRenderer.invoke('accounts-usage', { maxAgeMs }),
+    usage: (maxAgeMs, force) => ipcRenderer.invoke('accounts-usage', { maxAgeMs, force }),
     capture: (name) => ipcRenderer.invoke('accounts-capture', { name }),
     switch: (id) => ipcRenderer.invoke('accounts-switch', { id }),
     setDefault: (id) => ipcRenderer.invoke('accounts-set-default', { id }),

--- a/src/main/services/UsageService.js
+++ b/src/main/services/UsageService.js
@@ -466,15 +466,20 @@ function refreshUsage(accountId, force = false) {
  *
  * @param {string|null} accountId
  * @param {number} [maxAgeMs] - 0 forces a fetch
+ * @param {boolean} [force] - also re-read the credential store, for the
+ *   explicit refresh gesture; see readOAuthToken(). Without it, an account
+ *   whose token was missing or refused stays unreadable for the whole backoff
+ *   window (15 min), so refreshing right after `claude /login` on that account
+ *   still showed "usage unavailable".
  * @returns {Promise<Object>} same shape as getUsageData()
  */
-async function usageForAccount(accountId, maxAgeMs = 5 * 60 * 1000) {
+async function usageForAccount(accountId, maxAgeMs = 5 * 60 * 1000, force = false) {
   const entry = entryFor(accountId);
   const age = entry.lastFetch ? Date.now() - entry.lastFetch.getTime() : Infinity;
   // `>=` so that a maxAge of 0 always refetches: figures fetched in the same
   // millisecond are not "younger than 0ms", and the explicit refresh button
   // would otherwise be a no-op on a fast machine.
-  if (age >= maxAgeMs) await fetchUsage(accountId);
+  if (force || age >= maxAgeMs) await fetchUsage(accountId, force);
   return getUsageData(accountId);
 }
 

--- a/src/renderer/ui/panels/SettingsPanel.js
+++ b/src/renderer/ui/panels/SettingsPanel.js
@@ -2630,11 +2630,21 @@ class SettingsPanel extends BasePanel {
     const listEl = document.getElementById('claude-accounts-list');
     if (!listEl?.isConnected) return;
     if (!force && !listEl.closest('.settings-panel')?.classList.contains('active')) return;
-    if (this._accountsUsageInFlight) return;
+    // The explicit gesture is never swallowed: a background sweep already in
+    // flight would otherwise make the button re-enable itself having done
+    // nothing at all.
+    if (this._accountsUsageInFlight && !force) return;
+
+    if (force) {
+      // Say that every row is being re-read, rather than leaving the previous
+      // figures up for the seconds the sweep takes and looking inert.
+      this._accountsUsage = {};
+      this._paintAccountsUsage(listEl);
+    }
 
     this._accountsUsageInFlight = true;
     try {
-      const res = await this.api.accounts.usage(force ? 0 : undefined);
+      const res = await this.api.accounts.usage(force ? 0 : undefined, force);
       if (res?.success) this._accountsUsage = res.data || {};
     } catch (err) {
       console.warn('[SettingsPanel] account usage failed:', err?.message);

--- a/tests/ipc/accountsUsage.ipc.test.js
+++ b/tests/ipc/accountsUsage.ipc.test.js
@@ -85,7 +85,38 @@ describe('accounts-usage', () => {
   test('passes the requested max age through, so refresh can force a fetch', async () => {
     await handlers['accounts-usage']({}, { maxAgeMs: 0 });
 
-    expect(mockUsageService.usageForAccount).toHaveBeenCalledWith('acct-max', 0);
+    expect(mockUsageService.usageForAccount).toHaveBeenCalledWith('acct-max', 0, false);
+  });
+
+  test('the explicit refresh forces every account, not just the focused one', async () => {
+    await handlers['accounts-usage']({}, { maxAgeMs: 0, force: true });
+
+    // Without force the fetch trusts the cached token, so an account signed in
+    // again outside the app keeps reporting itself signed out.
+    expect(mockUsageService.usageForAccount).toHaveBeenCalledWith('acct-max', 0, true);
+    expect(mockUsageService.usageForAccount).toHaveBeenCalledWith('acct-team', 0, true);
+  });
+
+  test('the explicit refresh re-seeds stores the once-per-run bound had skipped', async () => {
+    await handlers['accounts-usage']({}, {});
+    mockAccountManager.ensureAccountStore.mockClear();
+
+    await handlers['accounts-usage']({}, { maxAgeMs: 0, force: true });
+
+    expect(mockAccountManager.ensureAccountStore).toHaveBeenCalledTimes(2);
+  });
+
+  test('an account whose fetch throws does not blank the others', async () => {
+    mockUsageService.usageForAccount.mockImplementation(async (id) => {
+      if (id === 'acct-team') throw new Error('keychain denied');
+      return { accountId: id, data: { buckets: [] }, stale: false, error: null };
+    });
+
+    const res = await handlers['accounts-usage']({}, { maxAgeMs: 0, force: true });
+
+    expect(res.success).toBe(true);
+    expect(res.data['acct-max']).toBeTruthy();
+    expect(res.data['acct-team'].error).toBe('keychain denied');
   });
 
   test('bootstraps each credential store once, not on every call', async () => {


### PR DESCRIPTION
Fixes #178

## The bug

**Settings → Claude accounts → Refresh usage** cannot recover an account that was signed in again outside the app. The button sends `maxAgeMs: 0`, which bypasses the cache of the *figures* — the fetch underneath still runs with the token already in the cache, and the token cache is the thing that is wrong:

- a missing or unreadable token is cached for `TOKEN_CACHE_BACKOFF` (15 min);
- a token the API refused is pinned as `entry.rejectedToken` until the CLI writes a different one.

So the one case the gesture exists for is exactly the one it could not notice. An account showing *"usage unavailable — run `claude /login` on this account"* kept showing it after the user did precisely that.

`readOAuthToken()` has taken a `force` flag since the single-account `usage-refresh` handler needed one. It just never reached the all-accounts sweep.

## The fix

Thread `force` from the button down to the store:

```
SettingsPanel → accounts.usage(0, true) → accounts-usage → usageForAccount(id, 0, true) → fetchUsage(id, true) → readOAuthToken(id, true)
```

and lift the once-per-run bound on `seedStoreOnce()` under `force`, so a credential store provisioned after the first sweep is seen.

**The periodic poll is untouched and still never forces.** On darwin every forced read is a potential Keychain prompt — that is why the token cache is six hours long, and why this stays tied to the button.

## Three smaller faults in the same gesture

| | Before | After |
|---|---|---|
| One account throws | `Promise.all` rejects → `{ success: false }` → every row keeps its stale figures | caught per account, reported as one account whose fetch failed |
| Click during a background sweep | `_accountsUsageInFlight` returns early — button disabled then re-enabled, nothing done | the explicit gesture is not subject to that guard |
| While the sweep runs | old figures stay up; a refresh ending on the same numbers looks like a dead button | rows repaint as "reading usage…" first |

## Tests

`tests/ipc/accountsUsage.ipc.test.js` gains four cases: the max-age passthrough now asserts the `force` argument, the explicit refresh forces *every* account rather than the focused one, a forced sweep re-seeds the stores the once-per-run bound had skipped, and an account whose fetch throws no longer blanks the others.

Full suite green (125 suites / 2885 tests).

## Not verified

The Keychain re-read itself was not exercised against a real signed-out account — the reasoning is from the cache's own backoff constants, and the behaviour under test is the argument threading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)