### PR TITLE
feat(settings): add configurable terminal font size

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ npm run build:win        # Windows NSIS installer
 npm run build:mac        # macOS DMG
 npm run build:linux      # Linux AppImage
 npm run publish          # Build and publish Windows installer to update server
-npm test                 # Run Jest tests (jsdom, 155 test files)
+npm test                 # Run Jest tests (jsdom, 157 test files)
 npm run test:watch       # Jest in watch mode
 npm run check:docs       # Fail if CLAUDE.md or the README translations have drifted
 npm run lint             # ESLint over main, renderer, shared, MCP servers and scripts
@@ -58,7 +58,7 @@ Electron Renderer Process (Browser)
 ├── src/renderer/workflow-fields/    # 13 custom UI fields for workflow nodes
 ├── src/renderer/workflow-triggers/  # 12 trigger types (definition + configurator)
 ├── src/renderer/viewers/            # PDF viewer + 3D (three.js) viewer
-├── src/renderer/i18n/               # EN/FR/ES/ID/zh-CN locales (3680 keys each)
+├── src/renderer/i18n/               # EN/FR/ES/ID/zh-CN locales (3682 keys each)
 └── src/renderer/utils/              # DOM, color, format, paths, icons, syntax highlighting
 
 Project Types (Plugin System)
@@ -352,7 +352,7 @@ The dashboard has three sub-views, switched by `_dashViews` and rendered from `D
 ### Internationalization (`src/renderer/i18n/locales/`)
 
 - **Languages:** French (default), English (fallback), Spanish, Indonesian, Simplified Chinese (`fr.json`, `en.json`, `es.json`, `id.json`, `zh-CN.json`)
-- **Keys:** 3680 per locale, all five in exact sync (enforced by `tests/i18n/i18n-coherence.test.js`)
+- **Keys:** 3682 per locale, all five in exact sync (enforced by `tests/i18n/i18n-coherence.test.js`)
 - **Loading:** only `en.json` is bundled eagerly, as the guaranteed-loaded fallback for `t()`; the others are fetched by `initI18n()`
 - **Detection:** auto-detect from `navigator.language`, `DEFAULT_LANGUAGE` is `fr`
 - **Usage:** `t('projects.openFolder')`, `t('key', { count: 5 })`, `data-i18n="..."` for static HTML
@@ -617,7 +617,7 @@ npm run test:e2e            # Playwright smoke test against the real Electron ap
 
 ### Unit tests (Jest)
 
-- **Framework:** Jest with jsdom, 155 test files
+- **Framework:** Jest with jsdom, 157 test files
 - **Setup:** `tests/setup.js` mocks `window.electron_nodeModules`, `window.electron_api`, `requestAnimationFrame`
 - **Pattern:** `**/tests/**/*.test.js`
 - **Directories:**

--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ npm install
 
 ### Settings
 - Accent color theming (preset palettes + custom hex)
+- Terminal font size (10 to 24 px), applied live to open terminals
 - Per-agent and per-tool color customization for chat tool cards
 - Language: English, French, Spanish, Indonesian, and Simplified Chinese with auto-detection
 - Editor integration: VS Code, Cursor, WebStorm, IntelliJ IDEA

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -779,6 +779,8 @@
     "accentColorDesc": "Customize the main interface color",
     "terminalTheme": "Terminal theme",
     "terminalThemeDesc": "Change the terminal colors",
+    "terminalFontSize": "Terminal font size",
+    "terminalFontSizeDesc": "Adjust the font size used in terminal tabs",
     "theme": "Terminal theme",
     "notifications": "Notifications",
     "closeAction": "Close action",

--- a/src/renderer/i18n/locales/es.json
+++ b/src/renderer/i18n/locales/es.json
@@ -776,6 +776,8 @@
     "accentColorDesc": "Personalizar el color principal de la interfaz",
     "terminalTheme": "Tema de terminal",
     "terminalThemeDesc": "Cambiar los colores de la terminal",
+    "terminalFontSize": "Tamaño de fuente de la terminal",
+    "terminalFontSizeDesc": "Ajustar el tamaño de fuente usado en las pestañas de terminal",
     "theme": "Tema de terminal",
     "notifications": "Notificaciones",
     "closeAction": "Acción al cerrar",

--- a/src/renderer/i18n/locales/fr.json
+++ b/src/renderer/i18n/locales/fr.json
@@ -874,6 +874,8 @@
     "accentColorDesc": "Personnalisez la couleur principale de l'interface",
     "terminalTheme": "Thème du terminal",
     "terminalThemeDesc": "Changez les couleurs du terminal",
+    "terminalFontSize": "Taille de police du terminal",
+    "terminalFontSizeDesc": "Ajustez la taille de police utilisée dans les onglets du terminal",
     "theme": "Thème du terminal",
     "notifications": "Notifications",
     "closeAction": "Action à la fermeture",

--- a/src/renderer/i18n/locales/id.json
+++ b/src/renderer/i18n/locales/id.json
@@ -779,6 +779,8 @@
     "accentColorDesc": "Sesuaikan warna utama antarmuka",
     "terminalTheme": "Tema terminal",
     "terminalThemeDesc": "Ubah warna terminal",
+    "terminalFontSize": "Ukuran font terminal",
+    "terminalFontSizeDesc": "Sesuaikan ukuran font yang digunakan di tab terminal",
     "theme": "Tema terminal",
     "notifications": "Notifikasi",
     "closeAction": "Aksi penutupan",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -779,6 +779,8 @@
     "accentColorDesc": "自定义主界面颜色",
     "terminalTheme": "终端主题",
     "terminalThemeDesc": "更改终端颜色",
+    "terminalFontSize": "终端字体大小",
+    "terminalFontSizeDesc": "调整终端选项卡中使用的字体大小",
     "theme": "终端主题",
     "notifications": "通知",
     "closeAction": "关闭行为",

--- a/src/renderer/state/settings.state.js
+++ b/src/renderer/state/settings.state.js
@@ -18,6 +18,7 @@ const defaultSettings = {
   skipPermissions: false,
   executionMode: 'safe', // 'safe' (default), 'auto' (SDK classifier), 'dangerous' (bypassPermissions)
   accentColor: '#d97706',
+  terminalFontSize: 14, // Terminal font size in px (10-24)
   notificationsEnabled: true,
   closeAction: 'ask', // 'ask', 'minimize', 'quit'
   shortcuts: {}, // Custom keyboard shortcuts overrides

--- a/src/renderer/ui/components/TerminalManager.js
+++ b/src/renderer/ui/components/TerminalManager.js
@@ -1880,7 +1880,7 @@ class TerminalManager extends BaseComponent {
     const terminal = new Terminal({
       theme: getTerminalTheme(terminalThemeId),
       fontFamily: TERMINAL_FONTS.claude.fontFamily,
-      fontSize: TERMINAL_FONTS.claude.fontSize,
+      fontSize: getSetting('terminalFontSize') || TERMINAL_FONTS.claude.fontSize,
       cursorBlink: true,
       scrollback: 5000
     });
@@ -2241,7 +2241,7 @@ class TerminalManager extends BaseComponent {
     const terminal = new Terminal({
       theme: getTerminalTheme(themeId),
       fontFamily: TERMINAL_FONTS[typeId]?.fontFamily || TERMINAL_FONTS.fivem.fontFamily,
-      fontSize: TERMINAL_FONTS[typeId]?.fontSize || TERMINAL_FONTS.fivem.fontSize,
+      fontSize: getSetting('terminalFontSize') || TERMINAL_FONTS[typeId]?.fontSize || TERMINAL_FONTS.fivem.fontSize,
       cursorBlink: false,
       disableStdin: disableStdin === true,
       scrollback: scrollback || 10000
@@ -2255,6 +2255,8 @@ class TerminalManager extends BaseComponent {
       fitAddon,
       project,
       projectIndex,
+      // Type consoles resize their PTY through their own IPC namespace, not `terminal`.
+      ipcNamespace,
       name: `${tabIcon} ${project.name}`,
       status: 'ready',
       type: typeId,
@@ -3286,7 +3288,7 @@ class TerminalManager extends BaseComponent {
     const terminal = new Terminal({
       theme: getTerminalTheme(terminalThemeId),
       fontFamily: TERMINAL_FONTS.claude.fontFamily,
-      fontSize: TERMINAL_FONTS.claude.fontSize,
+      fontSize: getSetting('terminalFontSize') || TERMINAL_FONTS.claude.fontSize,
       cursorBlink: true,
       scrollback: 5000
     });
@@ -3460,7 +3462,7 @@ class TerminalManager extends BaseComponent {
     const terminal = new Terminal({
       theme: getTerminalTheme(terminalThemeId),
       fontFamily: TERMINAL_FONTS.claude.fontFamily,
-      fontSize: TERMINAL_FONTS.claude.fontSize,
+      fontSize: getSetting('terminalFontSize') || TERMINAL_FONTS.claude.fontSize,
       cursorBlink: true,
       scrollback: 5000
     });
@@ -4062,6 +4064,33 @@ class TerminalManager extends BaseComponent {
     });
   }
 
+  updateAllTerminalsFontSize(fontSize) {
+    const terminals = terminalsState.get().terminals;
+    const self = this;
+
+    terminals.forEach((termData, id) => {
+      if (!termData.terminal || !termData.terminal.options) return;
+      termData.terminal.options.fontSize = fontSize;
+      // Defer fit+resize to next frame so xterm.js can recalculate glyph dimensions first
+      requestAnimationFrame(() => {
+        if (termData.fitAddon) {
+          try { termData.fitAddon.fit(); } catch (_) { /* container not measurable yet */ }
+        }
+        try { termData.terminal.refresh(0, termData.terminal.rows - 1); } catch (_) {}
+        const { cols, rows } = termData.terminal;
+        if (!cols || !rows) return;
+        // The container did not change size, so the ResizeObserver stays quiet:
+        // push the new grid to the PTY ourselves, through the same route the
+        // observer would use (project-type namespace, or the PTY behind the tab).
+        if (termData.ipcNamespace) {
+          self._api[termData.ipcNamespace]?.resize({ projectIndex: termData.projectIndex, cols, rows });
+        } else {
+          self._api.terminal.resize({ id: self._ptyTarget(id), cols, rows });
+        }
+      });
+    });
+  }
+
   // ── Navigation ──
 
   _getVisibleTerminalIds() {
@@ -4382,7 +4411,7 @@ class TerminalManager extends BaseComponent {
       const terminal = new Terminal({
         theme: getTerminalTheme(terminalThemeId),
         fontFamily: TERMINAL_FONTS.claude.fontFamily,
-        fontSize: TERMINAL_FONTS.claude.fontSize,
+        fontSize: getSetting('terminalFontSize') || TERMINAL_FONTS.claude.fontSize,
         cursorBlink: true,
         scrollback: 5000
       });
@@ -4826,6 +4855,7 @@ module.exports = {
   getTerminalLastTool: (id) => _getInstance()._terminalContext.get(id)?.lastTool || null,
   resumeSession: (project, sessionId, options) => _getInstance().resumeSession(project, sessionId, options),
   updateAllTerminalsTheme: (themeId) => _getInstance().updateAllTerminalsTheme(themeId),
+  updateAllTerminalsFontSize: (fontSize) => _getInstance().updateAllTerminalsFontSize(fontSize),
   focusNextTerminal: () => _getInstance().focusNextTerminal(),
   focusPrevTerminal: () => _getInstance().focusPrevTerminal(),
   openFileTab: (filePath, project) => _getInstance().openFileTab(filePath, project),

--- a/src/renderer/ui/panels/SettingsPanel.js
+++ b/src/renderer/ui/panels/SettingsPanel.js
@@ -1146,6 +1146,13 @@ class SettingsPanel extends BasePanel {
                     ${this._ctx.TERMINAL_THEMES[settings.terminalTheme || 'claude']?.name || 'Claude'}
                   </button>
                 </div>
+                <div class="settings-row">
+                  <div class="settings-label">
+                    <label for="terminal-font-size-input">${t('settings.terminalFontSize')}</label>
+                    <div class="settings-desc" id="terminal-font-size-desc">${t('settings.terminalFontSizeDesc')}</div>
+                  </div>
+                  <input type="number" class="form-input" id="terminal-font-size-input" aria-describedby="terminal-font-size-desc" value="${settings.terminalFontSize || 14}" min="10" max="24" step="1" style="width: 70px; text-align: center;">
+                </div>
               </div>
             </div>
             <div class="settings-group" data-section="behavior">
@@ -2357,6 +2364,18 @@ class SettingsPanel extends BasePanel {
       const languageDropdown = document.getElementById('language-dropdown');
       const newTerminalTheme = selectedThemeCard?.dataset.themeId || 'claude';
       const newLanguage = languageDropdown?.dataset.value || getCurrentLanguage();
+      const fontSizeInput = document.getElementById('terminal-font-size-input');
+      const newTerminalFontSize = fontSizeInput
+        ? Math.min(24, Math.max(10, parseInt(fontSizeInput.value, 10) || 14))
+        : (settings.terminalFontSize || 14);
+      // Echo the clamped value so the field never shows a size that was not applied.
+      if (fontSizeInput && fontSizeInput.value !== String(newTerminalFontSize)) {
+        fontSizeInput.value = String(newTerminalFontSize);
+      }
+      // Read from live state, not the render-time `settings` snapshot: the panel
+      // autosaves repeatedly without re-rendering, so 14 -> 16 -> 14 must still
+      // apply the second change to open terminals.
+      const prevTerminalFontSize = self._ctx.settingsState.get().terminalFontSize;
 
       let accentColor = settings.accentColor;
       const selectedSwatch = container.querySelector('.color-swatch.selected');
@@ -2457,6 +2476,7 @@ class SettingsPanel extends BasePanel {
         accentColor,
         closeAction: closeActionDropdown?.dataset.value || 'ask',
         terminalTheme: newTerminalTheme,
+        terminalFontSize: newTerminalFontSize,
         language: newLanguage,
         compactProjects: newCompactProjects,
         restoreTerminalSessions: newRestoreTerminalSessions,
@@ -2537,6 +2557,10 @@ class SettingsPanel extends BasePanel {
 
       if (newTerminalTheme !== settings.terminalTheme) {
         self._ctx.TerminalManager.updateAllTerminalsTheme(newTerminalTheme);
+      }
+
+      if (newTerminalFontSize !== prevTerminalFontSize) {
+        self._ctx.TerminalManager.updateAllTerminalsFontSize(newTerminalFontSize);
       }
 
       // Toggles below have side effects outside settings.json (OS login item,
@@ -2666,6 +2690,12 @@ class SettingsPanel extends BasePanel {
     // Save on blur for the column text input
     const parallelColumnInput = document.getElementById('parallel-auto-kanban-column');
     if (parallelColumnInput) parallelColumnInput.addEventListener('blur', autoSave);
+
+    // Save + live-apply font size on change
+    const fontSizeEl = document.getElementById('terminal-font-size-input');
+    if (fontSizeEl) {
+      fontSizeEl.addEventListener('change', autoSave);
+    }
 
     // Issue 4: Re-run setup wizard
     const btnRerunSetup = document.getElementById('btn-rerun-setup');

--- a/tests/features/TerminalFontSize.test.js
+++ b/tests/features/TerminalFontSize.test.js
@@ -1,0 +1,209 @@
+/**
+ * Terminal font size: applying the setting to open terminals and new consoles.
+ *
+ * Changing the size only alters xterm's glyph metrics; the container does not
+ * change, so the ResizeObserver that normally pushes a new grid to the PTY
+ * stays quiet. `updateAllTerminalsFontSize` has to do that push itself, and it
+ * has to reach the right backend for each kind of tab:
+ *
+ *   - a tab opened as a terminal is keyed by its PTY id;
+ *   - a tab that switched out of chat keeps its `chat-…` key and records the
+ *     PTY in `termData.ptyId` (sending the tab key matched nothing);
+ *   - a project-type console (WebApp, API, FiveM, Minecraft) resizes through
+ *     its own IPC namespace, not `terminal`.
+ *
+ * New project-type consoles must also read the setting at creation, so that
+ * an existing console and a reopened one end up the same size.
+ */
+
+const path = require('path');
+
+// xterm stand-in: records the constructor options and exposes a fixed grid.
+// Defined inside the factory (jest hoists mocks above other declarations) and
+// read back through the mocked module below.
+jest.mock('@xterm/xterm', () => ({
+  Terminal: class FakeTerminal {
+    constructor(options) {
+      this.options = { ...options };
+      this.cols = 100;
+      this.rows = 30;
+      this.refresh = () => {};
+      this.dispose = () => {};
+      // createTypeConsole wires a dozen xterm hooks (onSelectionChange, onKey,
+      // attachCustomKeyEventHandler, ...); none of them matter here, so any
+      // method not modelled above answers with a no-op disposable.
+      return new Proxy(this, {
+        get(target, key) {
+          if (key in target || typeof key !== 'string' || key === 'then') return target[key];
+          return () => ({ dispose() {} });
+        },
+      });
+    }
+    open() {}
+    loadAddon() {}
+    focus() {}
+    blur() {}
+  },
+}));
+jest.mock('@xterm/addon-fit', () => ({ FitAddon: class { fit() {} } }));
+jest.mock('@xterm/addon-webgl', () => ({ WebglAddon: class { onContextLoss() {} dispose() {} } }));
+// xterm is loaded lazily on first mount; hand the mocked modules straight back.
+jest.mock('../../src/renderer/services/xtermLoader', () => ({
+  loadXterm: async () => ({
+    Terminal: require('@xterm/xterm').Terminal,
+    FitAddon: require('@xterm/addon-fit').FitAddon,
+  }),
+  attachWebglAddon: () => {},
+}));
+
+// The console registry pulls in the whole project-type tree; a single stub
+// type with a WebApp-shaped console config is all that is exercised here.
+jest.mock('../../src/project-types/registry', () => ({
+  get: () => ({
+    getConsoleConfig: () => ({
+      typeId: 'webapp', tabIcon: 'W', tabClass: 'webapp-tab', dotClass: '', wrapperClass: '',
+      consoleViewSelector: '.console-view', ipcNamespace: 'webapp', scrollback: 1000, disableStdin: false,
+      getExistingLogs: () => [],
+    }),
+    getTerminalPanels: () => [{ getWrapperHtml: () => '<div class="console-view"></div>' }],
+  }),
+}));
+
+const { Terminal: FakeTerminal } = require('@xterm/xterm');
+
+const TM_PATH = '../../src/renderer/ui/components/TerminalManager';
+
+let TerminalManager;
+let terminalsState, addTerminal, getTerminal;
+let settingsState;
+
+beforeAll(() => {
+  global.ResizeObserver = class { observe() {} disconnect() {} unobserve() {} };
+  window.electron_api = {
+    ...window.electron_api,
+    terminal: {
+      create: jest.fn(async () => ({ success: true, id: 42 })),
+      input: jest.fn(), resize: jest.fn(), kill: jest.fn(),
+      onData: jest.fn(() => () => {}), onExit: jest.fn(() => () => {}),
+    },
+    webapp: { input: jest.fn(), resize: jest.fn() },
+  };
+
+  ({ TerminalManager } = require(TM_PATH));
+  ({ terminalsState, addTerminal, getTerminal } = require('../../src/renderer/state/terminals.state'));
+  ({ settingsState } = require('../../src/renderer/state/settings.state'));
+});
+
+let tm;
+
+beforeEach(() => {
+  window.electron_api.terminal.resize.mockClear();
+  window.electron_api.webapp.resize.mockClear();
+  terminalsState.set({ ...terminalsState.get(), terminals: new Map(), activeTerminal: null });
+  document.body.innerHTML = `
+    <div id="terminals-tabs"></div>
+    <div id="terminals-container"></div>
+    <div id="empty-terminals"></div>
+    <div id="terminals-filter"></div>`;
+  tm = new TerminalManager();
+  tm.filterByProject = jest.fn();
+  tm.setActiveTerminal = jest.fn();
+  tm.setCallbacks({ onRenderProjects: jest.fn() });
+});
+
+/** The next animation frame, as tests/setup.js models it (setTimeout 0). */
+const nextFrame = () => new Promise(resolve => setTimeout(resolve, 0));
+
+function addTab(id, extra = {}) {
+  const terminal = new FakeTerminal({ fontSize: 14 });
+  const fitAddon = { fit: jest.fn() };
+  addTerminal(id, {
+    terminal, fitAddon,
+    project: { id: 'p1', name: 'Proj', path: '/p' },
+    projectIndex: 0, name: 'tab', status: 'ready', mode: 'terminal',
+    ...extra,
+  });
+  return { terminal, fitAddon };
+}
+
+describe('updateAllTerminalsFontSize', () => {
+  test('applies the size, refits, and resizes a tab opened as a terminal by its own id', async () => {
+    const { terminal, fitAddon } = addTab(7);
+
+    tm.updateAllTerminalsFontSize(18);
+    await nextFrame();
+
+    expect(terminal.options.fontSize).toBe(18);
+    expect(fitAddon.fit).toHaveBeenCalled();
+    expect(window.electron_api.terminal.resize).toHaveBeenCalledWith({ id: 7, cols: 100, rows: 30 });
+  });
+
+  test('resizes a tab that switched out of chat by its PTY id, not its tab key', async () => {
+    addTab('chat-abc', { ptyId: 42 });
+
+    tm.updateAllTerminalsFontSize(18);
+    await nextFrame();
+
+    expect(window.electron_api.terminal.resize).toHaveBeenCalledWith({ id: 42, cols: 100, rows: 30 });
+    expect(window.electron_api.terminal.resize).not.toHaveBeenCalledWith(expect.objectContaining({ id: 'chat-abc' }));
+  });
+
+  test('resizes a project-type console through its own IPC namespace', async () => {
+    addTab('webapp-3-1', { ipcNamespace: 'webapp', projectIndex: 3, type: 'webapp' });
+
+    tm.updateAllTerminalsFontSize(18);
+    await nextFrame();
+
+    expect(window.electron_api.webapp.resize).toHaveBeenCalledWith({ projectIndex: 3, cols: 100, rows: 30 });
+    expect(window.electron_api.terminal.resize).not.toHaveBeenCalled();
+  });
+
+  test('skips a chat tab that has no xterm instance', async () => {
+    addTerminal('chat-only', { project: { id: 'p1' }, mode: 'chat', name: 'chat' });
+
+    expect(() => tm.updateAllTerminalsFontSize(18)).not.toThrow();
+    await nextFrame();
+
+    expect(window.electron_api.terminal.resize).not.toHaveBeenCalled();
+  });
+
+  test('applies a change back to the previous value', async () => {
+    const { terminal } = addTab(7);
+
+    tm.updateAllTerminalsFontSize(16);
+    await nextFrame();
+    tm.updateAllTerminalsFontSize(14);
+    await nextFrame();
+
+    // 14 → 16 → 14 at the manager level: each call applies unconditionally.
+    // The panel-side comparison that once skipped the second change is
+    // covered by tests/ui/settingsTerminalFontSize.test.js.
+    expect(terminal.options.fontSize).toBe(14);
+    expect(window.electron_api.terminal.resize).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('createTypeConsole', () => {
+  const project = { id: 'p-web', name: 'Site', path: path.join('C:', 'site'), type: 'webapp' };
+
+  test('reads the saved font size, so a reopened console matches a live-updated one', async () => {
+    settingsState.set({ ...settingsState.get(), terminalFontSize: 20 });
+
+    const id = await tm.createTypeConsole(project, 0);
+
+    const termData = getTerminal(id);
+    expect(termData.terminal.options.fontSize).toBe(20);
+    // Stored so the font-size updater can route the resize to `webapp.resize`.
+    expect(termData.ipcNamespace).toBe('webapp');
+  });
+
+  test('falls back to the console type default when no size is saved', async () => {
+    settingsState.set({ ...settingsState.get(), terminalFontSize: null });
+
+    const id = await tm.createTypeConsole(project, 1);
+
+    const { fontSize } = getTerminal(id).terminal.options;
+    expect(typeof fontSize).toBe('number');
+    expect(fontSize).toBeGreaterThan(0);
+  });
+});

--- a/tests/ui/settingsTerminalFontSize.test.js
+++ b/tests/ui/settingsTerminalFontSize.test.js
@@ -1,0 +1,99 @@
+/**
+ * Settings → Terminal font size, driven through the real input.
+ *
+ * The panel autosaves on every change without re-rendering, so the "did it
+ * change?" check before applying the size to open terminals must compare
+ * against live state, not the `settings` snapshot taken when the tab was
+ * rendered. With the snapshot, 14 → 16 → 14 saved the second change but never
+ * applied it: the value equalled the snapshot again.
+ *
+ * The general tab reaches into a wide API surface on render (accounts,
+ * GitHub, workspaces, app version); every call is answered with an empty
+ * result, and the render wraps each one in its own try/catch.
+ */
+
+// The Library tab (rendered alongside General) lists context packs and prompt
+// templates from disk; nothing here needs them.
+jest.mock('../../src/renderer/services/ContextPromptService', () => ({
+  getContextPacks: () => [],
+  getPromptTemplates: () => [],
+}));
+
+const { SettingsPanel } = require('../../src/renderer/ui/panels/SettingsPanel');
+const { settingsState } = require('../../src/renderer/state/settings.state');
+const themes = require('../../src/renderer/ui/themes/terminal-themes');
+
+const TERMINAL_THEMES = themes.TERMINAL_THEMES || themes;
+
+/** Every `api.<namespace>.<method>()` resolves to an empty object. */
+function permissiveApi() {
+  const method = () => jest.fn(async () => ({}));
+  const namespace = () => new Proxy({}, { get: (_, key) => (typeof key === 'string' ? method() : undefined) });
+  return new Proxy({}, { get: (_, key) => (typeof key === 'string' ? namespace() : undefined) });
+}
+
+const settle = () => new Promise(resolve => setTimeout(resolve, 20));
+
+let panel;
+let ctx;
+
+beforeEach(async () => {
+  document.body.innerHTML = '<div id="tab-settings"></div>';
+  settingsState.set({ ...settingsState.get(), terminalFontSize: 14, terminalTheme: 'claude' });
+
+  ctx = {
+    settingsState,
+    saveSettings: jest.fn(),
+    saveSettingsImmediate: jest.fn(),
+    applyAccentColor: jest.fn(),
+    TerminalManager: { updateAllTerminalsFontSize: jest.fn(), updateAllTerminalsTheme: jest.fn() },
+    TERMINAL_THEMES,
+    QuickActions: { QUICK_ACTION_ICONS: { play: '>' } },
+    ShortcutsManager: { renderShortcutsPanel: () => '', setupShortcutsPanelHandlers: () => {} },
+  };
+  panel = new SettingsPanel(document.getElementById('tab-settings'), { api: permissiveApi(), ctx });
+  await panel.renderSettingsTab('general');
+});
+
+function fontSizeInput() {
+  const input = document.getElementById('terminal-font-size-input');
+  if (!input) throw new Error('terminal-font-size-input not rendered');
+  return input;
+}
+
+async function typeFontSize(value) {
+  const input = fontSizeInput();
+  input.value = String(value);
+  input.dispatchEvent(new Event('change', { bubbles: true }));
+  await settle();
+}
+
+test('renders the input at the saved size with an associated label', () => {
+  const input = fontSizeInput();
+  expect(input.value).toBe('14');
+  expect(document.querySelector('label[for="terminal-font-size-input"]')).not.toBeNull();
+  expect(input.getAttribute('aria-describedby')).toBe('terminal-font-size-desc');
+  expect(document.getElementById('terminal-font-size-desc')).not.toBeNull();
+});
+
+test('14 → 16 → 14 applies both changes without re-rendering the tab', async () => {
+  await typeFontSize(16);
+  await typeFontSize(14);
+
+  expect(ctx.TerminalManager.updateAllTerminalsFontSize.mock.calls).toEqual([[16], [14]]);
+  expect(settingsState.get().terminalFontSize).toBe(14);
+});
+
+test('does not re-apply when the value did not change', async () => {
+  await typeFontSize(14);
+
+  expect(ctx.TerminalManager.updateAllTerminalsFontSize).not.toHaveBeenCalled();
+});
+
+test('clamps an out-of-range entry and echoes the applied value back into the field', async () => {
+  await typeFontSize(99);
+
+  expect(ctx.TerminalManager.updateAllTerminalsFontSize).toHaveBeenCalledWith(24);
+  expect(settingsState.get().terminalFontSize).toBe(24);
+  expect(fontSizeInput().value).toBe('24');
+});


### PR DESCRIPTION
## Summary

Adds a Terminal font size setting (Settings → General → Appearance, next to Terminal theme). The size was hardcoded per terminal kind; it can now be set between 10 and 24 px, applies live to every open terminal, and is used by new terminals and project-type consoles.

## Changes

- New `terminalFontSize` setting (default 14) with a number input in the Settings panel. Out-of-range entries are reset to the max or min allowed value. The input has a `<label for>` and an `aria-describedby` description.
- `TerminalManager.updateAllTerminalsFontSize()` applies the size to open terminals, refits on the next frame (xterm needs a render pass to remeasure glyphs) and pushes the new grid to the PTY. The resize is routed per terminal kind: the PTY id for tabs that switched out of chat, and the project type's own IPC namespace for WebApp / API / FiveM / Minecraft consoles.
- New terminals and new project-type consoles read the setting at creation (type consoles previously defaulted to 13 px, with the setting defaulting to 14 they now start at 14).
- i18n keys in en, fr, es, id and zh-CN, README bullet under Settings.
- Tests: `tests/ui/settingsTerminalFontSize.test.js` drives the real Settings input (14 → 16 → 14, no-change, clamp + echo, label association) and `tests/features/TerminalFontSize.test.js` covers the resize routing per terminal kind and console creation.

## Testing

- [ ] Tested on Windows 10
- [x] Tested on Windows 11
- [x] No console errors
- [x] Existing features still work

Verified live in an isolated instance: value persists to settings.json, an open terminal's cell went from 8×16 to 11×24 at 20 px and refit to the container (106 cols × 32 rows), a second terminal opened at the saved size. `npm run build:renderer && npm test`: 3401 tests pass.

## Related Issues

Closes #

